### PR TITLE
Update copy and layout of subscription confirmation page

### DIFF
--- a/app/assets/stylesheets/partials/_payment_form.scss
+++ b/app/assets/stylesheets/partials/_payment_form.scss
@@ -1,5 +1,6 @@
 .registration-page,
 .registration-success-page {
+  max-width: 42em;
   padding-bottom: 4em;
 
   @include at-breakpoint(40em) {
@@ -9,29 +10,11 @@
   @include at-breakpoint(60em) {
     padding-bottom: 9em;
   }
-}
-
-.registration-intro {
-  max-width: 42em;
 
   p {
     @include at-breakpoint(40em) {
       font-size: 1.175em;
     }
-  }
-}
-
-.registration-success-page {
-  @include at-breakpoint(40em) {
-    @include span-columns(11, 12);
-    margin: 2em auto 0;
-    float: none;
-  }
-
-  @include at-breakpoint(60em) {
-    @include span-columns(10, 12);
-    margin: 2em auto 0;
-    float: none;
   }
 }
 

--- a/app/views/subscriptions/create.html.haml
+++ b/app/views/subscriptions/create.html.haml
@@ -10,4 +10,4 @@
     you’ll receive a monthly receipt after each payment.
   %p
     You can cancel your subscription at any time, just
-    #{mail_to "contact@planningalerts.org.au", "email us"}.
+    #{mail_to "contact@planningalerts.org.au", "email us at contact@planningalerts.org.au"}.

--- a/app/views/subscriptions/create.html.haml
+++ b/app/views/subscriptions/create.html.haml
@@ -2,15 +2,12 @@
 
 .registration-success-page
   %h1 Thanks for subscribing!
-
   %p
     You can now #{link_to "sign up to get alerts for as many locations as you need", new_alert_path(email: @email)}.
     You’ll also keep getting alerts near the street addresses you’ve already signed up for.
-
   %p
     Your receipt has been emailed to you, and
     you’ll receive a monthly receipt after each payment.
-
   %p
     You can cancel your subscription at any time, just
     #{mail_to "contact@planningalerts.org.au", "email us"}.

--- a/app/views/subscriptions/create.html.haml
+++ b/app/views/subscriptions/create.html.haml
@@ -1,13 +1,16 @@
 - content_for :page_title, 'Success, subscription confirmed'
 
 .registration-success-page
-  %h1 Success!
-
-  %p Your subscription for #{@email} has been confirmed.Thank&nbsp;you.
+  %h1 Thanks for subscribing!
 
   %p
-    Go forth and #{link_to "add alerts to your heart's desire", new_alert_path(email: @email)}.
+    You can now #{link_to "sign up to get alerts for as many locations as you need", new_alert_path(email: @email)}.
+    You’ll also keep getting alerts near the street addresses you’ve already signed up for.
 
   %p
-    If you would like to cancel your subscription or have any questions
-    please #{mail_to "contact@planningalerts.org.au", "contact us"}.
+    Your receipt has been emailed to you, and
+    you’ll receive a monthly receipt after each payment.
+
+  %p
+    You can cancel your subscription at any time, just
+    #{mail_to "contact@planningalerts.org.au", "email us"}.

--- a/app/views/subscriptions/create.html.haml
+++ b/app/views/subscriptions/create.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title, 'Success, subscription confirmed'
 
 .registration-success-page
-  %h1 Thanks for subscribing!
+  %h1.page-title Thanks for subscribing!
   %p
     You can now #{link_to "sign up to get alerts for as many locations as you need", new_alert_path(email: @email)}.
     You’ll also keep getting alerts near the street addresses you’ve already signed up for.

--- a/spec/features/subscription_spec.rb
+++ b/spec/features/subscription_spec.rb
@@ -40,7 +40,7 @@ feature "Subscribing for access to several alerts" do
     first("input[name='stripeToken']", visible: false).set(stripe_helper.generate_card_token)
     click_button("Subscribe now $49/month")
 
-    expect(page).to have_content("Your subscription for mary@enterpriserealty.com has been confirmed")
+    expect(page).to have_content("Thanks for subscribing!")
     expect(Subscription.find_by!(email: email)).to be_paid
   end
 end


### PR DESCRIPTION
These commits update the layout of the confirmation page to match the new subscription page users have just come from. This gives them a more consistent experience.

It also updates the copy with the next iteration from the google doc to also include a information about their receipt. This text is simpler and more inline with the voice of the site.

Here's screenshots:

![screen shot 2015-08-13 at 4 05 36 pm](https://cloud.githubusercontent.com/assets/1239550/9243548/3824fa82-41d5-11e5-87e8-c906fa3d3b21.png)
![screen shot 2015-08-13 at 4 05 27 pm](https://cloud.githubusercontent.com/assets/1239550/9243549/382710ba-41d5-11e5-9859-ff1fed51ae39.png)


closes #712 
