### PR TITLE
Unsubscribe action wording

### DIFF
--- a/app/views/alert_notifier/_footer_actions.html.haml
+++ b/app/views/alert_notifier/_footer_actions.html.haml
@@ -2,5 +2,4 @@
   You can
   = link_to 'change the size', area_alert_url(protocol: @protocol, host: @host, id: @alert.confirm_id)
   of the area covered by this alert or
-  = link_to 'unsubscribe', unsubscribe_alert_url(protocol: @protocol, host: @host, id: @alert.confirm_id)
-  to stop receiving alerts for this address.
+  #{ link_to 'unsubscribe to stop receiving alerts for this address', unsubscribe_alert_url(protocol: @protocol, host: @host, id: @alert.confirm_id) }.

--- a/app/views/alert_notifier/_footer_actions.html.haml
+++ b/app/views/alert_notifier/_footer_actions.html.haml
@@ -1,5 +1,5 @@
 %p
   You can
   = link_to 'change the size', area_alert_url(protocol: @protocol, host: @host, id: @alert.confirm_id)
-  of the area covered by this alert or
-  #{ link_to 'unsubscribe to stop receiving alerts for this address', unsubscribe_alert_url(protocol: @protocol, host: @host, id: @alert.confirm_id) }.
+  of the area you’re interested in or
+  #{ link_to 'stop receiving alerts for this address', unsubscribe_alert_url(protocol: @protocol, host: @host, id: @alert.confirm_id) }.

--- a/app/views/alert_notifier/_footer_actions.html.haml
+++ b/app/views/alert_notifier/_footer_actions.html.haml
@@ -2,4 +2,4 @@
   You can
   = link_to 'change the size', area_alert_url(protocol: @protocol, host: @host, id: @alert.confirm_id)
   of the area you’re interested in or
-  #{ link_to 'stop receiving alerts for this address', unsubscribe_alert_url(protocol: @protocol, host: @host, id: @alert.confirm_id) }.
+  #{ link_to 'unsubscribe from alerts for this address', unsubscribe_alert_url(protocol: @protocol, host: @host, id: @alert.confirm_id) }.

--- a/app/views/alert_notifier/_footer_actions.html.haml
+++ b/app/views/alert_notifier/_footer_actions.html.haml
@@ -3,4 +3,4 @@
   = link_to 'change the size', area_alert_url(protocol: @protocol, host: @host, id: @alert.confirm_id)
   of the area covered by this alert or
   = link_to 'unsubscribe', unsubscribe_alert_url(protocol: @protocol, host: @host, id: @alert.confirm_id)
-  and stop receiving these emails.
+  to stop receiving alerts for this address.

--- a/app/views/alert_notifier/_footer_actions.text.erb
+++ b/app/views/alert_notifier/_footer_actions.text.erb
@@ -1,3 +1,3 @@
-To change the size of the area covered by the alerts: <%= raw area_alert_url(protocol: @protocol, host: @host, id: @alert.confirm_id) %>
+To change the size of the area you’re interested in: <%= raw area_alert_url(protocol: @protocol, host: @host, id: @alert.confirm_id) %>
 
 To stop receiving alerts for this address: <%= raw unsubscribe_alert_url(protocol: @protocol, host: @host, id: @alert.confirm_id) %>

--- a/app/views/alert_notifier/_footer_actions.text.erb
+++ b/app/views/alert_notifier/_footer_actions.text.erb
@@ -1,3 +1,3 @@
 To change the size of the area covered by the alerts: <%= raw area_alert_url(protocol: @protocol, host: @host, id: @alert.confirm_id) %>
 
-To stop receiving these emails: <%= raw unsubscribe_alert_url(protocol: @protocol, host: @host, id: @alert.confirm_id) %>
+To stop receiving alerts for this address: <%= raw unsubscribe_alert_url(protocol: @protocol, host: @host, id: @alert.confirm_id) %>

