### PR TITLE
Add tracking on link to comment form

### DIFF
--- a/app/assets/javascripts/applications.js
+++ b/app/assets/javascripts/applications.js
@@ -8,6 +8,10 @@ $('#comment_address_input a').click(function(e) {
 $( document ).ready(function() {
   // check if the Google Analytics function is available
   if (typeof ga == 'function') {
+    $('.link-to-comment-form').click(function(e) {
+      ga('send', 'event', 'comments', 'click link to go to comment form');
+    });
+
     $('#comment_submit_action input[type="submit"]').click(function(e) {
       ga('send', 'event', 'comments', 'click submit new comment');
     });

--- a/app/views/applications/show.html.haml
+++ b/app/views/applications/show.html.haml
@@ -40,7 +40,7 @@
       - if @comments.present?
         %h4= pluralize(@comments.count, "Comment")
         %p.small.quiet
-          Have your say by #{link_to "adding your own comment", "#add-comment"}.
+          Have your say by #{link_to "adding your own comment", "#add-comment", class: "link-to-comment-form"}.
         %ol#comments
           - @comments.each do |comment|
             %li{:id => "comment#{comment.id}"}


### PR DESCRIPTION
This will help us see if this link is actually helpful. Do people use this link to navigate, then make a comment? Let's find out.

![screen shot 2015-09-14 at 2 35 01 pm](https://cloud.githubusercontent.com/assets/1239550/9842176/e7a2074e-5aed-11e5-9436-5f10f292e84d.png)

closes #687 