### PR TITLE
Alert confirmation page for trial subscribers

### DIFF
--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -22,7 +22,17 @@ class AlertsController < ApplicationController
   def confirmed
     @alert = Alert.find_by!(confirm_id: params[:id])
     @alert.confirm!
-    @alert.create_subscription_if_required
+
+    if Subscription::FEATURE_ENABLED && @alert.email_has_several_other_alerts?
+      if @alert.subscription.nil?
+        @subscription = Subscription.create!(email: @alert.email, trial_started_at: Date.today)
+        @new_subscription = true
+        @alert.reload
+      else
+        @subscription = @alert.subscription
+        @new_subscription = false
+      end
+    end
   end
 
   def unsubscribe

--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -27,7 +27,6 @@ class AlertsController < ApplicationController
       if @alert.subscription.nil?
         @subscription = Subscription.create!(email: @alert.email, trial_started_at: Date.today)
         @new_subscription = true
-        @alert.reload
       else
         @subscription = @alert.subscription
         @new_subscription = false

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -200,6 +200,10 @@ class Alert < ActiveRecord::Base
     end
   end
 
+  def has_trial_subscription?
+    subscription.try(:trial?)
+  end
+
   private
 
   def remove_other_alerts_for_this_address

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -196,6 +196,7 @@ class Alert < ActiveRecord::Base
   def create_subscription_if_required
     if Subscription::FEATURE_ENABLED && email_has_several_other_alerts? && subscription.nil?
       Subscription.create!(email: email, trial_started_at: Date.today)
+      reload
     end
   end
 

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -193,13 +193,6 @@ class Alert < ActiveRecord::Base
     Alert.active.where(email: email).count >= 3
   end
 
-  def create_subscription_if_required
-    if Subscription::FEATURE_ENABLED && email_has_several_other_alerts? && subscription.nil?
-      Subscription.create!(email: email, trial_started_at: Date.today)
-      reload
-    end
-  end
-
   def has_trial_subscription?
     subscription.try(:trial?)
   end

--- a/app/views/alerts/confirmed.html.haml
+++ b/app/views/alerts/confirmed.html.haml
@@ -34,8 +34,9 @@
       You can
       = link_to "subscribe here", new_subscription_url(email: @alert.email)
       as soon as you’re ready.
-%p
-  You can
-  = link_to "change the size of the area covered by the alerts", area_alert_path(:id => @alert.confirm_id)
-  now or at a later time. Every email alert will have this link. If you want alerts around another address as well
-  = link_to "you can sign up for multiple alerts", new_alert_path
+- if !@alert.reload.subscription.try(:trial?)
+  %p
+    You can
+    = link_to "change the size of the area covered by the alerts", area_alert_path(:id => @alert.confirm_id)
+    now or at a later time. Every email alert will have this link. If you want alerts around another address as well
+    = link_to "you can sign up for multiple alerts", new_alert_path

--- a/app/views/alerts/confirmed.html.haml
+++ b/app/views/alerts/confirmed.html.haml
@@ -6,8 +6,10 @@
       You will now receive email alerts for any planning applications we find within <strong>#{meters_in_words(@alert.radius_meters)}</strong>
       of <strong>#{@alert.address}</strong>.
   - else
-    - # TODO: Make alert count dynamic
-    %h3 Great, you now have alerts set up for 3 street addresses!
+    %h3
+      Great, you now have alerts set up for
+      = Alert.active.where(email: @alert.email).count.to_s
+      street addresses!
     %p
       You need a paid subscription to get alerts for several addresses, or to use PlanningAlerts for your work.
       A subscription costs $49 per month.

--- a/app/views/alerts/confirmed.html.haml
+++ b/app/views/alerts/confirmed.html.haml
@@ -40,4 +40,4 @@
     = link_to "change the size of the area covered by the alerts", area_alert_path(:id => @alert.confirm_id)
     now or at a later time. Every email alert will have this link.
     If you want alerts around another address as well
-    = link_to "you can sign up for multiple alerts", new_alert_path
+    #{link_to "you can sign up for multiple alerts", new_alert_path}.

