### PR TITLE
Use a more intuitive verb and make comment button personal

### DIFF
--- a/app/views/comments/_comment_form.html.haml
+++ b/app/views/comments/_comment_form.html.haml
@@ -29,7 +29,7 @@
         = label_tag :little_sweety, 'Little Sweety'
         = text_field_tag :little_sweety, "", placeholder: "Please leave this blank"
     = f.actions do
-      = f.action :submit, button_html: {class: "button button-action"}
+      = f.action :submit, label: "Post your comment",  button_html: {class: "button button-action"}
 - elsif !@application.comment_url.blank?
   %p
     = link_to "How to comment", @application.comment_url

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -36,7 +36,7 @@ feature "Give feedback to Council" do
     fill_in("Name", with: "Matthew Landauer")
     fill_in("Email", with: "example@example.com")
     # Don't fill in the address
-    click_button("Create Comment")
+    click_button("Post your comment")
 
     page.should have_content("Some of the comment wasn't filled out completely. See below.")
     page.should_not have_content("Now check your email")
@@ -53,7 +53,7 @@ feature "Give feedback to Council" do
     fill_in("Name", with: "Matthew Landauer")
     fill_in("Email", with: "example@example.com")
     fill_in("Address", with: "11 Foo Street")
-    click_button("Create Comment")
+    click_button("Post your comment")
 
     page.should have_content("Now check your email")
     page.should have_content("Click on the link in the email to confirm your comment")
@@ -137,7 +137,7 @@ feature "Give feedback to Council" do
       fill_in("Name", with: "Matthew Landauer")
       fill_in("Email", with: "example@example.com")
       # Don't fill in the address
-      click_button("Create Comment")
+      click_button("Post your comment")
 
       page.should have_content("Some of the comment wasn't filled out completely. See below.")
       page.should_not have_content("Now check your email")


### PR DESCRIPTION
## Why

Wording of the 'submit comment button' is not relevant to people making a comment, it is currently "Create Comment".

The term 'create' here refers to the record being created in the database. This is an opportunity to encourage the person and make them feel more comfortable with publicly discussing local planning.

## The PR

The verb 'post' would be clearer here to describe the comment being
posted to the page and also to the council. Post is the term
used by Facebook to describe making a status update as well, so
people may be comfortable with this concept.

Also refer to 'your comment' rather than just 'comment' to
re-enforce the person’s sense of ownership of their action.

## Before
![screen shot 2015-09-25 at 11 51 08 am](https://cloud.githubusercontent.com/assets/1239550/10091228/d68fcb6c-637b-11e5-83a4-b4108141ae8f.png)

## After
![screen shot 2015-09-25 at 11 50 47 am](https://cloud.githubusercontent.com/assets/1239550/10091231/dec231bc-637b-11e5-9557-e2d0c5177ba2.png)

Relates to #767 