### PR TITLE
Bulk date API

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -47,9 +47,13 @@ class ApiController < ApplicationController
   def date_scraped
     begin
       date = Date.parse(params[:date_scraped])
-      api_render(Application.where(date_scraped: date.beginning_of_day...date.end_of_day), "All applications collected on #{date}")
     rescue ArgumentError => e
       raise e unless e.message == "invalid date"
+    end
+
+    if date
+      api_render(Application.where(date_scraped: date.beginning_of_day...date.end_of_day), "All applications collected on #{date}")
+    else
       respond_to do |format|
         format.js { render json: {error: "invalid date_scraped"}, status: 401 }
       end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -45,8 +45,15 @@ class ApiController < ApplicationController
   end
 
   def date_scraped
-    date = Date.new(2015, 05, 06) # TODO: Parse date from param
-    api_render(Application.where(date_scraped: date.beginning_of_day...date.end_of_day), "All applications collected on #{date}")
+    begin
+      date = Date.parse(params[:date_scraped])
+      api_render(Application.where(date_scraped: date.beginning_of_day...date.end_of_day), "All applications collected on #{date}")
+    rescue ArgumentError => e
+      raise e unless e.message == "invalid date"
+      respond_to do |format|
+        format.js { render json: {error: "invalid date_scraped"}, status: 401 }
+      end
+    end
   end
 
   # Note that this returns results in a slightly different format than the

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -55,7 +55,7 @@ class ApiController < ApplicationController
       api_render(Application.where(date_scraped: date.beginning_of_day...date.end_of_day), "All applications collected on #{date}")
     else
       respond_to do |format|
-        format.js { render json: {error: "invalid date_scraped"}, status: 401 }
+        format.js { render json: {error: "invalid date_scraped"}, status: 400 }
       end
     end
   end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,5 +1,6 @@
 class ApiController < ApplicationController
   before_filter :check_api_parameters, except: [:old_index, :howto]
+  before_filter :authenticate_bulk_api, only: [:all, :date_scraped]
 
   def authority
     # TODO Handle the situation where the authority name isn't found
@@ -45,47 +46,31 @@ class ApiController < ApplicationController
 
   def date_scraped
     date = Date.today # TODO: Parse date from param
-    if User.where(api_key: params[:key], bulk_api: true).exists?
-      api_render(Application.where(date_scraped: date.beginning_of_day...date.end_of_day), "All applications collected on #{date}")
-    else
-      respond_to do |format|
-        format.js do
-          render json: {error: "not authorised"}, status: 401
-        end
-      end
-    end
+    api_render(Application.where(date_scraped: date.beginning_of_day...date.end_of_day), "All applications collected on #{date}")
   end
 
   # Note that this returns results in a slightly different format than the
   # other API calls because the paging is done differently (via scrape time rather than page number)
   def all
     # TODO Check that params page and v aren't being used
-    if User.where(api_key: params[:key], bulk_api: true).exists?
-      ApiStatistic.log(request)
-      apps = Application.reorder("id")
-      apps = apps.where("id > ?", params["since_id"]) if params["since_id"]
+    ApiStatistic.log(request)
+    apps = Application.reorder("id")
+    apps = apps.where("id > ?", params["since_id"]) if params["since_id"]
 
-      # Max number of records that we'll show
-      limit = 1000
+    # Max number of records that we'll show
+    limit = 1000
 
-      applications = apps.limit(limit).to_a
-      last = applications.last
-      last = Application.reorder("id").last if last.nil?
-      max_id = last.id if last
+    applications = apps.limit(limit).to_a
+    last = applications.last
+    last = Application.reorder("id").last if last.nil?
+    max_id = last.id if last
 