--- a/app/views/alerts/confirmed.html.haml
+++ b/app/views/alerts/confirmed.html.haml
@@ -1,11 +1,19 @@
 - content_for :page_title, "Confirmed"
-.attention
-  - if !@alert.reload.subscription.try(:trial?)
+- if !@alert.reload.subscription.try(:trial?)
+  .attention
     %h3 Thanks, your alert has been activated
     %p
       You will now receive email alerts for any planning applications we find within <strong>#{meters_in_words(@alert.radius_meters)}</strong>
       of <strong>#{@alert.address}</strong>.
-  - else
+  %p
+    You can
+    = link_to "change the size of the area covered by the alerts", area_alert_path(:id => @alert.confirm_id)
+    now or at a later time. Every email alert will have this link.
+    If you want alerts around another address as well
+    #{link_to "you can sign up for multiple alerts", new_alert_path}.
+
+- else
+  .attention
     %h3
       Great, you now have alerts set up for
       = Alert.active.where(email: @alert.email).count.to_s
@@ -34,10 +42,3 @@
       You can
       = link_to "subscribe here", new_subscription_url(email: @alert.email)
       as soon as you’re ready.
-- if !@alert.reload.subscription.try(:trial?)
-  %p
-    You can
-    = link_to "change the size of the area covered by the alerts", area_alert_path(:id => @alert.confirm_id)
-    now or at a later time. Every email alert will have this link.
-    If you want alerts around another address as well
-    #{link_to "you can sign up for multiple alerts", new_alert_path}.

--- a/app/views/alerts/confirmed.html.haml
+++ b/app/views/alerts/confirmed.html.haml
@@ -1,5 +1,5 @@
 - content_for :page_title, "Confirmed"
-- if @alert.reload.subscription.try(:trial?)
+- if @alert.has_trial_subscription?
   .attention
     %h3
       Great, you now have alerts set up for

--- a/app/views/alerts/confirmed.html.haml
+++ b/app/views/alerts/confirmed.html.haml
@@ -38,5 +38,6 @@
   %p
     You can
     = link_to "change the size of the area covered by the alerts", area_alert_path(:id => @alert.confirm_id)
-    now or at a later time. Every email alert will have this link. If you want alerts around another address as well
+    now or at a later time. Every email alert will have this link.
+    If you want alerts around another address as well
     = link_to "you can sign up for multiple alerts", new_alert_path

--- a/app/views/alerts/confirmed.html.haml
+++ b/app/views/alerts/confirmed.html.haml
@@ -6,13 +6,14 @@
       You will now receive email alerts for any planning applications we find within <strong>#{meters_in_words(@alert.radius_meters)}</strong>
       of <strong>#{@alert.address}</strong>.
   - else
-    %h3 Thanks, your alert has been activated
+    - # TODO: Make alert count dynamic
+    %h3 Great, you now have alerts set up for 3 street addresses!
     %p
       You will now receive email alerts for any planning applications we find within <strong>#{meters_in_words(@alert.radius_meters)}</strong>
       of <strong>#{@alert.address}</strong>.
     = form_tag subscriptions_path, id: 'subscription-payment-form', class: 'registration-intro' do
       %p
-        You now have several email alerts. PlanningAlerts is free for low-volume, non-commercial use. After a free trial, you'll need to subscribe to keep getting alerts.
+        PlanningAlerts is free for low-volume, non-commercial use. After a free trial, you'll need to subscribe to keep getting alerts.
       = render partial: "subscriptions/stripe_button", locals: {email: @alert.email}
 %p
   You can

--- a/app/views/alerts/confirmed.html.haml
+++ b/app/views/alerts/confirmed.html.haml
@@ -1,19 +1,5 @@
 - content_for :page_title, "Confirmed"
-- if !@alert.reload.subscription.try(:trial?)
-  .attention
-    %h3 Thanks, your alert has been activated
-    %p
-      You will now receive email alerts for any planning applications we find within
-      %strong #{meters_in_words(@alert.radius_meters)}
-      of
-      %strong #{@alert.address}.
-  %p
-    You can #{link_to "change the size of the area covered by the alerts", area_alert_path(id: @alert.confirm_id)}
-    now or at a later time. Every email alert will have this link.
-    If you want alerts around another address as well
-    #{link_to "you can sign up for multiple alerts", new_alert_path}.
-
-- else
+- if @alert.reload.subscription.try(:trial?)
   .attention
     %h3
       Great, you now have alerts set up for
