### PR TITLE
Note to paid subscribers in alert email

### DIFF
--- a/app/views/alert_notifier/_footer_main.html.haml
+++ b/app/views/alert_notifier/_footer_main.html.haml
@@ -1,3 +1,11 @@
+- if @alert.subscription.try(:paid?)
+  %p
+    You’re a paid subscriber so feel free to
+    #{link_to "sign up for alerts from as many locations as you need", new_alert_path(email: @alert.email)}.
+  %p
+    You can cancel your subscription at any time, just
+    #{mail_to "contact@planningalerts.org.au", "email us at contact@planningalerts.org.au"}.
+
 %p
   %strong Find PlanningAlerts useful?
   Support this charity-run project with a #{link_to "tax deductible donation", donate_url(protocol: @protocol, host: @host, utm_medium: "email", utm_source: "alerts")}.

--- a/app/views/alert_notifier/_footer_main.html.haml
+++ b/app/views/alert_notifier/_footer_main.html.haml
@@ -5,10 +5,10 @@
   %p
     You can cancel your subscription at any time, just
     #{mail_to "contact@planningalerts.org.au", "email us at contact@planningalerts.org.au"}.
-
-%p
-  %strong Find PlanningAlerts useful?
-  Support this charity-run project with a #{link_to "tax deductible donation", donate_url(protocol: @protocol, host: @host, utm_medium: "email", utm_source: "alerts")}.
-%p
-  PlanningAlerts is a free service run by the independent charity #{link_to 'OpenAustralia Foundation', 'https://www.openaustraliafoundation.org.au/'}.
-  Discover our #{link_to 'other projects', 'https://www.openaustraliafoundation.org.au/projects/'}.
+- else
+  %p
+    %strong Find PlanningAlerts useful?
+    Support this charity-run project with a #{link_to "tax deductible donation", donate_url(protocol: @protocol, host: @host, utm_medium: "email", utm_source: "alerts")}.
+  %p
+    PlanningAlerts is a free service run by the independent charity #{link_to 'OpenAustralia Foundation', 'https://www.openaustraliafoundation.org.au/'}.
+    Discover our #{link_to 'other projects', 'https://www.openaustraliafoundation.org.au/projects/'}.

--- a/app/views/alert_notifier/_footer_main.html.haml
+++ b/app/views/alert_notifier/_footer_main.html.haml
@@ -1,7 +1,7 @@
 - if @alert.subscription.try(:paid?)
   %p
     You’re a paid subscriber so feel free to
-    #{link_to "sign up for alerts from as many locations as you need", new_alert_path(email: @alert.email)}.
+    #{link_to "sign up for alerts from as many locations as you need", new_alert_url(email: @alert.email)}.
   %p
     You can cancel your subscription at any time, just
     #{mail_to "contact@planningalerts.org.au", "email us at contact@planningalerts.org.au"}.

--- a/spec/views/alert_notifier/alert_spec.rb
+++ b/spec/views/alert_notifier/alert_spec.rb
@@ -24,13 +24,8 @@ describe "alert_notifier/alert" do
       render
     end
 
-    it "should not show the trial banner" do
-      rendered.should_not have_content("trial subscription")
-    end
-
-    it "should not show a note saying they are a ‘paid subscriber’" do
-      rendered.should_not have_content("You’re a paid subscriber")
-    end
+    it { rendered.should_not have_content("trial subscription") }
+    it { rendered.should_not have_content("You’re a paid subscriber") }
   end
 
   context "when the recipient has a trial subscription" do
@@ -41,17 +36,9 @@ describe "alert_notifier/alert" do
       render
     end
 
-    it "should show the trial banner" do
-      rendered.should have_content("trial subscription")
-    end
-
-    it "should show the number of days remaining in the trial" do
-      rendered.should have_content("7 days remaining")
-    end
-
-    it "should not show a note saying they are a ‘paid subscriber’" do
-      rendered.should_not have_content("You’re a paid subscriber")
-    end
+    it { rendered.should have_content("trial subscription") }
+    it { rendered.should have_content("7 days remaining") }
+    it { rendered.should_not have_content("You’re a paid subscriber") }
   end
 
   context "when the recipient has a trial subscription with only one day left" do
@@ -62,9 +49,7 @@ describe "alert_notifier/alert" do
       render
     end
 
-    it "should not pluralise 'day'" do
-      rendered.should have_content("1 day remaining")
-    end
+    it { rendered.should have_content("1 day remaining") }
   end
 
   context "when the recipient is a paid subscriber" do
@@ -75,8 +60,6 @@ describe "alert_notifier/alert" do
       render
     end
 
-    it "should show a note saying they are a ‘paid subscriber’" do
-      rendered.should have_content("You’re a paid subscriber")
-    end
+    it { rendered.should have_content("You’re a paid subscriber") }
   end
 end