-      respond_to do |format|
-        format.js do
-          s = {:applications => applications, :application_count => apps.count, :max_id => max_id}
-          j = s.to_json(:except => [:authority_id, :suburb, :state, :postcode, :distance],
-            :include => {:authority => {:only => [:full_name]}})
-          render :json => j, :callback => params[:callback]
-        end
-      end
-    else
-      respond_to do |format|
-        format.js do
-          render json: {error: "not authorised"}, status: 401
-        end
+    respond_to do |format|
+      format.js do
+        s = {:applications => applications, :application_count => apps.count, :max_id => max_id}
+        j = s.to_json(:except => [:authority_id, :suburb, :state, :postcode, :distance],
+          :include => {:authority => {:only => [:full_name]}})
+        render :json => j, :callback => params[:callback]
       end
     end
   end
@@ -133,6 +118,16 @@ class ApiController < ApplicationController
     invalid_parameter_keys = params.keys - valid_parameter_keys
     unless invalid_parameter_keys.empty?
       render :text => "Bad request: Invalid parameter(s) used: #{invalid_parameter_keys.sort.join(', ')}", :status => 400
+    end
+  end
+
+  def authenticate_bulk_api
+    unless User.where(api_key: params[:key], bulk_api: true).exists?
+      respond_to do |format|
+        format.js do
+          render json: {error: "not authorised"}, status: 401
+        end
+      end
     end
   end
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -45,7 +45,7 @@ class ApiController < ApplicationController
   end
 
   def date_scraped
-    date = Date.today # TODO: Parse date from param
+    date = Date.new(2015, 05, 06) # TODO: Parse date from param
     api_render(Application.where(date_scraped: date.beginning_of_day...date.end_of_day), "All applications collected on #{date}")
   end
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -127,7 +127,7 @@ class ApiController < ApplicationController
       "suburb", "state",
       "address", "lat", "lng", "radius", "area_size",
       "bottom_left_lat", "bottom_left_lng", "top_right_lat", "top_right_lng",
-      "callback", "count", "v", "key", "since_id"]
+      "callback", "count", "v", "key", "since_id", "date_scraped"]
 
     # Parameter error checking (only do it on the API calls)
     invalid_parameter_keys = params.keys - valid_parameter_keys

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -43,6 +43,19 @@ class ApiController < ApplicationController
       "Recent applications in the area (#{lat0},#{lng0}) (#{lat1},#{lng1})")
   end
 
+  def date_scraped
+    date = Date.today # TODO: Parse date from param
+    if User.where(api_key: params[:key], bulk_api: true).exists?
+      api_render(Application.where(date_scraped: date.beginning_of_day...date.end_of_day), "All applications collected on #{date}")
+    else
+      respond_to do |format|
+        format.js do
+          render json: {error: "not authorised"}, status: 401
+        end
+      end
+    end
+  end
+
   # Note that this returns results in a slightly different format than the
   # other API calls because the paging is done differently (via scrape time rather than page number)
   def all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,8 @@ PlanningalertsApp::Application.routes.draw do
     get 'applications' => 'api#area', as: nil,
       constraints: QueryParamsPresentConstraint.new(:bottom_left_lat, :bottom_left_lng,
         :top_right_lat, :top_right_lng)
+    get 'applications' => 'api#date_scraped', as: nil,
+      constraints: QueryParamsPresentConstraint.new(:date_scraped)
     get 'applications' => 'api#all', as: nil
   end
 

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -275,24 +275,32 @@ describe ApiController do
   end
 
   describe "#date_scraped" do
-    it "should error if invalid api key is given" do
-      get :date_scraped, :key => "jsdfhsd", :format => "js", date_scraped: Date.today
-      response.status.should == 401
-      response.body.should == '{"error":"not authorised"}'
+    context "invalid authentication" do
+      it "should error if invalid api key is given" do
+        get :date_scraped, :key => "jsdfhsd", :format => "js", date_scraped: Date.today
+        response.status.should == 401
+        response.body.should == '{"error":"not authorised"}'
+      end
+
+      it "should error if valid api key is given but no bulk api access" do
+        user = User.create!(email: "foo@bar.com", password: "foofoo")
+        get :date_scraped, :key => user.api_key, :format => "js", date_scraped: Date.today
+        response.status.should == 401
+        response.body.should == '{"error":"not authorised"}'
+      end
     end
 