@@ -40,3 +26,16 @@
     %p
       You can #{link_to "subscribe here", new_subscription_url(email: @alert.email)}
       as soon as you’re ready.
+- else
+  .attention
+    %h3 Thanks, your alert has been activated
+    %p
+      You will now receive email alerts for any planning applications we find within
+      %strong #{meters_in_words(@alert.radius_meters)}
+      of
+      %strong #{@alert.address}.
+  %p
+    You can #{link_to "change the size of the area covered by the alerts", area_alert_path(id: @alert.confirm_id)}
+    now or at a later time. Every email alert will have this link.
+    If you want alerts around another address as well
+    #{link_to "you can sign up for multiple alerts", new_alert_path}.

--- a/app/views/alerts/confirmed.html.haml
+++ b/app/views/alerts/confirmed.html.haml
@@ -9,10 +9,25 @@
     - # TODO: Make alert count dynamic
     %h3 Great, you now have alerts set up for 3 street addresses!
     %p
-      You will now receive email alerts for any planning applications we find within <strong>#{meters_in_words(@alert.radius_meters)}</strong>
-      of <strong>#{@alert.address}</strong>.
+      You need a paid subscription to get alerts for several addresses, or to use PlanningAlerts for your work.
+      A subscription costs $49 per month.
+      Once you’re subscribed you can get alerts from as many locations as you need.
+    - # TODO: Make this a test for if the trial has just been created, rather than its length
+    - # Because if you sign up for another alert on the same day you'll see this again.
+    - if @alert.subscription.trial_days_remaining == 7
+      %p
+        We’ve set you up a 7 day free trial subscription,
+        so you can start getting your new alerts straight away.
+    - else
+      %p
+        You still have
+        = pluralize(@alert.subscription.trial_days_remaining, "day")
+        remaining on your free trial subscription,
+        so you’ll start getting your new alerts straight away.
     %p
-      PlanningAlerts is free for low-volume, non-commercial use. After a free trial, you'll need to subscribe to keep getting alerts.
+      Non-commercial use of PlanningAlerts is free for any number of addresses.
+      If this sounds like you, please #{mail_to "contact@planningalerts.org.au", "email us"}—we’ll be happy
+      to help with a free, non-commercial subscription.
     %p
       You can
       = link_to "subscribe here", new_subscription_url(email: @alert.email)

--- a/app/views/alerts/confirmed.html.haml
+++ b/app/views/alerts/confirmed.html.haml
@@ -3,7 +3,7 @@
   .attention
     %h3
       Great, you now have alerts set up for
-      #{Alert.active.where(email: @alert.email).count.to_s} street addresses!
+      #{@subscription.alerts.count} street addresses!
     %p
       %strong You need a paid subscription to get alerts for several addresses, or to use PlanningAlerts for your work.
       #{link_to "A subscription costs $49 per month", new_subscription_url(email: @alert.email)}.

--- a/app/views/alerts/confirmed.html.haml
+++ b/app/views/alerts/confirmed.html.haml
@@ -3,8 +3,10 @@
   .attention
     %h3 Thanks, your alert has been activated
     %p
-      You will now receive email alerts for any planning applications we find within <strong>#{meters_in_words(@alert.radius_meters)}</strong>
-      of <strong>#{@alert.address}</strong>.
+      You will now receive email alerts for any planning applications we find within
+      %strong #{meters_in_words(@alert.radius_meters)}
+      of
+      %strong #{@alert.address}.
   %p
     You can #{link_to "change the size of the area covered by the alerts", area_alert_path(id: @alert.confirm_id)}
     now or at a later time. Every email alert will have this link.

--- a/app/views/alerts/confirmed.html.haml
+++ b/app/views/alerts/confirmed.html.haml
@@ -19,7 +19,7 @@
       = Alert.active.where(email: @alert.email).count.to_s
       street addresses!
     %p