--- a/app/views/alert_notifier/_footer_actions.text.erb
+++ b/app/views/alert_notifier/_footer_actions.text.erb
@@ -1,3 +1,3 @@
 To change the size of the area you’re interested in: <%= raw area_alert_url(protocol: @protocol, host: @host, id: @alert.confirm_id) %>
 
-To stop receiving alerts for this address: <%= raw unsubscribe_alert_url(protocol: @protocol, host: @host, id: @alert.confirm_id) %>
+To unsubscribe from alerts for this address: <%= raw unsubscribe_alert_url(protocol: @protocol, host: @host, id: @alert.confirm_id) %>

--- a/spec/mailers/regression/alert_notifier/email1.html
+++ b/spec/mailers/regression/alert_notifier/email1.html
@@ -82,8 +82,7 @@ Discover our <a href="https://www.openaustraliafoundation.org.au/projects/">othe
 You can
 <a href="https://dev.planningalerts.org.au/alerts/abcdef/area">change the size</a>
 of the area covered by this alert or
-<a href="https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe">unsubscribe</a>
-and stop receiving these emails.
+<a href="https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe">unsubscribe to stop receiving alerts for this address</a>.
 </p>
 
 </div>

--- a/spec/mailers/regression/alert_notifier/email1.html
+++ b/spec/mailers/regression/alert_notifier/email1.html
@@ -81,8 +81,8 @@ Discover our <a href="https://www.openaustraliafoundation.org.au/projects/">othe
 <p>
 You can
 <a href="https://dev.planningalerts.org.au/alerts/abcdef/area">change the size</a>
-of the area covered by this alert or
-<a href="https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe">unsubscribe to stop receiving alerts for this address</a>.
+of the area you’re interested in or
+<a href="https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe">stop receiving alerts for this address</a>.
 </p>
 
 </div>

--- a/spec/mailers/regression/alert_notifier/email1.html
+++ b/spec/mailers/regression/alert_notifier/email1.html
@@ -82,7 +82,7 @@ Discover our <a href="https://www.openaustraliafoundation.org.au/projects/">othe
 You can
 <a href="https://dev.planningalerts.org.au/alerts/abcdef/area">change the size</a>
 of the area you’re interested in or
-<a href="https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe">stop receiving alerts for this address</a>.
+<a href="https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe">unsubscribe from alerts for this address</a>.
 </p>
 
 </div>

--- a/spec/mailers/regression/alert_notifier/email1.txt
+++ b/spec/mailers/regression/alert_notifier/email1.txt
@@ -27,4 +27,4 @@ Discover our other projects: https://www.openaustraliafoundation.org.au/projects
 
 To change the size of the area covered by the alerts: https://dev.planningalerts.org.au/alerts/abcdef/area
 
-To stop receiving these emails: https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe
+To stop receiving alerts for this address: https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe

--- a/spec/mailers/regression/alert_notifier/email1.txt
+++ b/spec/mailers/regression/alert_notifier/email1.txt
@@ -27,4 +27,4 @@ Discover our other projects: https://www.openaustraliafoundation.org.au/projects
 
 To change the size of the area you’re interested in: https://dev.planningalerts.org.au/alerts/abcdef/area
 
-To stop receiving alerts for this address: https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe
+To unsubscribe from alerts for this address: https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe

--- a/spec/mailers/regression/alert_notifier/email1.txt
+++ b/spec/mailers/regression/alert_notifier/email1.txt
@@ -25,6 +25,6 @@ https://dev.planningalerts.org.au/donate?utm_medium=email&utm_source=alerts
 PlanningAlerts is a free service run by independent charity the OpenAustralia Foundation.
 Discover our other projects: https://www.openaustraliafoundation.org.au/projects/
 
-To change the size of the area covered by the alerts: https://dev.planningalerts.org.au/alerts/abcdef/area
+To change the size of the area you’re interested in: https://dev.planningalerts.org.au/alerts/abcdef/area
 
 To stop receiving alerts for this address: https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe

--- a/spec/mailers/regression/alert_notifier/email2.html
+++ b/spec/mailers/regression/alert_notifier/email2.html
@@ -99,8 +99,8 @@ Discover our <a href="https://www.openaustraliafoundation.org.au/projects/">othe
 <p>
 You can
 <a href="https://dev.planningalerts.org.au/alerts/abcdef/area">change the size</a>
-of the area covered by this alert or
-<a href="https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe">unsubscribe to stop receiving alerts for this address</a>.
+of the area you’re interested in or
+<a href="https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe">stop receiving alerts for this address</a>.
 </p>
 
 </div>

--- a/spec/mailers/regression/alert_notifier/email2.html
+++ b/spec/mailers/regression/alert_notifier/email2.html
@@ -100,7 +100,7 @@ Discover our <a href="https://www.openaustraliafoundation.org.au/projects/">othe
 You can
 <a href="https://dev.planningalerts.org.au/alerts/abcdef/area">change the size</a>
 of the area you’re interested in or
-<a href="https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe">stop receiving alerts for this address</a>.
+<a href="https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe">unsubscribe from alerts for this address</a>.
 </p>
 
 </div>

--- a/spec/mailers/regression/alert_notifier/email2.html
+++ b/spec/mailers/regression/alert_notifier/email2.html
@@ -100,8 +100,7 @@ Discover our <a href="https://www.openaustraliafoundation.org.au/projects/">othe
 You can
 <a href="https://dev.planningalerts.org.au/alerts/abcdef/area">change the size</a>
 of the area covered by this alert or
-<a href="https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe">unsubscribe</a>
-and stop receiving these emails.
+<a href="https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe">unsubscribe to stop receiving alerts for this address</a>.
 </p>
 
 </div>

--- a/spec/mailers/regression/alert_notifier/email2.txt
+++ b/spec/mailers/regression/alert_notifier/email2.txt
@@ -34,6 +34,6 @@ https://dev.planningalerts.org.au/donate?utm_medium=email&utm_source=alerts
 PlanningAlerts is a free service run by independent charity the OpenAustralia Foundation.
 Discover our other projects: https://www.openaustraliafoundation.org.au/projects/
 
-To change the size of the area covered by the alerts: https://dev.planningalerts.org.au/alerts/abcdef/area
+To change the size of the area you’re interested in: https://dev.planningalerts.org.au/alerts/abcdef/area
 
 To stop receiving alerts for this address: https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe

--- a/spec/mailers/regression/alert_notifier/email2.txt
+++ b/spec/mailers/regression/alert_notifier/email2.txt
@@ -36,4 +36,4 @@ Discover our other projects: https://www.openaustraliafoundation.org.au/projects
 
 To change the size of the area covered by the alerts: https://dev.planningalerts.org.au/alerts/abcdef/area
 
-To stop receiving these emails: https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe
+To stop receiving alerts for this address: https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe

--- a/spec/mailers/regression/alert_notifier/email2.txt
+++ b/spec/mailers/regression/alert_notifier/email2.txt
@@ -36,4 +36,4 @@ Discover our other projects: https://www.openaustraliafoundation.org.au/projects
 
 To change the size of the area you’re interested in: https://dev.planningalerts.org.au/alerts/abcdef/area
 
-To stop receiving alerts for this address: https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe
+To unsubscribe from alerts for this address: https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe

--- a/spec/mailers/regression/alert_notifier/email3.html
+++ b/spec/mailers/regression/alert_notifier/email3.html
@@ -52,8 +52,8 @@ Discover our <a href="https://www.openaustraliafoundation.org.au/projects/">othe
 <p>
 You can
 <a href="https://dev.planningalerts.org.au/alerts/abcdef/area">change the size</a>
