### PR TITLE
Fix regression where partial can't be found, fixes #778

### DIFF
--- a/app/views/applications/_comments_area.html.haml
+++ b/app/views/applications/_comments_area.html.haml
@@ -7,4 +7,4 @@
       - @comments.each do |comment|
         %li{:id => "comment#{comment.id}"}
           = render :partial => 'comments/comment', :locals => {:comment => comment}
-  = render "comment_form"
+  = render "applications/comment_form"

--- a/app/views/applications/show.html.haml
+++ b/app/views/applications/show.html.haml
@@ -35,9 +35,9 @@
         %p.source (Source: #{link_to @application.authority.full_name, authority_path(@application.authority.short_name_encoded)}, reference #{@application.council_reference})
 
     - if current_user && current_user.admin?
-      = render "comments_options_tabs"
+      = render "applications/comments_options_tabs"
     - else
-      = render "comments_area"
+      = render "applications/comments_area"
 
 #sidebar
   #alert

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -25,6 +25,23 @@ feature "Give feedback to Council" do
     page.should_not have_content("How to comment on this application")
   end
 
+  scenario "Getting an error message if the comment form isn’t completed correctly" do
+    authority = create(:authority, full_name: "Foo", email: "feedback@foo.gov.au")
+    VCR.use_cassette('planningalerts') do
+      application = create(:application, id: "1", authority_id: authority.id)
+      visit(application_path(application))
+    end
+
+    fill_in("Comment", with: "I think this is a really good idea")
+    fill_in("Name", with: "Matthew Landauer")
+    fill_in("Email", with: "example@example.com")
+    # Don't fill in the address
+    click_button("Create Comment")
+
+    page.should have_content("Some of the comment wasn't filled out completely. See below.")
+    page.should_not have_content("Now check your email")
+  end
+
   scenario "Adding a comment" do
     authority = create(:authority, full_name: "Foo", email: "feedback@foo.gov.au")
     VCR.use_cassette('planningalerts') do


### PR DESCRIPTION
When the applications/show is called from the comment controlled,
it searches for partials in the views/comments directory.

This raises an error because partials were extracted from this view using just
the partial name.

Using an absolute path (from the view directory) fixes this as
rails can always find the partial no matter which controller the
applications/show view is called from.

This also adds an integration test for the situation that
this bug was discovered in.