-    it "should error if valid api key is given but no bulk api access" do
-      user = User.create!(email: "foo@bar.com", password: "foofoo")
-      get :date_scraped, :key => user.api_key, :format => "js", date_scraped: Date.today
-      response.status.should == 401
-      response.body.should == '{"error":"not authorised"}'
-    end
+    context "valid authentication" do
+      let(:user) do
+        user = User.create!(email: "foo@bar.com", password: "foofoo")
+        user.update_attribute(:bulk_api, true)
+        user
+      end
 
-    it "should be successful if valid api key is given with bulk api access" do
-      user = User.create!(email: "foo@bar.com", password: "foofoo")
-      user.update_attribute(:bulk_api, true)
-      get :date_scraped, :key => user.api_key, :format => "js", date_scraped: Date.today
-      response.should be_success
+      it "should be successful if valid api key is given with bulk api access" do
+        get :date_scraped, :key => user.api_key, :format => "js", date_scraped: Date.today
+        response.should be_success
+      end
     end
   end
 end

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -277,13 +277,13 @@ describe ApiController do
   describe "#date_scraped" do
     context "invalid authentication" do
       it "should error if invalid api key is given" do
-        get :date_scraped, :key => "jsdfhsd", :format => "js", date_scraped: Date.today
+        get :date_scraped, :key => "jsdfhsd", :format => "js", date_scraped: "2015-05-06"
         response.status.should == 401
         response.body.should == '{"error":"not authorised"}'
       end
 
       it "should error if valid api key is given but no bulk api access" do
-        get :date_scraped, :key => FactoryGirl.create(:user).api_key, :format => "js", date_scraped: Date.today
+        get :date_scraped, :key => FactoryGirl.create(:user).api_key, :format => "js", date_scraped: "2015-05-06"
         response.status.should == 401
         response.body.should == '{"error":"not authorised"}'
       end
@@ -293,7 +293,7 @@ describe ApiController do
       let(:user) { FactoryGirl.create(:user, bulk_api: true) }
 
       it "should be successful if valid api key is given with bulk api access" do
-        get :date_scraped, :key => user.api_key, :format => "js", date_scraped: Date.today
+        get :date_scraped, :key => user.api_key, :format => "js", date_scraped: "2015-05-06"
         response.should be_success
       end
     end

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -273,4 +273,26 @@ describe ApiController do
       end
     end
   end
+
+  describe "#date_scraped" do
+    it "should error if invalid api key is given" do
+      get :date_scraped, :key => "jsdfhsd", :format => "js"
+      response.status.should == 401
+      response.body.should == '{"error":"not authorised"}'
+    end
+
+    it "should error if valid api key is given but no bulk api access" do
+      user = User.create!(email: "foo@bar.com", password: "foofoo")
+      get :date_scraped, :key => user.api_key, :format => "js"
+      response.status.should == 401
+      response.body.should == '{"error":"not authorised"}'
+    end
+
+    it "should be successful if valid api key is given with bulk api access" do
+      user = User.create!(email: "foo@bar.com", password: "foofoo")
+      user.update_attribute(:bulk_api, true)
+      get :date_scraped, :key => user.api_key, :format => "js"
+      response.should be_success
+    end
+  end
 end

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -46,7 +46,8 @@ describe ApiController do
         user = User.create!(email: "foo@bar.com", password: "foofoo")
         user.update_attribute(:bulk_api, true)
         VCR.use_cassette('planningalerts') do
