### PR TITLE
New subscription page

### DIFF
--- a/app/assets/stylesheets/partials/_payment_form.scss
+++ b/app/assets/stylesheets/partials/_payment_form.scss
@@ -1,7 +1,6 @@
 .registration-page,
 .registration-success-page {
   padding-bottom: 2em;
-  text-align: center;
 
   @include at-breakpoint(40em) {
     padding-bottom: 4em;
@@ -26,20 +25,6 @@
     @include at-breakpoint(40em) {
       font-size: 1.3em;
     }
-  }
-}
-
-.registration-page {
-  @include at-breakpoint(40em) {
-    @include span-columns(10, 12);
-    margin: 2em auto 0;
-    float: none;
-  }
-
-  @include at-breakpoint(60em) {
-    @include span-columns(8, 12);
-    margin: 2em auto 0;
-    float: none;
   }
 }
 

--- a/app/assets/stylesheets/partials/_payment_form.scss
+++ b/app/assets/stylesheets/partials/_payment_form.scss
@@ -12,9 +12,7 @@
 }
 
 .registration-intro {
-  @include at-breakpoint(53em) {
-    width: 60%;
-  }
+  max-width: 42em;
 
   p {
     @include at-breakpoint(40em) {

--- a/app/assets/stylesheets/partials/_payment_form.scss
+++ b/app/assets/stylesheets/partials/_payment_form.scss
@@ -1,13 +1,13 @@
 .registration-page,
 .registration-success-page {
-  padding-bottom: 2em;
+  padding-bottom: 4em;
 
   @include at-breakpoint(40em) {
-    padding-bottom: 4em;
+    padding-bottom: 8em;
   }
 
   @include at-breakpoint(60em) {
-    padding-bottom: 6em;
+    padding-bottom: 9em;
   }
 }
 

--- a/app/assets/stylesheets/partials/_payment_form.scss
+++ b/app/assets/stylesheets/partials/_payment_form.scss
@@ -9,14 +9,6 @@
   @include at-breakpoint(60em) {
     padding-bottom: 6em;
   }
-
-  p {
-    font-size: 1.1em;
-
-    @include at-breakpoint(40em) {
-      font-size: 1.3em;
-    }
-  }
 }
 
 .registration-success-page {

--- a/app/assets/stylesheets/partials/_payment_form.scss
+++ b/app/assets/stylesheets/partials/_payment_form.scss
@@ -36,8 +36,7 @@
 }
 
 p.form-processing {
-  margin: 0 auto 1em;
-  padding: 1em 0 .7em;
+  margin: 0 0 .2em;
   font-size: 1.25em;
   font-weight: bold;
 }

--- a/app/assets/stylesheets/partials/_payment_form.scss
+++ b/app/assets/stylesheets/partials/_payment_form.scss
@@ -10,15 +10,6 @@
     padding-bottom: 6em;
   }
 
-  h1 {
-    font-size: 2em;
-    line-height: 1.2;
-
-    @include at-breakpoint(40em) {
-      font-size: 2.5em;
-    }
-  }
-
   p {
     font-size: 1.1em;
 

--- a/app/assets/stylesheets/partials/_payment_form.scss
+++ b/app/assets/stylesheets/partials/_payment_form.scss
@@ -11,6 +11,18 @@
   }
 }
 
+.registration-intro {
+  @include at-breakpoint(53em) {
+    width: 60%;
+  }
+
+  p {
+    @include at-breakpoint(40em) {
+      font-size: 1.175em;
+    }
+  }
+}
+
 .registration-success-page {
   @include at-breakpoint(40em) {
     @include span-columns(11, 12);

--- a/app/assets/stylesheets/partials/_payment_form.scss
+++ b/app/assets/stylesheets/partials/_payment_form.scss
@@ -42,54 +42,6 @@
   }
 }
 