-      You need a paid subscription to get alerts for several addresses, or to use PlanningAlerts for your work.
+      %strong You need a paid subscription to get alerts for several addresses, or to use PlanningAlerts for your work.
       A subscription costs $49 per month.
       Once you’re subscribed you can get alerts from as many locations as you need.
     - # TODO: Make this a test for if the trial has just been created, rather than its length
@@ -35,7 +35,7 @@
         remaining on your free trial subscription,
         so you’ll start getting your new alerts straight away.
     %p
-      Non-commercial use of PlanningAlerts is free for any number of addresses.
+      %strong Non-commercial use of PlanningAlerts is free for any number of addresses.
       If this sounds like you, please #{mail_to "contact@planningalerts.org.au", "email us"}—we’ll be happy
       to help with a free, non-commercial subscription.
     %p

--- a/app/views/alerts/confirmed.html.haml
+++ b/app/views/alerts/confirmed.html.haml
@@ -1,11 +1,15 @@
 - content_for :page_title, "Confirmed"
 .attention
-  %h3 Thanks, your alert has been activated
-  %p
-    You will now receive email alerts for any planning applications we find within <strong>#{meters_in_words(@alert.radius_meters)}</strong>
-    of <strong>#{@alert.address}</strong>.
-
-  - if @alert.reload.subscription.try(:trial?)
+  - if !@alert.reload.subscription.try(:trial?)
+    %h3 Thanks, your alert has been activated
+    %p
+      You will now receive email alerts for any planning applications we find within <strong>#{meters_in_words(@alert.radius_meters)}</strong>
+      of <strong>#{@alert.address}</strong>.
+  - else
+    %h3 Thanks, your alert has been activated
+    %p
+      You will now receive email alerts for any planning applications we find within <strong>#{meters_in_words(@alert.radius_meters)}</strong>
+      of <strong>#{@alert.address}</strong>.
     = form_tag subscriptions_path, id: 'subscription-payment-form', class: 'registration-intro' do
       %p
         You now have several email alerts. PlanningAlerts is free for low-volume, non-commercial use. After a free trial, you'll need to subscribe to keep getting alerts.

--- a/app/views/alerts/confirmed.html.haml
+++ b/app/views/alerts/confirmed.html.haml
@@ -8,9 +8,7 @@
       %strong You need a paid subscription to get alerts for several addresses, or to use PlanningAlerts for your work.
       #{link_to "A subscription costs $49 per month", new_subscription_url(email: @alert.email)}.
       Once you’re subscribed you can get alerts from as many locations as you need.
-    - # TODO: Make this a test for if the trial has just been created, rather than its length
-    - # Because if you sign up for another alert on the same day you'll see this again.
-    - if @subscription.trial_days_remaining == 7
+    - if @new_subscription
       %p
         We’ve set you up a 7 day free trial subscription,
         so you can start getting your new alerts straight away.

--- a/app/views/alerts/confirmed.html.haml
+++ b/app/views/alerts/confirmed.html.haml
@@ -6,8 +6,7 @@
       You will now receive email alerts for any planning applications we find within <strong>#{meters_in_words(@alert.radius_meters)}</strong>
       of <strong>#{@alert.address}</strong>.
   %p
-    You can
-    = link_to "change the size of the area covered by the alerts", area_alert_path(:id => @alert.confirm_id)
+    You can #{link_to "change the size of the area covered by the alerts", area_alert_path(:id => @alert.confirm_id)}
     now or at a later time. Every email alert will have this link.
     If you want alerts around another address as well
     #{link_to "you can sign up for multiple alerts", new_alert_path}.
@@ -16,8 +15,7 @@
   .attention
     %h3
       Great, you now have alerts set up for
-      = Alert.active.where(email: @alert.email).count.to_s
-      street addresses!
+      #{Alert.active.where(email: @alert.email).count.to_s} street addresses!
     %p
       %strong You need a paid subscription to get alerts for several addresses, or to use PlanningAlerts for your work.
       #{link_to "A subscription costs $49 per month", new_subscription_url(email: @alert.email)}.
@@ -30,8 +28,7 @@
         so you can start getting your new alerts straight away.
     - else
       %p