-          result = Factory(:application, :id => 10, :date_scraped => Time.utc(2001,1,1))
+          authority = Factory(:authority, full_name: "Acme Local Planning Authority")
+          result = Factory(:application, :id => 10, :date_scraped => Time.utc(2001,1,1), authority: authority)
           Application.stub_chain(:where, :paginate).and_return([result])
         end
         get :all, :key => user.api_key, :format => "js"
@@ -91,7 +92,8 @@ describe ApiController do
 
     it "should support jsonp" do
       VCR.use_cassette('planningalerts') do
-        result = Factory(:application, :id => 10, :date_scraped => Time.utc(2001,1,1))
+        authority = Factory(:authority, full_name: "Acme Local Planning Authority")
+        result = Factory(:application, :id => 10, :date_scraped => Time.utc(2001,1,1), authority: authority)
         Application.stub_chain(:where, :paginate).and_return([result])
       end
       get :postcode, :format => "js", :postcode => "2780", :callback => "foobar"
@@ -121,7 +123,8 @@ describe ApiController do
 
     it "should support json api version 2" do
       VCR.use_cassette('planningalerts') do
-        application = Factory(:application, :id => 10, :date_scraped => Time.utc(2001,1,1))
+        authority = Factory(:authority, full_name: "Acme Local Planning Authority")
+        application = Factory(:application, :id => 10, :date_scraped => Time.utc(2001,1,1), authority: authority)
         result = [application]
         result.stub!(:total_pages).and_return(5)
         Application.stub_chain(:where, :paginate).and_return(result)

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -294,9 +294,16 @@ describe ApiController do
 
     context "valid authentication" do
       let(:user) { FactoryGirl.create(:user, bulk_api: true) }
+      before(:each) do
+        VCR.use_cassette('planningalerts', allow_playback_repeats: true) do
+          FactoryGirl.create_list(:application, 5, date_scraped: DateTime.new(2015, 05, 05, 12, 0, 0))
+          FactoryGirl.create_list(:application, 5, date_scraped: DateTime.new(2015, 05, 06, 12, 0, 0))
+        end
+      end
       subject { get :date_scraped, :key => user.api_key, :format => "js", date_scraped: "2015-05-06" }
 
       it { expect(subject).to be_success }
+      it { expect(JSON.parse(subject.body).count).to eq 5 }
     end
   end
 end

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -291,11 +291,7 @@ describe ApiController do
     end
 
     context "valid authentication" do
-      let(:user) do
-        user = User.create!(email: "foo@bar.com", password: "foofoo")
-        user.update_attribute(:bulk_api, true)
-        user
-      end
+      let(:user) { FactoryGirl.create(:user, bulk_api: true) }
 
       it "should be successful if valid api key is given with bulk api access" do
         get :date_scraped, :key => user.api_key, :format => "js", date_scraped: Date.today

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -276,14 +276,14 @@ describe ApiController do
 
   describe "#date_scraped" do
     it "should error if invalid api key is given" do
-      get :date_scraped, :key => "jsdfhsd", :format => "js"
+      get :date_scraped, :key => "jsdfhsd", :format => "js", date_scraped: Date.today
       response.status.should == 401
       response.body.should == '{"error":"not authorised"}'
     end
 
     it "should error if valid api key is given but no bulk api access" do
       user = User.create!(email: "foo@bar.com", password: "foofoo")
-      get :date_scraped, :key => user.api_key, :format => "js"
+      get :date_scraped, :key => user.api_key, :format => "js", date_scraped: Date.today
       response.status.should == 401
       response.body.should == '{"error":"not authorised"}'
     end
@@ -291,7 +291,7 @@ describe ApiController do
     it "should be successful if valid api key is given with bulk api access" do
       user = User.create!(email: "foo@bar.com", password: "foofoo")
       user.update_attribute(:bulk_api, true)