--- a/spec/views/alert_notifier/alert_spec.rb
+++ b/spec/views/alert_notifier/alert_spec.rb
@@ -14,7 +14,7 @@ describe "alert_notifier/alert" do
     assign(:alert, mock_model(Alert, address: "Foo Parade",
       radius_meters: 2000, confirm_id: "1234", subscription: nil))
     render
-    rendered.should have_content("Alterations & additions")
+    expect(rendered).to have_content("Alterations & additions")
   end
 
   context "when the recipient is not a subscriber" do
@@ -24,8 +24,8 @@ describe "alert_notifier/alert" do
       render
     end
 
-    it { rendered.should_not have_content("trial subscription") }
-    it { rendered.should_not have_content("You’re a paid subscriber") }
+    it { expect(rendered).to_not have_content("trial subscription") }
+    it { expect(rendered).to_not have_content("You’re a paid subscriber") }
   end
 
   context "when the recipient has a trial subscription" do
@@ -36,9 +36,9 @@ describe "alert_notifier/alert" do
       render
     end
 
-    it { rendered.should have_content("trial subscription") }
-    it { rendered.should have_content("7 days remaining") }
-    it { rendered.should_not have_content("You’re a paid subscriber") }
+    it { expect(rendered).to have_content("trial subscription") }
+    it { expect(rendered).to have_content("7 days remaining") }
+    it { expect(rendered).to_not have_content("You’re a paid subscriber") }
   end
 
   context "when the recipient has a trial subscription with only one day left" do
@@ -49,7 +49,7 @@ describe "alert_notifier/alert" do
       render
     end
 
-    it { rendered.should have_content("1 day remaining") }
+    it { expect(rendered).to have_content("1 day remaining") }
   end
 
   context "when the recipient is a paid subscriber" do
@@ -60,6 +60,6 @@ describe "alert_notifier/alert" do
       render
     end
 
-    it { rendered.should have_content("You’re a paid subscriber") }
+    it { expect(rendered).to have_content("You’re a paid subscriber") }
   end
 end

--- a/spec/views/alert_notifier/alert_spec.rb
+++ b/spec/views/alert_notifier/alert_spec.rb
@@ -47,4 +47,27 @@ describe "alert_notifier/alert" do
     render
     rendered.should have_content("1 day remaining")
   end
+
+  it "should not show a note to people without a subscription saying they are a ‘paid subscriber’" do
+    assign(:alert, mock_model(Alert, address: "Foo Parade",
+      radius_meters: 2000, confirm_id: "1234", subscription: nil))
+    render
+    rendered.should_not have_content("You’re a paid subscriber")
+  end
+
+  it "should not show a note to trial subscribers saying they are a ‘paid subscriber’" do
+    subscription = create(:subscription, trial_started_at: Date.today)
+    assign(:alert, mock_model(Alert, address: "Foo Parade",
+      radius_meters: 2000, confirm_id: "1234", subscription: subscription))
+    render
+    rendered.should_not have_content("You’re a paid subscriber")
+  end
+
+  it "should show a note to paid subscribers saying they are a ‘paid subscriber’" do
+    subscription = create(:subscription, stripe_subscription_id: "a_stripe_id")
+    assign(:alert, mock_model(Alert, address: "Foo Parade",
+      radius_meters: 2000, confirm_id: "1234", subscription: subscription))
+    render
+    rendered.should have_content("You’re a paid subscriber")
+  end
 end

--- a/spec/views/alert_notifier/alert_spec.rb
+++ b/spec/views/alert_notifier/alert_spec.rb
@@ -24,6 +24,7 @@ describe "alert_notifier/alert" do
       render
     end
 
+    it { expect(rendered).to have_content("Support this charity-run project with a tax deductible donation") }
     it { expect(rendered).to_not have_content("trial subscription") }
     it { expect(rendered).to_not have_content("You’re a paid subscriber") }
   end
@@ -36,6 +37,7 @@ describe "alert_notifier/alert" do
       render
     end
 
+    it { expect(rendered).to have_content("Support this charity-run project with a tax deductible donation") }
     it { expect(rendered).to have_content("trial subscription") }
     it { expect(rendered).to have_content("7 days remaining") }
     it { expect(rendered).to_not have_content("You’re a paid subscriber") }
@@ -61,5 +63,6 @@ describe "alert_notifier/alert" do
     end
 
     it { expect(rendered).to have_content("You’re a paid subscriber") }
+    it { expect(rendered).to_not have_content("Support this charity-run project with a tax deductible donation") }
   end
 end

--- a/spec/views/alert_notifier/alert_spec.rb
+++ b/spec/views/alert_notifier/alert_spec.rb
@@ -17,57 +17,66 @@ describe "alert_notifier/alert" do
     rendered.should have_content("Alterations & additions")
   end
 