-of the area covered by this alert or
-<a href="https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe">unsubscribe to stop receiving alerts for this address</a>.
+of the area you’re interested in or
+<a href="https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe">stop receiving alerts for this address</a>.
 </p>
 
 </div>

--- a/spec/mailers/regression/alert_notifier/email3.html
+++ b/spec/mailers/regression/alert_notifier/email3.html
@@ -53,7 +53,7 @@ Discover our <a href="https://www.openaustraliafoundation.org.au/projects/">othe
 You can
 <a href="https://dev.planningalerts.org.au/alerts/abcdef/area">change the size</a>
 of the area you’re interested in or
-<a href="https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe">stop receiving alerts for this address</a>.
+<a href="https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe">unsubscribe from alerts for this address</a>.
 </p>
 
 </div>

--- a/spec/mailers/regression/alert_notifier/email3.html
+++ b/spec/mailers/regression/alert_notifier/email3.html
@@ -53,8 +53,7 @@ Discover our <a href="https://www.openaustraliafoundation.org.au/projects/">othe
 You can
 <a href="https://dev.planningalerts.org.au/alerts/abcdef/area">change the size</a>
 of the area covered by this alert or
-<a href="https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe">unsubscribe</a>
-and stop receiving these emails.
+<a href="https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe">unsubscribe to stop receiving alerts for this address</a>.
 </p>
 
 </div>

--- a/spec/mailers/regression/alert_notifier/email3.txt
+++ b/spec/mailers/regression/alert_notifier/email3.txt
@@ -25,4 +25,4 @@ Discover our other projects: https://www.openaustraliafoundation.org.au/projects
 
 To change the size of the area covered by the alerts: https://dev.planningalerts.org.au/alerts/abcdef/area
 
-To stop receiving these emails: https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe
+To stop receiving alerts for this address: https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe

--- a/spec/mailers/regression/alert_notifier/email3.txt
+++ b/spec/mailers/regression/alert_notifier/email3.txt
@@ -23,6 +23,6 @@ https://dev.planningalerts.org.au/donate?utm_medium=email&utm_source=alerts
 PlanningAlerts is a free service run by independent charity the OpenAustralia Foundation.
 Discover our other projects: https://www.openaustraliafoundation.org.au/projects/
 
-To change the size of the area covered by the alerts: https://dev.planningalerts.org.au/alerts/abcdef/area
+To change the size of the area you’re interested in: https://dev.planningalerts.org.au/alerts/abcdef/area
 
 To stop receiving alerts for this address: https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe

--- a/spec/mailers/regression/alert_notifier/email3.txt
+++ b/spec/mailers/regression/alert_notifier/email3.txt
@@ -25,4 +25,4 @@ Discover our other projects: https://www.openaustraliafoundation.org.au/projects
 
 To change the size of the area you’re interested in: https://dev.planningalerts.org.au/alerts/abcdef/area
 
-To stop receiving alerts for this address: https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe
+To unsubscribe from alerts for this address: https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe

--- a/spec/mailers/regression/alert_notifier/email4.html
+++ b/spec/mailers/regression/alert_notifier/email4.html
@@ -83,8 +83,8 @@ from the
 <p>
 You can
 <a href="http://nsw.127.0.0.1.xip.io:3000/alerts/abcdef/area">change the size</a>
-of the area covered by this alert or
-<a href="http://nsw.127.0.0.1.xip.io:3000/alerts/abcdef/unsubscribe">unsubscribe to stop receiving alerts for this address</a>.
+of the area you’re interested in or
+<a href="http://nsw.127.0.0.1.xip.io:3000/alerts/abcdef/unsubscribe">stop receiving alerts for this address</a>.
 </p>
 
 </div>

--- a/spec/mailers/regression/alert_notifier/email4.html
+++ b/spec/mailers/regression/alert_notifier/email4.html
@@ -84,8 +84,7 @@ from the
 You can
 <a href="http://nsw.127.0.0.1.xip.io:3000/alerts/abcdef/area">change the size</a>
 of the area covered by this alert or