-#button-pro-signup {
-  @include box-sizing(border-box);
-  margin: 0 auto 1em;
-  border: 0;
-  padding: 1em;
-  text-align: center;
-  font-size: 1.25em;
-  font-family: $blueprint-font-family;
-  -webkit-appearance: none;
-  background: darken($light, 8%);
-  text-shadow: 0 1px 0 $lightest;
-  border-radius: .2em;
-  display: block;
-
-  &:hover,
-  &:focus {
-    background: darken($light, 25%);
-  }
-
-  &:hover {
-    cursor: pointer;
-  }
-
-  strong {
-    display: block;
-  }
-
-  &[disabled] {
-    color: $font-color;
-  }
-
-  & + p {
-    font-size: 1em;
-  }
-}
-
-.registration-price-container {
-  margin-bottom: .5em;
-}
-
-.registration-price {
-  font-size: 2.5em;
-}
-
-.registration-price-per {
-  font-size: 1.25em;
-}
-
 p.form-processing {
   margin: 0 auto 1em;
   padding: 1em 0 .7em;

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -15,6 +15,7 @@ class SubscriptionsController < ApplicationController
 
     if params[:email]
       @email = params[:email]
+      @subscription = Subscription.find_by(email: @email)
     end
   end
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -15,7 +15,6 @@ class SubscriptionsController < ApplicationController
 
     if params[:email]
       @email = params[:email]
-      @subscription = Subscription.find_by(email: @email)
     end
   end
 

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title, 'Get less email & more useful alerts'
+- content_for :page_title, 'Activate your subscription'
 
 .registration-page
   = form_tag subscriptions_path, id: 'subscription-payment-form', class: 'registration-intro' do

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -10,10 +10,10 @@
       Once you’re subscribed you can sign up for alerts from as many locations as you need
       and use PlanningAlerts in your work.
 
-    - if Subscription.find_by(email: @email).try :trial?
+    - if @subscription && @subscription.trial?
       %p
         You’ve got
-        = pluralize(Subscription.find_by(email: @email).trial_days_remaining, 'day')
+        = pluralize(@subscription.trial_days_remaining, 'day')
         left on your trial subscription.
 
     -# TODO: Move to head to block page until it loads

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -15,5 +15,3 @@
     %input{type: 'hidden', name: 'stripeAmount', value: @amount}
     %button{disabled: true, type: 'submit', id: "button-pro-signup", data: {key: Configuration::STRIPE_PUBLISHABLE_KEY, amount: @amount, email: (@email if @email)}}
       Subscribe now #{@display_amount}/month
-
-    %p No lock-in. Cancel anytime.

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -10,6 +10,10 @@
       Once you’re subscribed you can sign up for alerts from as many locations as you need
       and use PlanningAlerts in your work.
 
+    - if Subscription.find_by(email: @email).try :trial?
+      - # TODO: make the day count dynamic
+      %p You’ve got three days left on your trial subscription.
+
     -# TODO: Move to head to block page until it loads
     %script{src: "https://checkout.stripe.com/checkout.js"}
 

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -6,7 +6,8 @@
 
     %p
       - # TODO: Make the address count dynamic
-      Subscribe here to keep getting alerts of planning applications near your 3 addresses.
+      Subscribe here #{ @email ? 'to keep getting' : 'if you need' }
+      alerts of planning applications near #{ @email ? 'your 3' : 'several' } addresses.
       Once you’re subscribed you can sign up for alerts from as many locations as you need
       and use PlanningAlerts in your work.
 

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -13,5 +13,5 @@
     %script{src: "https://checkout.stripe.com/checkout.js"}
 
     %input{type: 'hidden', name: 'stripeAmount', value: @amount}
-    %button{disabled: true, type: 'submit', id: "button-pro-signup", data: {key: Configuration::STRIPE_PUBLISHABLE_KEY, amount: @amount, email: (@email if @email)}}
+    %button{disabled: true, type: 'submit', class: "button-action", id: "button-pro-signup", data: {key: Configuration::STRIPE_PUBLISHABLE_KEY, amount: @amount, email: (@email if @email)}}
       Subscribe now #{@display_amount}/month

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -9,12 +9,6 @@
       Once you’re subscribed you can sign up for alerts from as many locations as you need
       and use PlanningAlerts in your work.
 
-    - if @subscription && @subscription.trial?
-      %p
-        You have
-        = pluralize(@subscription.trial_days_remaining, 'day')
-        left on your trial subscription.
-
     -# TODO: Move to head to block page until it loads
     %script{src: "https://checkout.stripe.com/checkout.js"}
 

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -2,7 +2,7 @@
 
 .registration-page
   = form_tag subscriptions_path, id: 'subscription-payment-form', class: 'registration-intro' do
-    %h1.page-title Get planning alerts for all the locations you need
+    %h1.page-title Activate your subscription
 
     %p
       You need an active subscription to

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -2,7 +2,7 @@
 
 .registration-page
   = form_tag subscriptions_path, id: 'subscription-payment-form', class: 'registration-intro' do
-    %h1 Get planning alerts for all the locations you need
+    %h1.page-title Get planning alerts for all the locations you need
 
     %p
       While personal use of PlanningAlerts is free

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -12,7 +12,7 @@
 
     - if @subscription && @subscription.trial?
       %p
-        You’ve got
+        You have
         = pluralize(@subscription.trial_days_remaining, 'day')
         left on your trial subscription.
 

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -5,8 +5,7 @@
     %h1.page-title Get planning alerts for all the locations you need
 
     %p
-      While personal use of PlanningAlerts is free
-      tracking multiple locations, or using it for commercial purposes,
+      Tracking multiple locations and using PlanningAlerts for commercial purposes
       requires an active subscription.
 
     -# TODO: Move to head to block page until it loads

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -6,7 +6,7 @@
 
     %p
       You need an active subscription to
-      receive planning alerts from multiple locations or for commercial purposes.
+      receive planning alerts for multiple street addresses or for commercial purposes.
 
     -# TODO: Move to head to block page until it loads
     %script{src: "https://checkout.stripe.com/checkout.js"}

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -2,13 +2,12 @@
 
 .registration-page
   = form_tag subscriptions_path, id: 'subscription-payment-form', class: 'registration-intro' do
-    %h1 Sift through less email and get more useful&nbsp;alerts
+    %h1 Get planning alerts for all the locations you need
 
-    %p You’ll get all your alerts in one email so you never have to sift&nbsp;through your inbox&nbsp;again.
-
-    %p Discover new opportunities by watching as many locations as&nbsp;you&nbsp;need.
-
-    %p Make sure your coverage is complete. You can easily add and edit addresses from your full list of alerts in one&nbsp;place.
+    %p
+      While personal use of PlanningAlerts is free
+      tracking multiple locations, or using it for commercial purposes,
+      requires an active subscription.
 
     -# TODO: Move to head to block page until it loads
     %script{src: "https://checkout.stripe.com/checkout.js"}

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -6,7 +6,7 @@
 
     %p
       You need an active subscription to
-      track multiple locations or use PlanningAlerts for commercial purposes.
+      receive planning alerts from multiple locations or for commercial purposes.
 
     -# TODO: Move to head to block page until it loads
     %script{src: "https://checkout.stripe.com/checkout.js"}

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -1,8 +1,8 @@
-- content_for :page_title, 'Activate your subscription'
+- content_for :page_title, 'Subscribe here'
 
 .registration-page
   = form_tag subscriptions_path, id: 'subscription-payment-form', class: 'registration-intro' do
-    %h1.page-title Activate your subscription
+    %h1.page-title Subscribe here
 
     %p
       You need an active subscription to

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -5,8 +5,7 @@
     %h1.page-title Subscribe here
 
     %p
-      Subscribe here #{ @email ? 'to get' : 'if you need' }
-      alerts of planning applications near several addresses.
+      Subscribe here to get alerts of planning applications near several addresses.
       Once you’re subscribed you can sign up for alerts from as many locations as you need
       and use PlanningAlerts in your work.
 

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -5,8 +5,10 @@
     %h1.page-title Subscribe here
 
     %p
-      You need an active subscription to
-      receive planning alerts for multiple street addresses or for commercial purposes.
+      - # TODO: Make the address count dynamic
+      Subscribe here to keep getting alerts of planning applications near your 3 addresses.
+      Once you’re subscribed you can sign up for alerts from as many locations as you need
+      and use PlanningAlerts in your work.
 
     -# TODO: Move to head to block page until it loads
     %script{src: "https://checkout.stripe.com/checkout.js"}

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -11,8 +11,7 @@
       and use PlanningAlerts in your work.
 
     - if Subscription.find_by(email: @email).try :trial?
-      - # TODO: make the day count dynamic
-      %p You’ve got three days left on your trial subscription.
+      %p You’ve got #{ pluralize(Subscription.find_by(email: @email).trial_days_remaining, 'day') } left on your trial subscription.
 
     -# TODO: Move to head to block page until it loads
     %script{src: "https://checkout.stripe.com/checkout.js"}

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -5,7 +5,7 @@
     %h1.page-title Subscribe here
 
     %p
-      Subscribe here #{ @email ? 'to keep getting' : 'if you need' }
+      Subscribe here #{ @email ? 'to get' : 'if you need' }
       alerts of planning applications near several addresses.
       Once you’re subscribed you can sign up for alerts from as many locations as you need
       and use PlanningAlerts in your work.

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -5,8 +5,8 @@
     %h1.page-title Get planning alerts for all the locations you need
 
     %p
-      Tracking multiple locations and using PlanningAlerts for commercial purposes
-      requires an active subscription.
+      You need an active subscription to
+      track multiple locations or use PlanningAlerts for commercial purposes.
 
     -# TODO: Move to head to block page until it loads
     %script{src: "https://checkout.stripe.com/checkout.js"}

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -5,9 +5,8 @@
     %h1.page-title Subscribe here
 
     %p
-      - # TODO: Make the address count dynamic
       Subscribe here #{ @email ? 'to keep getting' : 'if you need' }
-      alerts of planning applications near #{ @email ? 'your 3' : 'several' } addresses.
+      alerts of planning applications near several addresses.
       Once you’re subscribed you can sign up for alerts from as many locations as you need
       and use PlanningAlerts in your work.
 

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -11,7 +11,10 @@
       and use PlanningAlerts in your work.
 
     - if Subscription.find_by(email: @email).try :trial?
-      %p You’ve got #{ pluralize(Subscription.find_by(email: @email).trial_days_remaining, 'day') } left on your trial subscription.
+      %p
+        You’ve got
+        = pluralize(Subscription.find_by(email: @email).trial_days_remaining, 'day')
+        left on your trial subscription.
 
     -# TODO: Move to head to block page until it loads
     %script{src: "https://checkout.stripe.com/checkout.js"}


### PR DESCRIPTION
This implements a first pass on the new subscription page that users see when they click the link in the subscriptions banner when they are on a trial subscription.

These commits:

* replace the page copy with copy appropriate to the new system we're making
* strips back the styles to better match the site generally

![screen shot 2015-08-12 at 3 20 34 pm](https://cloud.githubusercontent.com/assets/1239550/9217035/e624d4f2-4105-11e5-817b-57329c033d66.png)

Any feedback/thoughts at this stage @henare ? I'll assign to you to merge or respond.

closes #708 

^^^ Close that issue and open new ones for continued iteration like #712 