-  it "should not show the trial banner if there's no subscription" do
-    assign(:alert, mock_model(Alert, address: "Foo Parade",
-      radius_meters: 2000, confirm_id: "1234", subscription: nil))
-    render
-    rendered.should_not have_content("trial subscription")
+  context "when the recipient is not a subscriber" do
+    before :each do
+      assign(:alert, mock_model(Alert, address: "Foo Parade",
+        radius_meters: 2000, confirm_id: "1234", subscription: nil))
+      render
+    end
+
+    it "should not show the trial banner" do
+      rendered.should_not have_content("trial subscription")
+    end
+
+    it "should not show a note saying they are a ‘paid subscriber’" do
+      rendered.should_not have_content("You’re a paid subscriber")
+    end
   end
 
-  it "should show the trial banner to trial subscribers" do
-    subscription = create(:subscription, trial_started_at: Date.today)
-    assign(:alert, mock_model(Alert, address: "Foo Parade",
-      radius_meters: 2000, confirm_id: "1234", subscription: subscription))
-    render
-    rendered.should have_content("trial subscription")
+  context "when the recipient has a trial subscription" do
+    before :each do
+      subscription = create(:subscription, trial_started_at: Date.today)
+      assign(:alert, mock_model(Alert, address: "Foo Parade",
+        radius_meters: 2000, confirm_id: "1234", subscription: subscription))
+      render
+    end
+
+    it "should show the trial banner" do
+      rendered.should have_content("trial subscription")
+    end
+
+    it "should show the number of days remaining in the trial" do
+      rendered.should have_content("7 days remaining")
+    end
+
+    it "should not show a note saying they are a ‘paid subscriber’" do
+      rendered.should_not have_content("You’re a paid subscriber")
+    end
   end
 
-  it "should show the number of days remaining in the trial subscription" do
-    subscription = create(:subscription, trial_started_at: Date.today)
-    assign(:alert, mock_model(Alert, address: "Foo Parade",
-      radius_meters: 2000, confirm_id: "1234", subscription: subscription))
-    render
-    rendered.should have_content("7 days remaining")
+  context "when the recipient has a trial subscription with only one day left" do
+    before :each do
+      subscription = create(:subscription, trial_started_at: 6.days.ago)
+      assign(:alert, mock_model(Alert, address: "Foo Parade",
+        radius_meters: 2000, confirm_id: "1234", subscription: subscription))
+      render
+    end
+
+    it "should not pluralise 'day'" do
+      rendered.should have_content("1 day remaining")
+    end
   end
 
-  it "should not pluralise 'day' when there's only one left" do
-    subscription = create(:subscription, trial_started_at: 6.days.ago)
-    assign(:alert, mock_model(Alert, address: "Foo Parade",
-      radius_meters: 2000, confirm_id: "1234", subscription: subscription))
-    render
-    rendered.should have_content("1 day remaining")
-  end
+  context "when the recipient is a paid subscriber" do
+    before :each do
+      subscription = create(:subscription, stripe_subscription_id: "a_stripe_id")
+      assign(:alert, mock_model(Alert, address: "Foo Parade",
+        radius_meters: 2000, confirm_id: "1234", subscription: subscription))
+      render
+    end
 
-  it "should not show a note to people without a subscription saying they are a ‘paid subscriber’" do
-    assign(:alert, mock_model(Alert, address: "Foo Parade",
-      radius_meters: 2000, confirm_id: "1234", subscription: nil))
-    render
-    rendered.should_not have_content("You’re a paid subscriber")
-  end
-
-  it "should not show a note to trial subscribers saying they are a ‘paid subscriber’" do
-    subscription = create(:subscription, trial_started_at: Date.today)
-    assign(:alert, mock_model(Alert, address: "Foo Parade",
-      radius_meters: 2000, confirm_id: "1234", subscription: subscription))
-    render
-    rendered.should_not have_content("You’re a paid subscriber")
-  end
-
-  it "should show a note to paid subscribers saying they are a ‘paid subscriber’" do
-    subscription = create(:subscription, stripe_subscription_id: "a_stripe_id")
-    assign(:alert, mock_model(Alert, address: "Foo Parade",
-      radius_meters: 2000, confirm_id: "1234", subscription: subscription))
-    render
-    rendered.should have_content("You’re a paid subscriber")
+    it "should show a note saying they are a ‘paid subscriber’" do
+      rendered.should have_content("You’re a paid subscriber")
+    end
   end
 end


### PR DESCRIPTION
This adds a note for subscribers, reminding them that they're paying and that they can sign up for alerts from as many addresses as they want. It also let's them know how they can cancel their subscription.

closes #713 

![screen shot 2015-08-17 at 10 32 20 am](https://cloud.githubusercontent.com/assets/1239550/9296255/b48959da-44cb-11e5-9533-ac66d8133bfd.png)

The's also a refactor of the alert notifier view spec.