-        You still have
-        = pluralize(@alert.subscription.trial_days_remaining, "day")
+        You still have #{pluralize(@alert.subscription.trial_days_remaining, "day")}
         remaining on your free trial subscription,
         so you’ll start getting your new alerts straight away.
     %p
@@ -39,6 +36,5 @@
       If this sounds like you, please #{mail_to "contact@planningalerts.org.au", "email us"}—we’ll be happy
       to help with a free, non-commercial subscription.
     %p
-      You can
-      = link_to "subscribe here", new_subscription_url(email: @alert.email)
+      You can #{link_to "subscribe here", new_subscription_url(email: @alert.email)}
       as soon as you’re ready.

--- a/app/views/alerts/confirmed.html.haml
+++ b/app/views/alerts/confirmed.html.haml
@@ -1,5 +1,5 @@
 - content_for :page_title, "Confirmed"
-- if @alert.has_trial_subscription?
+- if @subscription.try(:trial?)
   .attention
     %h3
       Great, you now have alerts set up for
@@ -10,13 +10,13 @@
       Once you’re subscribed you can get alerts from as many locations as you need.
     - # TODO: Make this a test for if the trial has just been created, rather than its length
     - # Because if you sign up for another alert on the same day you'll see this again.
-    - if @alert.subscription.trial_days_remaining == 7
+    - if @subscription.trial_days_remaining == 7
       %p
         We’ve set you up a 7 day free trial subscription,
         so you can start getting your new alerts straight away.
     - else
       %p
-        You still have #{pluralize(@alert.subscription.trial_days_remaining, "day")}
+        You still have #{pluralize(@subscription.trial_days_remaining, "day")}
         remaining on your free trial subscription,
         so you’ll start getting your new alerts straight away.
     %p

--- a/app/views/alerts/confirmed.html.haml
+++ b/app/views/alerts/confirmed.html.haml
@@ -6,7 +6,7 @@
       You will now receive email alerts for any planning applications we find within <strong>#{meters_in_words(@alert.radius_meters)}</strong>
       of <strong>#{@alert.address}</strong>.
   %p
-    You can #{link_to "change the size of the area covered by the alerts", area_alert_path(:id => @alert.confirm_id)}
+    You can #{link_to "change the size of the area covered by the alerts", area_alert_path(id: @alert.confirm_id)}
     now or at a later time. Every email alert will have this link.
     If you want alerts around another address as well
     #{link_to "you can sign up for multiple alerts", new_alert_path}.

--- a/app/views/alerts/confirmed.html.haml
+++ b/app/views/alerts/confirmed.html.haml
@@ -10,7 +10,7 @@
       Once you’re subscribed you can get alerts from as many locations as you need.
     - if @new_subscription
       %p
-        We’ve set you up a 7 day free trial subscription,
+        We’ve set you up with a 7 day free trial subscription,
         so you can start getting your new alerts straight away.
     - else
       %p

--- a/app/views/alerts/confirmed.html.haml
+++ b/app/views/alerts/confirmed.html.haml
@@ -20,7 +20,7 @@
       street addresses!
     %p
       %strong You need a paid subscription to get alerts for several addresses, or to use PlanningAlerts for your work.
-      A subscription costs $49 per month.
+      #{link_to "A subscription costs $49 per month", new_subscription_url(email: @alert.email)}.
       Once you’re subscribed you can get alerts from as many locations as you need.
     - # TODO: Make this a test for if the trial has just been created, rather than its length
     - # Because if you sign up for another alert on the same day you'll see this again.

--- a/app/views/alerts/confirmed.html.haml
+++ b/app/views/alerts/confirmed.html.haml
@@ -11,10 +11,12 @@
     %p
       You will now receive email alerts for any planning applications we find within <strong>#{meters_in_words(@alert.radius_meters)}</strong>
       of <strong>#{@alert.address}</strong>.
