### PR TITLE
Comment confirmation tracking

### DIFF
--- a/app/assets/javascripts/applications.js
+++ b/app/assets/javascripts/applications.js
@@ -8,6 +8,10 @@ $('#comment_address_input a').click(function(e) {
 $( document ).ready(function() {
   // check if the Google Analytics function is available
   if (typeof ga == 'function') {
+    $('#comment_submit_action input[type="submit"]').click(function(e) {
+      ga('send', 'event', 'comments', 'click submit new comment');
+    });
+
     if ($('.notice-comment-confirmed').length) {
       ga('send', 'event', 'comments', 'comment confirm message displayed');
     }

--- a/app/assets/javascripts/applications.js
+++ b/app/assets/javascripts/applications.js
@@ -3,3 +3,13 @@ $('#comment_address_input a').click(function(e) {
   e.preventDefault();
   $('#faq_commenting_address').slideToggle('fast');
 });
+
+// GA Tracking of comment process
+$( document ).ready(function() {
+  // check if the Google Analytics function is available
+  if (typeof ga == 'function') {
+    if ($('.notice-comment-confirmed').length) {
+      ga('send', 'event', 'comments', 'comment confirm message displayed');
+    }
+  }
+});

--- a/app/views/comments/_confirmed.html.haml
+++ b/app/views/comments/_confirmed.html.haml
@@ -1,6 +1,6 @@
 %span.notice-comment-confirmed
   Thanks.
-  = link_to 'Your comment', application_path(@comment.application, :anchor => "comment#{@comment.id}")
+  = link_to 'Your comment', application_path(@comment.application, anchor: "comment#{@comment.id}")
   has been sent to
   = @comment.application.authority.full_name
   and is now visible on this page.

--- a/app/views/comments/_confirmed.html.haml
+++ b/app/views/comments/_confirmed.html.haml
@@ -1,5 +1,6 @@
-Thanks.
-= link_to 'Your comment', application_path(@comment.application, :anchor => "comment#{@comment.id}")
-has been sent to
-= @comment.application.authority.full_name
-and is now visible on this page.
+%span.notice-comment-confirmed
+  Thanks.
+  = link_to 'Your comment', application_path(@comment.application, :anchor => "comment#{@comment.id}")
+  has been sent to
+  = @comment.application.authority.full_name
+  and is now visible on this page.

--- a/app/views/comments/_confirmed.html.haml
+++ b/app/views/comments/_confirmed.html.haml
@@ -1,1 +1,5 @@
-Thanks. #{link_to 'Your comment', application_path(@comment.application, :anchor => "comment#{@comment.id}")} has been sent to #{@comment.application.authority.full_name} and is now visible on this page.
+Thanks.
+= link_to 'Your comment', application_path(@comment.application, :anchor => "comment#{@comment.id}")
+has been sent to
+= @comment.application.authority.full_name
+and is now visible on this page.


### PR DESCRIPTION
## Why

At the moment our attempts to track comment confirmation in Google Analytics aren't working (see [comment](https://github.com/openaustralia/planningalerts/issues/687#issuecomment-132423667) on #687 ). We want to be capture these actions in ga so we can better understand what people do before and after they comment.

## These commits

* add a class to target and some js to fire the event when GA is loaded and the confirmation message is on screen.