### PR TITLE
Provide more and clearer information on the new subscription page

### DIFF
--- a/app/assets/stylesheets/partials/_payment_form.scss
+++ b/app/assets/stylesheets/partials/_payment_form.scss
@@ -1,6 +1,6 @@
 .registration-page,
 .registration-success-page {
-  max-width: 42em;
+  max-width: 43em;
   padding-bottom: 4em;
 
   @include at-breakpoint(40em) {

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -5,12 +5,14 @@
     %h1.page-title Subscribe here
 
     %p
-      Subscribe here to get alerts of planning applications near several addresses,
-      or to use PlanningAlerts for your work.
+      %strong
+        Subscribe here to get alerts of planning applications near several addresses,
+        or to use PlanningAlerts for your work.
       Once you’re subscribed you can sign up for alerts from as many locations as you need.
 
     %p
-      Non-commercial use of PlanningAlerts is free for any number of addresses.
+      %strong
+        Non-commercial use of PlanningAlerts is free for any number of addresses.
       If this sounds like you, please #{mail_to "contact@planningalerts.org.au", "email us"}—
       we’ll be happy to help with a free, non-commercial subscription.
 

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -6,7 +6,7 @@
 
     %p
       %strong
-        Subscribe here to get alerts of planning applications near several addresses,
+        Subscribe here to get alerts for several addresses,
         or to use PlanningAlerts for your work.
       Once you’re subscribed you can sign up for alerts from as many locations as you need.
 

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -5,14 +5,11 @@
     %h1.page-title Subscribe here
 
     %p
-      %strong
-        Subscribe here to get alerts for several addresses,
-        or to use PlanningAlerts for your work.
+      %strong Subscribe here to get alerts for several addresses, or to use PlanningAlerts for your work.
       Once you’re subscribed you can sign up for alerts from as many locations as you need.
 
     %p
-      %strong
-        Non-commercial use of PlanningAlerts is free for any number of addresses.
+      %strong Non-commercial use of PlanningAlerts is free for any number of addresses.
       If this sounds like you, please #{mail_to "contact@planningalerts.org.au", "email us"}—
       we’ll be happy to help with a free, non-commercial subscription.
 

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -10,7 +10,7 @@
 
     %p
       %strong Non-commercial use of PlanningAlerts is free for any number of addresses.
-      If this sounds like you, please #{mail_to "contact@planningalerts.org.au", "email us"}—
-      we’ll be happy to help with a free, non-commercial subscription.
+      If this sounds like you, please #{mail_to "contact@planningalerts.org.au", "email us"}—we’ll
+      be happy to help with a free, non-commercial subscription.
 
     = render partial: "stripe_button", locals: {email: @email}

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -5,8 +5,8 @@
     %h1.page-title Subscribe here
 
     %p
-      Subscribe here to get alerts of planning applications near several addresses.
-      Once you’re subscribed you can sign up for alerts from as many locations as you need
-      and use PlanningAlerts in your work.
+      Subscribe here to get alerts of planning applications near several addresses,
+      or to use PlanningAlerts for your work.
+      Once you’re subscribed you can sign up for alerts from as many locations as you need.
 
     = render partial: "stripe_button", locals: {email: @email}

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -11,6 +11,9 @@
     %p
       %strong Non-commercial use of PlanningAlerts is free for any number of addresses.
       If this sounds like you, please #{mail_to "contact@planningalerts.org.au", "email us"}—we’ll
-      be happy to help with a free, non-commercial subscription.
+      be happy to help with a free,
+      - # This prevents the term breaking over two lines, remove this hack if copy changes make it possible
+      %span{style: "white-space: nowrap;"}non-commercial
+      subscription.
 
     = render partial: "stripe_button", locals: {email: @email}

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -9,4 +9,9 @@
       or to use PlanningAlerts for your work.
       Once you’re subscribed you can sign up for alerts from as many locations as you need.
 
+    %p
+      Non-commercial use of PlanningAlerts is free for any number of addresses.
+      If this sounds like you, please #{mail_to "contact@planningalerts.org.au", "email us"}—
+      we’ll be happy to help with a free, non-commercial subscription.
+
     = render partial: "stripe_button", locals: {email: @email}

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -5,7 +5,7 @@
     %h1.page-title Subscribe here
 
     %p
-      %strong Subscribe here to get alerts for several addresses, or to use PlanningAlerts for your work.
+      %strong Subscribe here to get alerts for several addresses if you use PlanningAlerts for your work.
       Once you’re subscribed you can sign up for alerts from as many locations as you need.
 
     %p


### PR DESCRIPTION
These commits change the text on the new subscription page to make it clearer that you need a subscription for commercial use or to get alerts for several addresses, and also let you know what to do if you're a non-commercial user. This also makes it consistent with the text on the 3rd alert confirmation/trial start page.

Before:
![screen shot 2015-08-18 at 11 21 36 am](https://cloud.githubusercontent.com/assets/1239550/9320271/58080c94-459b-11e5-8f73-222e42aa8c5b.png)

After:
![screen shot 2015-08-18 at 11 18 08 am](https://cloud.githubusercontent.com/assets/1239550/9320278/6514401a-459b-11e5-9c72-696de8d6213a.png)
![screen shot 2015-08-18 at 11 17 52 am](https://cloud.githubusercontent.com/assets/1239550/9320277/643c30b2-459b-11e5-8489-78b7cccfa400.png)


closes #721 
closes #722 