-<a href="http://nsw.127.0.0.1.xip.io:3000/alerts/abcdef/unsubscribe">unsubscribe</a>
-and stop receiving these emails.
+<a href="http://nsw.127.0.0.1.xip.io:3000/alerts/abcdef/unsubscribe">unsubscribe to stop receiving alerts for this address</a>.
 </p>
 
 </div>

--- a/spec/mailers/regression/alert_notifier/email4.html
+++ b/spec/mailers/regression/alert_notifier/email4.html
@@ -84,7 +84,7 @@ from the
 You can
 <a href="http://nsw.127.0.0.1.xip.io:3000/alerts/abcdef/area">change the size</a>
 of the area you’re interested in or
-<a href="http://nsw.127.0.0.1.xip.io:3000/alerts/abcdef/unsubscribe">stop receiving alerts for this address</a>.
+<a href="http://nsw.127.0.0.1.xip.io:3000/alerts/abcdef/unsubscribe">unsubscribe from alerts for this address</a>.
 </p>
 
 </div>

--- a/spec/mailers/regression/alert_notifier/email4.txt
+++ b/spec/mailers/regression/alert_notifier/email4.txt
@@ -24,4 +24,4 @@ https://www.openaustraliafoundation.org.au
 
 To change the size of the area covered by the alerts: http://nsw.127.0.0.1.xip.io:3000/alerts/abcdef/area
 
-To stop receiving these emails: http://nsw.127.0.0.1.xip.io:3000/alerts/abcdef/unsubscribe
+To stop receiving alerts for this address: http://nsw.127.0.0.1.xip.io:3000/alerts/abcdef/unsubscribe

--- a/spec/mailers/regression/alert_notifier/email4.txt
+++ b/spec/mailers/regression/alert_notifier/email4.txt
@@ -22,6 +22,6 @@ Application Tracking is brought to you by Planning & Environment, NSW.
 It is powered by PlanningAlerts.org.au from the OpenAustralia Foundation
 https://www.openaustraliafoundation.org.au
 
-To change the size of the area covered by the alerts: http://nsw.127.0.0.1.xip.io:3000/alerts/abcdef/area
+To change the size of the area you’re interested in: http://nsw.127.0.0.1.xip.io:3000/alerts/abcdef/area
 
 To stop receiving alerts for this address: http://nsw.127.0.0.1.xip.io:3000/alerts/abcdef/unsubscribe

--- a/spec/mailers/regression/alert_notifier/email4.txt
+++ b/spec/mailers/regression/alert_notifier/email4.txt
@@ -24,4 +24,4 @@ https://www.openaustraliafoundation.org.au
 
 To change the size of the area you’re interested in: http://nsw.127.0.0.1.xip.io:3000/alerts/abcdef/area
 
-To stop receiving alerts for this address: http://nsw.127.0.0.1.xip.io:3000/alerts/abcdef/unsubscribe
+To unsubscribe from alerts for this address: http://nsw.127.0.0.1.xip.io:3000/alerts/abcdef/unsubscribe


### PR DESCRIPTION
This changes the wording of the unsubscribe link in alert emails to make it clearer what you are unsubscribing from. The idea for this change came from the discussion here https://github.com/openaustralia/planningalerts/pull/734#issuecomment-131649057

The wording changes from:

> [unsubscribe](#) and stop receiving these emails

To:

> [unsubscribe to stop receiving alerts for this address](#)

![screen shot 2015-08-17 at 12 46 42 pm](https://cloud.githubusercontent.com/assets/1239550/9297194/a8a49b4e-44de-11e5-94e1-f132f58e73d3.png)
![screen shot 2015-08-17 at 12 46 27 pm](https://cloud.githubusercontent.com/assets/1239550/9297193/a8655452-44de-11e5-8bb8-606f215d5682.png)
