### PR TITLE
Fix morph link for broken scrapers.

### DIFF
--- a/app/views/authorities/index.html.haml
+++ b/app/views/authorities/index.html.haml
@@ -29,16 +29,12 @@
         = link_to authority.full_name, authority_url(authority.short_name_encoded)
         - if authority.broken?
           %span.highlight
-            - if authority.scraperwiki_url
-              = link_to "possibly broken", authority.scraperwiki_url
+            - if authority.morph_url
+              = link_to "possibly broken", authority.morph_url
             - else
               possibly broken
         &mdash;
         - if authority.morph_url
           = link_to "Morph scraper", authority.morph_url
-        - elsif authority.scraperwiki_url
-          = link_to "Scraperwiki scraper", authority.scraperwiki_url
         - else
           = link_to "internal scraper", "https://github.com/openaustralia/planningalerts-parsers"
-          
-


### PR DESCRIPTION
On the authorities pages the morph scrapers that report as possibly broken are linking to scraperwiki where a url is available, all of these links are returning a 500 status from the scraperwiki site, fixed the links to point to the morph url.

Removed scraperwiki links in general as they are all broken anyway. I didn't removed them from anywhere but the view as I wasn't sure if the urls are still needed elsewhere.