-    = form_tag subscriptions_path, id: 'subscription-payment-form', class: 'registration-intro' do
-      %p
-        PlanningAlerts is free for low-volume, non-commercial use. After a free trial, you'll need to subscribe to keep getting alerts.
-      = render partial: "subscriptions/stripe_button", locals: {email: @alert.email}
+    %p
+      PlanningAlerts is free for low-volume, non-commercial use. After a free trial, you'll need to subscribe to keep getting alerts.
+    %p
+      You can
+      = link_to "subscribe here", new_subscription_url(email: @alert.email)
+      as soon as you’re ready.
 %p
   You can
   = link_to "change the size of the area covered by the alerts", area_alert_path(:id => @alert.confirm_id)

--- a/spec/features/subscription_spec.rb
+++ b/spec/features/subscription_spec.rb
@@ -37,6 +37,8 @@ feature "Subscribing for access to several alerts" do
       expect(page).to have_content("you now have alerts set up for 3 street addresses")
       expect(Subscription.find_by!(email: email).trial_days_remaining).to eql 7
       expect(Subscription.find_by!(email: email)).to be_trial
+      click_link("subscribe here")
+
       # Fake what the Stripe JS does (i.e. inject the token in the form if successful)
       # FIXME: This isn't having an effect because we're just setting the plan amout to 0. See comment above.
       first("input[name='stripeToken']", visible: false).set(stripe_helper.generate_card_token)

--- a/spec/features/subscription_spec.rb
+++ b/spec/features/subscription_spec.rb
@@ -34,7 +34,7 @@ feature "Subscribing for access to several alerts" do
       expect(current_email).to have_body_text("24 Bruce Road, Glenbrook NSW 2773")
       click_first_link_in_email
 
-      expect(page).to have_content("You now have several email alerts")
+      expect(page).to have_content("you now have alerts set up for 3 street addresses")
       expect(Subscription.find_by!(email: email).trial_days_remaining).to eql 7
       expect(Subscription.find_by!(email: email)).to be_trial
       # Fake what the Stripe JS does (i.e. inject the token in the form if successful)

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -337,40 +337,4 @@ describe Alert do
       it { expect(alert.email_has_several_other_alerts?).to be_true }
     end
   end
-
-  describe "#create_subscription_if_required" do
-    let(:email) { "luke@example.org" }
-    let(:alert) { Alert.find_by(email: email) }
-
-    before :each do
-      2.times { create(:alert, confirmed: true, email: email) }
-    end
-
-    context "2 alerts" do
-      it do
-        expect(Subscription).not_to receive(:create!).with(email: email, trial_started_at: Date.today)
-        alert.create_subscription_if_required
-      end
-    end
-
-    context "3 alerts or more" do
-      before :each do
-        create(:alert, confirmed: true, email: email)
-      end
-
-      it do
-        expect(Subscription).to receive(:create!).with(email: email, trial_started_at: Date.today)
-        alert.create_subscription_if_required
-      end
-
-      context "already has a subscription" do
-        before { create(:subscription, email: email) }
-
-        it do
-          expect(Subscription).to_not receive(:create!).with(email: email, trial_started_at: Date.today)
-          alert.create_subscription_if_required
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
This improves the text on the alert confirmation page for people on their trial subscription. It makes it friendlier, much more direct and gives more of an explanation of what they need to do.

It also simplifies the page by removing the radius adjustment link and the link to subscribe to more alerts.

It also removes the 'Subscribe now' button and replaces it with a link to the new subscription page to give more focus to the information on the page, rather than the new action.

## Before
![screen shot 2015-08-14 at 3 51 16 pm](https://cloud.githubusercontent.com/assets/1239550/9268003/7f996e44-429c-11e5-8729-43981aa22bfc.png)
![screen shot 2015-08-14 at 3 51 05 pm](https://cloud.githubusercontent.com/assets/1239550/9268004/7fa027fc-429c-11e5-933b-f63467ad3cce.png)

## Now
![screen shot 2015-08-14 at 3 50 42 pm](https://cloud.githubusercontent.com/assets/1239550/9268006/864f3f20-429c-11e5-8917-e10636c120e9.png)
![screen shot 2015-08-14 at 3 50 22 pm](https://cloud.githubusercontent.com/assets/1239550/9268007/868fd6d4-429c-11e5-8022-cd31b01378e6.png)

closes #711