### PR TITLE
Remove charity and donation messages from alert footer for trial subscribers

### DIFF
--- a/app/views/alert_notifier/alert.html.haml
+++ b/app/views/alert_notifier/alert.html.haml
@@ -11,5 +11,5 @@
       = render "applications"
     .footer-outer
       .footer-inner
-        = render "footer_main"
+        = render "footer_main" unless @alert.subscription.try(:trial?)
         = render "footer_actions"

--- a/spec/views/alert_notifier/alert_spec.rb
+++ b/spec/views/alert_notifier/alert_spec.rb
@@ -37,7 +37,7 @@ describe "alert_notifier/alert" do
       render
     end
 
-    it { expect(rendered).to have_content("Support this charity-run project with a tax deductible donation") }
+    it { expect(rendered).to_not have_content("Support this charity-run project with a tax deductible donation") }
     it { expect(rendered).to have_content("trial subscription") }
     it { expect(rendered).to have_content("7 days remaining") }
     it { expect(rendered).to_not have_content("You’re a paid subscriber") }

--- a/spec/views/alert_notifier/alert_spec.rb
+++ b/spec/views/alert_notifier/alert_spec.rb
@@ -37,9 +37,9 @@ describe "alert_notifier/alert" do
       render
     end
 
-    it { expect(rendered).to_not have_content("Support this charity-run project with a tax deductible donation") }
     it { expect(rendered).to have_content("trial subscription") }
     it { expect(rendered).to have_content("7 days remaining") }
+    it { expect(rendered).to_not have_content("Support this charity-run project with a tax deductible donation") }
     it { expect(rendered).to_not have_content("You’re a paid subscriber") }
   end
 


### PR DESCRIPTION
The content in the footer is supposed to tell subscribers that this is a community project and that they should subscribe. That's a confusing message for trial subscribers. They are being told that they need to subscribe because they are getting several alerts and are using the project in their work.

This removes the two relevant sentences from the footer of alerts to trial subscribers.

## Before
![screen shot 2015-08-21 at 5 25 09 pm](https://cloud.githubusercontent.com/assets/1239550/9403398/24d3cb60-482a-11e5-9aad-9f64275b127a.png)

## After
![screen shot 2015-08-21 at 5 24 48 pm](https://cloud.githubusercontent.com/assets/1239550/9403401/2a73f874-482a-11e5-864a-91a5abbd855c.png)

closes #753 