### PR TITLE
Median applications per week were (semi-)incorrectly showing zero for some councils.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ public/javascripts/all.js
 public/javascripts/mxn_bundle.js
 webrat.log
 .DS_Store
+
+#IntelliJ
+*.iml
+.generators
+.rakeTasks

--- a/app/models/authority.rb
+++ b/app/models/authority.rb
@@ -139,7 +139,7 @@ class Authority < ActiveRecord::Base
   end
 
   def median_applications_per_week
-    v = applications_per_week.map{|a| a[1]}.sort
+    v = applications_per_week.select{|a| a[1] > 0}.map{|a| a[1]}.sort
     v[v.count / 2]
   end
 


### PR DESCRIPTION
https://tickets.openaustraliafoundation.org.au/browse/PA-444

I'm not sure if this is the best solution, but the calculation for median applications per week now excludes weeks where there were zero applications. I understand that this will make calculations slightly wrong for councils who tend to have more genuine weeks with zero applications, but the tradeoff is with the inevitable scrapers that fail for long periods at a time now returning numbers other than 0.

Another solution would be to smooth the filter so it only pulls, e.g. multiple weeks in a row of zero.