-      get :date_scraped, :key => user.api_key, :format => "js"
+      get :date_scraped, :key => user.api_key, :format => "js", date_scraped: Date.today
       response.should be_success
     end
   end

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -304,6 +304,12 @@ describe ApiController do
 
       it { expect(subject).to be_success }
       it { expect(JSON.parse(subject.body).count).to eq 5 }
+
+      context "invalid date" do
+        subject { get :date_scraped, :key => user.api_key, :format => "js", date_scraped: "foobar" }
+        it { expect(subject).to_not be_success }
+        it { expect(subject.body).to eq '{"error":"invalid date_scraped"}' }
+      end
     end
   end
 end

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -275,27 +275,25 @@ describe ApiController do
   end
 
   describe "#date_scraped" do
-    context "invalid authentication" do
-      it "should error if invalid api key is given" do
-        get :date_scraped, :key => "jsdfhsd", :format => "js", date_scraped: "2015-05-06"
-        response.status.should == 401
-        response.body.should == '{"error":"not authorised"}'
-      end
+    context "invalid api key is given" do
+      subject { get :date_scraped, :key => "jsdfhsd", :format => "js", date_scraped: "2015-05-06" }
 
-      it "should error if valid api key is given but no bulk api access" do
-        get :date_scraped, :key => FactoryGirl.create(:user).api_key, :format => "js", date_scraped: "2015-05-06"
-        response.status.should == 401
-        response.body.should == '{"error":"not authorised"}'
-      end
+      it { expect(subject.status).to eq 401 }
+      it { expect(subject.body).to eq '{"error":"not authorised"}' }
+    end
+
+    context "valid api key is given but no bulk api access" do
+      subject { get :date_scraped, :key => FactoryGirl.create(:user).api_key, :format => "js", date_scraped: "2015-05-06" }
+
+      it { expect(subject.status).to eq 401 }
+      it { expect(subject.body).to eq '{"error":"not authorised"}' }
     end
 
     context "valid authentication" do
       let(:user) { FactoryGirl.create(:user, bulk_api: true) }
+      subject { get :date_scraped, :key => user.api_key, :format => "js", date_scraped: "2015-05-06" }
 
-      it "should be successful if valid api key is given with bulk api access" do
-        get :date_scraped, :key => user.api_key, :format => "js", date_scraped: "2015-05-06"
-        response.should be_success
-      end
+      it { expect(subject).to be_success }
     end
   end
 end

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -283,8 +283,7 @@ describe ApiController do
       end
 
       it "should error if valid api key is given but no bulk api access" do
-        user = User.create!(email: "foo@bar.com", password: "foofoo")
-        get :date_scraped, :key => user.api_key, :format => "js", date_scraped: Date.today
+        get :date_scraped, :key => FactoryGirl.create(:user).api_key, :format => "js", date_scraped: Date.today
         response.status.should == 401
         response.body.should == '{"error":"not authorised"}'
       end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,5 +1,5 @@
 Factory.define :authority do |a|
-  a.full_name "Acme Local Planning Authority"
+  a.sequence(:full_name) { |n| "Acme Local Planning Authority - #{n}" }
   a.short_name {|b| b.full_name}
 end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -19,3 +19,8 @@ Factory.define :comment do |c|
   c.address "12 Foo Street"
   c.association :application
 end
+
+Factory.define :user do |u|
+  u.email "foo@bar.com"
+  u.password "foofoo"
+end


### PR DESCRIPTION
This adds the ability for bulk API users to get all applications created in PlanningAlerts for a particular day.

Whilst I created this for a specific project I can see it being used in other ways.

It could be used by commercial users that want all applications but not an entire copy of the PlanningAlerts database (which is what our current bulk API provides). Or for commercial users that only want a full copy of more recent applications without the years of history we have. With this API they can just make an API call a day to keep up to date with new applications.

It could also be used by people interested in doing ad hoc research, e.g. if you want a whole month or year of applications this API method would be the best way for you to do that.

Assigning to @mlandauer to review the concept, and a brief code review if he feels like it.