### PR TITLE
Track how trial subscribers respond so we can improve subscription flow

### DIFF
--- a/app/mailers/alert_notifier.rb
+++ b/app/mailers/alert_notifier.rb
@@ -4,7 +4,7 @@ class AlertNotifier < ActionMailer::Base
 
   def alert(theme, alert, applications, comments = [])
     @alert, @applications, @comments = alert, applications, comments
-
+    @analytics_params = {utm_source: "alert", utm_medium: "email", utm_campaign: "trial_subscriber"}
 
     themed_mail(theme: theme, from: email_from(theme), to: alert.email,
       subject: render_to_string(partial: "subject",

--- a/app/mailers/alert_notifier.rb
+++ b/app/mailers/alert_notifier.rb
@@ -4,7 +4,7 @@ class AlertNotifier < ActionMailer::Base
 
   def alert(theme, alert, applications, comments = [])
     @alert, @applications, @comments = alert, applications, comments
-    @analytics_params = {utm_source: "alert", utm_medium: "email", utm_campaign: "trial_subscriber"}
+    @trial_subscriber_analytics_params = {utm_source: "alert", utm_medium: "email", utm_campaign: "trial_subscriber"}
 
     themed_mail(theme: theme, from: email_from(theme), to: alert.email,
       subject: render_to_string(partial: "subject",

--- a/app/views/alert_notifier/_trial_banner.html.haml
+++ b/app/views/alert_notifier/_trial_banner.html.haml
@@ -3,7 +3,7 @@
     %tr
       %td
         .trial-banner-button-container
-          = link_to "Subscribe now", new_subscription_url(email: @alert.email, utm_source: "alert", utm_medium: "email", utm_campaign: "trial_subscriber"), class: 'trial-banner-button'
+          = link_to "Subscribe now", new_subscription_url(@analytics_params.merge(email: @alert.email)), class: 'trial-banner-button'
         %p
-          Your #{link_to "trial subscription", new_subscription_url(email: @alert.email, utm_source: "alert", utm_medium: "email", utm_campaign: "trial_subscriber")}
+          Your #{link_to "trial subscription", new_subscription_url(@analytics_params.merge(email: @alert.email))}
           has #{pluralize(@alert.subscription.trial_days_remaining, "day")} remaining

--- a/app/views/alert_notifier/_trial_banner.html.haml
+++ b/app/views/alert_notifier/_trial_banner.html.haml
@@ -3,7 +3,7 @@
     %tr
       %td
         .trial-banner-button-container
-          = link_to "Subscribe now", new_subscription_url(@analytics_params.merge(email: @alert.email)), class: 'trial-banner-button'
+          = link_to "Subscribe now", new_subscription_url(@trial_subscriber_analytics_params.merge(email: @alert.email)), class: 'trial-banner-button'
         %p
-          Your #{link_to "trial subscription", new_subscription_url(@analytics_params.merge(email: @alert.email))}
+          Your #{link_to "trial subscription", new_subscription_url(@trial_subscriber_analytics_params.merge(email: @alert.email))}
           has #{pluralize(@alert.subscription.trial_days_remaining, "day")} remaining

--- a/app/views/alert_notifier/_trial_banner.html.haml
+++ b/app/views/alert_notifier/_trial_banner.html.haml
@@ -3,7 +3,7 @@
     %tr
       %td
         .trial-banner-button-container
-          = link_to "Subscribe now", new_subscription_url(email: @alert.email), class: 'trial-banner-button'
+          = link_to "Subscribe now", new_subscription_url(email: @alert.email, utm_source: "alert", utm_medium: "email", utm_campaign: "trial_subscriber"), class: 'trial-banner-button'
         %p
-          Your #{link_to "trial subscription", new_subscription_url(email: @alert.email)}
+          Your #{link_to "trial subscription", new_subscription_url(email: @alert.email, utm_source: "alert", utm_medium: "email", utm_campaign: "trial_subscriber")}
           has #{pluralize(@alert.subscription.trial_days_remaining, "day")} remaining

--- a/app/views/alert_notifier/_trial_banner.html.haml
+++ b/app/views/alert_notifier/_trial_banner.html.haml
@@ -3,7 +3,7 @@
     %tr
       %td
         .trial-banner-button-container
-          = link_to "Subscribe now", new_subscription_url(@trial_subscriber_analytics_params.merge(email: @alert.email)), class: 'trial-banner-button'
+          = link_to "Subscribe now", new_subscription_url(@trial_subscriber_analytics_params.merge(utm_content: "button_link", email: @alert.email)), class: 'trial-banner-button'
         %p
-          Your #{link_to "trial subscription", new_subscription_url(@trial_subscriber_analytics_params.merge(email: @alert.email))}
+          Your #{link_to "trial subscription", new_subscription_url(@trial_subscriber_analytics_params.merge(utm_content: "text_link", email: @alert.email))}
           has #{pluralize(@alert.subscription.trial_days_remaining, "day")} remaining

--- a/app/views/alert_notifier/_trial_banner.text.erb
+++ b/app/views/alert_notifier/_trial_banner.text.erb
@@ -1,3 +1,3 @@
 Your trial subscription has <%= pluralize(@alert.subscription.trial_days_remaining, "day") %> left
 Use this link to subscribe now:
-<%= new_subscription_url(email: @alert.email) %>
+<%= new_subscription_url(email: @alert.email, utm_source: "alert", utm_medium: "email", utm_campaign: "trial_subscriber") %>

--- a/app/views/alert_notifier/_trial_banner.text.erb
+++ b/app/views/alert_notifier/_trial_banner.text.erb
@@ -1,3 +1,3 @@
 Your trial subscription has <%= pluralize(@alert.subscription.trial_days_remaining, "day") %> left
 Use this link to subscribe now:
-<%= new_subscription_url(email: @alert.email, utm_source: "alert", utm_medium: "email", utm_campaign: "trial_subscriber") %>
+<%= new_subscription_url(@analytics_params.merge(email: @alert.email)) %>

--- a/app/views/alert_notifier/_trial_banner.text.erb
+++ b/app/views/alert_notifier/_trial_banner.text.erb
@@ -1,3 +1,3 @@
 Your trial subscription has <%= pluralize(@alert.subscription.trial_days_remaining, "day") %> left
 Use this link to subscribe now:
-<%= new_subscription_url(@trial_subscriber_analytics_params.merge(email: @alert.email)) %>
+<%= new_subscription_url(@trial_subscriber_analytics_params.merge(utm_content: "text_format_link", email: @alert.email)) %>

--- a/app/views/alert_notifier/_trial_banner.text.erb
+++ b/app/views/alert_notifier/_trial_banner.text.erb
@@ -1,3 +1,3 @@
 Your trial subscription has <%= pluralize(@alert.subscription.trial_days_remaining, "day") %> left
 Use this link to subscribe now:
-<%= new_subscription_url(@analytics_params.merge(email: @alert.email)) %>
+<%= new_subscription_url(@trial_subscriber_analytics_params.merge(email: @alert.email)) %>

--- a/spec/views/alert_notifier/alert_spec.rb
+++ b/spec/views/alert_notifier/alert_spec.rb
@@ -34,7 +34,7 @@ describe "alert_notifier/alert" do
       subscription = create(:subscription, trial_started_at: Date.today)
       assign(:alert, mock_model(Alert, address: "Foo Parade",
         radius_meters: 2000, confirm_id: "1234", subscription: subscription))
-      assign(:analytics_params, foo: :bar)
+      assign(:trial_subscriber_analytics_params, foo: :bar)
       render
     end
 
@@ -49,7 +49,7 @@ describe "alert_notifier/alert" do
       subscription = create(:subscription, trial_started_at: 6.days.ago)
       assign(:alert, mock_model(Alert, address: "Foo Parade",
         radius_meters: 2000, confirm_id: "1234", subscription: subscription))
-      assign(:analytics_params, foo: :bar)
+      assign(:trial_subscriber_analytics_params, foo: :bar)
       render
     end
 

--- a/spec/views/alert_notifier/alert_spec.rb
+++ b/spec/views/alert_notifier/alert_spec.rb
@@ -34,6 +34,7 @@ describe "alert_notifier/alert" do
       subscription = create(:subscription, trial_started_at: Date.today)
       assign(:alert, mock_model(Alert, address: "Foo Parade",
         radius_meters: 2000, confirm_id: "1234", subscription: subscription))
+      assign(:analytics_params, foo: :bar)
       render
     end
 
@@ -48,6 +49,7 @@ describe "alert_notifier/alert" do
       subscription = create(:subscription, trial_started_at: 6.days.ago)
       assign(:alert, mock_model(Alert, address: "Foo Parade",
         radius_meters: 2000, confirm_id: "1234", subscription: subscription))
+      assign(:analytics_params, foo: :bar)
       render
     end
 


### PR DESCRIPTION
This adds Google Analytics tracking params to the trial banner links so we can specifically see how trial subscribers move through the site.

This doesn't feel very DRY, but I couldn't work out how to move that up into the mailer, so I did the dumb thing.

Closes #747.