### PR TITLE
Emphasise the person behind the comment

### DIFF
--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -72,10 +72,6 @@ ol#comments {
   font-size: 1em;
 }
 
-.comment-meta {
-  color: $font-color;
-}
-
 .comment-address,
 .comment-meta {
   padding: .75em 1em;
@@ -84,6 +80,11 @@ ol#comments {
 .comment-text,
 .comment-actions {
   padding: 0 1em .75em;
+}
+
+.comment-author,
+.comment-time {
+  color: $font-color;
 }
 
 .comment-author {

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -81,7 +81,6 @@ ol#comments {
   padding: .75em 1em;
 }
 
-
 .comment-text,
 .comment-actions {
   padding: 0 1em .75em;

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -89,10 +89,6 @@ ol#comments {
   font-size: 1em;
 }
 
-.comment-meta {
-  color: $font-color;
-}
-
 .comment-author {
   margin-right: .5em;
   display: block;

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -87,7 +87,7 @@ ol#comments {
 }
 
 .comment-author {
-  margin-right: .75em;
+  margin-right: .5em;
   display: block;
   font-weight: bold;
 

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -101,7 +101,7 @@ ol#comments {
   }
 }
 
-.comment-time {
+.comment-time-block {
   font-size: 0.9em;
 }
 

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -8,7 +8,6 @@
   }
 }
 
-
 ol#comments {
   @include no-bullets;
   padding-left: 0;

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -72,6 +72,10 @@ ol#comments {
   font-size: 1em;
 }
 
+.comment-meta {
+  color: $font-color;
+}
+
 .comment-address,
 .comment-meta {
   padding: .75em 1em;
@@ -80,11 +84,6 @@ ol#comments {
 .comment-text,
 .comment-actions {
   padding: 0 1em .75em;
-}
-
-.comment-author,
-.comment-time {
-  color: $font-color;
 }
 
 .comment-author {

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -44,6 +44,7 @@ ol#comments {
 .comment-item {
   margin-bottom: 2.5em;
   background: #fafafa;
+  @include clearfix;
 
   a &:hover {
     background: #f0f0f0;
@@ -76,9 +77,14 @@ ol#comments {
 }
 
 .comment-address,
-.comment-text,
 .comment-meta {
   padding: .75em 1em;
+}
+
+
+.comment-text,
+.comment-actions {
+  padding: 0 1em .75em;
 }
 
 .comment-author {
@@ -93,12 +99,15 @@ ol#comments {
   font-size: 0.9em;
 }
 
+.comment-actions {
+  float: right;
+  clear: both;
+  font-size: 0.9em;
+}
+
 .comment-action {
   @include quiet;
-  margin-top: .15em;
   margin-left: .5em;
-  float: right;
-  font-size: 0.9em;
   text-decoration: underline;
 }
 

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -68,8 +68,14 @@ ol#comments {
 }
 
 .comment-address,
-.comment-meta {
+.comment-meta,
+.comment-text {
   color: $font-color;
+}
+
+.comment-address,
+.comment-text {
+  margin: 0;
 }
 
 .comment-text,
@@ -79,13 +85,10 @@ ol#comments {
 
 .comment-text {
   font-style: normal;
-  margin: 0;
   border: 0;
-  color: $font-color;
 }
 
 .comment-address {
-  margin: 0;
   font-size: 1em;
 }
 

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -87,6 +87,7 @@ ol#comments {
 }
 
 .comment-author {
+  margin-right: .75em;
   display: block;
   font-weight: bold;
 

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -95,7 +95,6 @@ ol#comments {
 .comment-author {
   margin-right: .5em;
   display: block;
-  font-weight: bold;
 
   @include at-breakpoint(40em) {
     display: inline-block;

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -78,7 +78,6 @@ ol#comments {
   margin: 0;
 }
 
-.comment-text,
 .comment-meta {
   padding: 0 0 .75em;
 }
@@ -86,6 +85,7 @@ ol#comments {
 .comment-text {
   font-style: normal;
   border: 0;
+  padding: 0;
 }
 
 .comment-address {
@@ -108,6 +108,11 @@ ol#comments {
   float: right;
   clear: both;
   font-size: 0.9em;
+  padding: .75em 0 0;
+
+  @include at-breakpoint(40em) {
+    padding: 0;
+  }
 }
 
 .comment-action {

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -73,7 +73,7 @@ ol#comments {
 }
 
 .comment-meta {
-  @include quiet;
+  color: $font-color;
 }
 
 .comment-address,
@@ -88,6 +88,7 @@ ol#comments {
 
 .comment-author {
   display: block;
+  font-weight: bold;
 
   @include at-breakpoint(40em) {
     display: inline-block;

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -40,10 +40,18 @@ ol#comments {
   }
 }
 
+.panel-heading,
+.panel-body {
+  padding: .75em 1em;
+}
+
+.panel-body {
+  @include clearfix;
+}
+
 .comment-item {
   margin-bottom: 2.5em;
   background: #fafafa;
-  @include clearfix;
 
   a &:hover {
     background: #f0f0f0;
@@ -77,12 +85,12 @@ ol#comments {
 
 .comment-address,
 .comment-meta {
-  padding: .75em 1em;
+  color: $font-color;
 }
 
 .comment-text,
-.comment-actions {
-  padding: 0 1em .75em;
+.comment-meta {
+  padding: 0 0 .75em;
 }
 
 .comment-author {

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -67,6 +67,16 @@ ol#comments {
   }
 }
 
+.comment-address,
+.comment-meta {
+  color: $font-color;
+}
+
+.comment-text,
+.comment-meta {
+  padding: 0 0 .75em;
+}
+
 .comment-text {
   font-style: normal;
   margin: 0;
@@ -81,16 +91,6 @@ ol#comments {
 
 .comment-meta {
   color: $font-color;
-}
-
-.comment-address,
-.comment-meta {
-  color: $font-color;
-}
-
-.comment-text,
-.comment-meta {
-  padding: 0 0 .75em;
 }
 
 .comment-author {

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -79,6 +79,7 @@ ol#comments {
 }
 
 .comment-meta {
+  @include quiet;
   padding: 0 0 .75em;
 }
 

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -93,7 +93,6 @@ ol#comments {
 }
 
 .comment-author {
-  margin-right: .5em;
   display: block;
 
   @include at-breakpoint(40em) {

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -41,7 +41,7 @@ ol#comments {
   }
 }
 
-.comment {
+.comment-item {
   margin-bottom: 2.5em;
   background: #fafafa;
 

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -1,6 +1,6 @@
 %li
-  - if current_page?(comments_path)
+  - if with_link_wrapper
     = link_to application_path(comment.application), title: "View application at #{comment.application.address}", class: "panel-link" do
-      = render 'comments/comment_item', comment: comment
+      = render 'comments/comment_item', comment: comment, with_address: true
   - else
-    = render 'comments/comment_item', comment: comment
+    = render 'comments/comment_item', comment: comment, with_address: false

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -1,6 +1,6 @@
 - if current_page?(comments_path)
   = link_to application_path(comment.application), title: "View application at #{comment.application.address}", class: "panel-link" do
-    %figure.comment.panel
+    %figure.comment-item.panel
       %h2.comment-address.panel-heading
         In
         %strong #{comment.application.suburb} #{comment.application.state}
@@ -13,7 +13,7 @@
         %time.comment-time{datetime: comment.updated_at.strftime("%F")}
           #{time_ago_in_words(comment.updated_at)} ago
 - else
-  %figure.comment.panel
+  %figure.comment-item.panel
     %blockquote.comment-text= comment_as_html(comment.text)
     %figcaption.comment-meta
       %span.comment-author by #{comment.name}

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -1,25 +1,5 @@
 - if current_page?(comments_path)
   = link_to application_path(comment.application), title: "View application at #{comment.application.address}", class: "panel-link" do
-    %figure.comment-item.panel
-      %h2.comment-address.panel-heading
-        In
-        %strong #{comment.application.suburb} #{comment.application.state}
-        on
-        = comment.application.description ? "“" + truncate(comment.application.description) + "” at" : "application for"
-        #{comment.application.address}
-      %blockquote.comment-text= comment_as_html(comment.text)
-      %figcaption.comment-meta
-        %span.comment-author by #{comment.name}
-        %time.comment-time{datetime: comment.updated_at.strftime("%F")}
-          #{time_ago_in_words(comment.updated_at)} ago
+    = render 'comments/comment_item', comment: comment
 - else
-  %figure.comment-item.panel
-    %blockquote.comment-text= comment_as_html(comment.text)
-    %figcaption.comment-meta
-      %span.comment-author by #{comment.name}
-      %time.comment-time{datetime: comment.updated_at.strftime("%F")}
-        #{time_ago_in_words(comment.updated_at)} ago
-      - if current_user && current_user.admin?
-        = link_to "admin", admin_application_comment_path(comment), class: "comment-action"
-      - if current_page?(application_path(comment.application))
-        = link_to "report comment", new_comment_report_path(comment), title: "Report this comment by #{comment.name} for removal", class: "comment-action"
+  = render 'comments/comment_item', comment: comment

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -1,5 +1,6 @@
-- if current_page?(comments_path)
-  = link_to application_path(comment.application), title: "View application at #{comment.application.address}", class: "panel-link" do
+%li
+  - if current_page?(comments_path)
+    = link_to application_path(comment.application), title: "View application at #{comment.application.address}", class: "panel-link" do
+      = render 'comments/comment_item', comment: comment
+  - else
     = render 'comments/comment_item', comment: comment
-- else
-  = render 'comments/comment_item', comment: comment

--- a/app/views/comments/_comment_item.html.haml
+++ b/app/views/comments/_comment_item.html.haml
@@ -8,7 +8,7 @@
       #{comment.application.address}
   %figcaption.comment-meta
     %span.comment-author #{comment.name}
-    = link_to application_path(comment.application, anchor: "comment#{comment.id}") do
+    = link_to application_url(comment.application, anchor: "comment#{comment.id}") do
       %time.comment-time{datetime: comment.updated_at.strftime("%F")}
         #{time_ago_in_words(comment.updated_at)} ago
   %blockquote.comment-text= comment_as_html(comment.text)

--- a/app/views/comments/_comment_item.html.haml
+++ b/app/views/comments/_comment_item.html.haml
@@ -1,4 +1,4 @@
-%figure.comment-item.panel
+%figure.comment-item.panel{id: "comment#{comment.id}"}
   - if current_page?(comments_path)
     %h2.comment-address.panel-heading
       In

--- a/app/views/comments/_comment_item.html.haml
+++ b/app/views/comments/_comment_item.html.haml
@@ -1,0 +1,18 @@
+%figure.comment-item.panel
+  - if current_page?(comments_path)
+    %h2.comment-address.panel-heading
+      In
+      %strong #{comment.application.suburb} #{comment.application.state}
+      on
+      = comment.application.description ? "“" + truncate(comment.application.description) + "” at" : "application for"
+      #{comment.application.address}
+  %blockquote.comment-text= comment_as_html(comment.text)
+  %figcaption.comment-meta
+    %span.comment-author by #{comment.name}
+    %time.comment-time{datetime: comment.updated_at.strftime("%F")}
+      #{time_ago_in_words(comment.updated_at)} ago
+    - unless current_page?(comments_path)
+      - if current_user && current_user.admin?
+        = link_to "admin", admin_application_comment_path(comment), class: "comment-action"
+      - if current_page?(application_path(comment.application))
+        = link_to "report comment", new_comment_report_path(comment), title: "Report this comment by #{comment.name} for removal", class: "comment-action"

--- a/app/views/comments/_comment_item.html.haml
+++ b/app/views/comments/_comment_item.html.haml
@@ -1,5 +1,5 @@
 %figure.comment-item.panel{id: "comment#{comment.id}"}
-  - if current_page?(comments_path)
+  - if with_address
     %h2.comment-address.panel-heading
       In
       %strong #{comment.application.suburb} #{comment.application.state}

--- a/app/views/comments/_comment_item.html.haml
+++ b/app/views/comments/_comment_item.html.haml
@@ -6,13 +6,13 @@
       on
       = comment.application.description ? "“" + truncate(comment.application.description) + "” at" : "application for"
       #{comment.application.address}
-  %blockquote.comment-text= comment_as_html(comment.text)
   %figcaption.comment-meta
-    %span.comment-author by #{comment.name}
+    %span.comment-author #{comment.name}
     %time.comment-time{datetime: comment.updated_at.strftime("%F")}
       #{time_ago_in_words(comment.updated_at)} ago
-    - unless current_page?(comments_path)
+  %blockquote.comment-text= comment_as_html(comment.text)
+  - unless current_page?(comments_path)
+    .comment-actions
       - if current_user && current_user.admin?
-        = link_to "admin", admin_application_comment_path(comment), class: "comment-action"
-      - if current_page?(application_path(comment.application))
-        = link_to "report comment", new_comment_report_path(comment), title: "Report this comment by #{comment.name} for removal", class: "comment-action"
+        = link_to "admin", admin_application_comment_path(comment), class: 'comment-action'
+      = link_to "report comment", new_comment_report_path(comment), title: "Report this comment by #{comment.name} for removal", class: "comment-action"

--- a/app/views/comments/_comment_item.html.haml
+++ b/app/views/comments/_comment_item.html.haml
@@ -9,8 +9,10 @@
   .panel-body
     %figcaption.comment-meta
       %span.comment-author #{comment.name}
-      %time.comment-time{datetime: comment.updated_at.strftime("%F")}
-        #{time_ago_in_words(comment.updated_at)} ago
+      %span.comment-time-block
+        commented
+        %time.comment-time{datetime: comment.updated_at.strftime("%F")}
+          #{time_ago_in_words(comment.updated_at)} ago
     %blockquote.comment-text= comment_as_html(comment.text)
     - unless current_page?(comments_path)
       .comment-actions

--- a/app/views/comments/_comment_item.html.haml
+++ b/app/views/comments/_comment_item.html.haml
@@ -8,7 +8,7 @@
       #{comment.application.address}
   %figcaption.comment-meta
     %span.comment-author #{comment.name}
-    = link_to application_url(comment.application, anchor: "comment#{comment.id}") do
+    = link_to application_path(comment.application, anchor: "comment#{comment.id}") do
       %time.comment-time{datetime: comment.updated_at.strftime("%F")}
         #{time_ago_in_words(comment.updated_at)} ago
   %blockquote.comment-text= comment_as_html(comment.text)

--- a/app/views/comments/_comment_item.html.haml
+++ b/app/views/comments/_comment_item.html.haml
@@ -8,9 +8,8 @@
       #{comment.application.address}
   %figcaption.comment-meta
     %span.comment-author #{comment.name}
-    = link_to application_path(comment.application, anchor: "comment#{comment.id}") do
-      %time.comment-time{datetime: comment.updated_at.strftime("%F")}
-        #{time_ago_in_words(comment.updated_at)} ago
+    %time.comment-time{datetime: comment.updated_at.strftime("%F")}
+      #{time_ago_in_words(comment.updated_at)} ago
   %blockquote.comment-text= comment_as_html(comment.text)
   - unless current_page?(comments_path)
     .comment-actions

--- a/app/views/comments/_comment_item.html.haml
+++ b/app/views/comments/_comment_item.html.haml
@@ -6,13 +6,14 @@
       on
       = comment.application.description ? "“" + truncate(comment.application.description) + "” at" : "application for"
       #{comment.application.address}
-  %figcaption.comment-meta
-    %span.comment-author #{comment.name}
-    %time.comment-time{datetime: comment.updated_at.strftime("%F")}
-      #{time_ago_in_words(comment.updated_at)} ago
-  %blockquote.comment-text= comment_as_html(comment.text)
-  - unless current_page?(comments_path)
-    .comment-actions
-      - if current_user && current_user.admin?
-        = link_to "admin", admin_application_comment_path(comment), class: 'comment-action'
-      = link_to "report comment", new_comment_report_path(comment), title: "Report this comment by #{comment.name} for removal", class: "comment-action"
+  .panel-body
+    %figcaption.comment-meta
+      %span.comment-author #{comment.name}
+      %time.comment-time{datetime: comment.updated_at.strftime("%F")}
+        #{time_ago_in_words(comment.updated_at)} ago
+    %blockquote.comment-text= comment_as_html(comment.text)
+    - unless current_page?(comments_path)
+      .comment-actions
+        - if current_user && current_user.admin?
+          = link_to "admin", admin_application_comment_path(comment), class: 'comment-action'
+        = link_to "report comment", new_comment_report_path(comment), title: "Report this comment by #{comment.name} for removal", class: "comment-action"

--- a/app/views/comments/_comment_item.html.haml
+++ b/app/views/comments/_comment_item.html.haml
@@ -8,8 +8,9 @@
       #{comment.application.address}
   %figcaption.comment-meta
     %span.comment-author #{comment.name}
-    %time.comment-time{datetime: comment.updated_at.strftime("%F")}
-      #{time_ago_in_words(comment.updated_at)} ago
+    = link_to application_path(comment.application, anchor: "comment#{comment.id}") do
+      %time.comment-time{datetime: comment.updated_at.strftime("%F")}
+        #{time_ago_in_words(comment.updated_at)} ago
   %blockquote.comment-text= comment_as_html(comment.text)
   - unless current_page?(comments_path)
     .comment-actions

--- a/app/views/comments/_comments_area.html.haml
+++ b/app/views/comments/_comments_area.html.haml
@@ -4,5 +4,5 @@
     %p.small.quiet
       Have your say by #{link_to "adding your own comment", "#add-comment", class: "link-to-comment-form"}.
     %ol#comments
-      = render @comments
+      = render @comments, with_link_wrapper: false
   = render "comments/comment_form"

--- a/app/views/comments/_comments_area.html.haml
+++ b/app/views/comments/_comments_area.html.haml
@@ -4,7 +4,5 @@
     %p.small.quiet
       Have your say by #{link_to "adding your own comment", "#add-comment", class: "link-to-comment-form"}.
     %ol#comments
-      - @comments.each do |comment|
-        %li
-          = render 'comments/comment', comment: comment
+      = render @comments
   = render "comments/comment_form"

--- a/app/views/comments/_comments_area.html.haml
+++ b/app/views/comments/_comments_area.html.haml
@@ -5,6 +5,6 @@
       Have your say by #{link_to "adding your own comment", "#add-comment", class: "link-to-comment-form"}.
     %ol#comments
       - @comments.each do |comment|
-        %li{:id => "comment#{comment.id}"}
-          = render :partial => 'comments/comment', :locals => {:comment => comment}
+        %li
+          = render 'comments/comment', comment: comment
   = render "comments/comment_form"

--- a/app/views/comments/index.html.haml
+++ b/app/views/comments/index.html.haml
@@ -2,4 +2,4 @@
 %h1.page-title Recent comments
 = paginated_section @comments, :previous_label => "« Newer", :next_label => "Older »" do
   %ol#comments
-    = render @comments, with_link: true
+    = render @comments, with_link_wrapper: true

--- a/app/views/comments/index.html.haml
+++ b/app/views/comments/index.html.haml
@@ -2,6 +2,4 @@
 %h1.page-title Recent comments
 = paginated_section @comments, :previous_label => "« Newer", :next_label => "Older »" do
   %ol#comments
-    - @comments.each do |comment|
-      %li
-        = render 'comments/comment', comment: comment, with_link: true
+    = render @comments, with_link: true

--- a/app/views/comments/index.html.haml
+++ b/app/views/comments/index.html.haml
@@ -1,4 +1,7 @@
 - content_for :page_title, "Recent comments"
 %h1.page-title Recent comments
 = paginated_section @comments, :previous_label => "« Newer", :next_label => "Older »" do
-  = render @comments
+  %ol#comments
+    - @comments.each do |comment|
+      %li
+        = render 'comments/comment', comment: comment, with_link: true

--- a/app/views/reports/new.html.haml
+++ b/app/views/reports/new.html.haml
@@ -1,6 +1,6 @@
 - content_for :page_title, "Report comment"
 %h3= yield :page_title
-= render :partial => 'comments/comment', :locals => {:comment => @comment}
+= render @comment, with_link_wrapper: false
 %p
   This form is for reporting comments that should be removed. Reasons can include that
   the comment is spam, abusive, unlawful or harassing &mdash; in other words, where people are going

--- a/spec/views/comments/comment_spec.rb
+++ b/spec/views/comments/comment_spec.rb
@@ -15,7 +15,7 @@ describe "comments/_comment" do
       text: 'This is a link to <a href="http://openaustralia.org">openaustralia.org</a>')
     render partial: "comment", object: comment
     rendered.should == <<-EOF
-<figure class='comment-item panel'>
+<figure class='comment-item panel' id='comment#{comment.id}'>
 <figcaption class='comment-meta'>
 <span class='comment-author'>Matthew</span>
 <time class='comment-time' datetime='2015-01-26'>
@@ -37,7 +37,7 @@ less than a minute ago
       text: "This is the first paragraph\nAnd the next line\n\nThis is a new paragraph")
     render partial: "comment", object: comment
     rendered.should == <<-EOF
-<figure class='comment-item panel'>
+<figure class='comment-item panel' id='comment#{comment.id}'>
 <figcaption class='comment-meta'>
 <span class='comment-author'>Matthew</span>
 <time class='comment-time' datetime='2015-01-26'>
@@ -62,7 +62,7 @@ less than a minute ago
       text: "<a href=\"javascript:document.location='http://www.google.com/'\">A nasty link</a><img src=\"http://foo.co\">")
     render partial: "comment", object: comment
     rendered.should == <<-EOF
-<figure class='comment-item panel'>
+<figure class='comment-item panel' id='comment#{comment.id}'>
 <figcaption class='comment-meta'>
 <span class='comment-author'>Matthew</span>
 <time class='comment-time' datetime='2015-01-26'>

--- a/spec/views/comments/comment_spec.rb
+++ b/spec/views/comments/comment_spec.rb
@@ -13,68 +13,35 @@ describe "comments/_comment" do
     application = mock_model(Application)
     comment = mock_model(Comment, name: "Matthew", updated_at: Time.now, application: application,
       text: 'This is a link to <a href="http://openaustralia.org">openaustralia.org</a>')
-    render partial: "comment", object: comment
-    rendered.should == <<-EOF
-<figure class='comment-item panel' id='comment#{comment.id}'>
-<figcaption class='comment-meta'>
-<span class='comment-author'>Matthew</span>
-<time class='comment-time' datetime='2015-01-26'>
-less than a minute ago
-</time>
-</figcaption>
-<blockquote class='comment-text'><p>This is a link to <a href="http://openaustralia.org" rel="nofollow">openaustralia.org</a></p></blockquote>
-<div class='comment-actions'>
-<a class="comment-action" href="/comments/#{comment.id}/reports/new" title="Report this comment by Matthew for removal">report comment</a>
-</div>
-</figure>
+    expected_html = "<blockquote class='comment-text'><p>This is a link to <a href=\"http://openaustralia.org\" rel=\"nofollow\">openaustralia.org</a></p></blockquote>"
 
-    EOF
+    render partial: "comment", object: comment
+
+    expect(rendered).to include(expected_html)
   end
 
   it "should format simple text in separate paragraphs with p tags" do
     application = mock_model(Application)
     comment = mock_model(Comment, name: "Matthew", updated_at: Time.now, application: application,
       text: "This is the first paragraph\nAnd the next line\n\nThis is a new paragraph")
-    render partial: "comment", object: comment
-    rendered.should == <<-EOF
-<figure class='comment-item panel' id='comment#{comment.id}'>
-<figcaption class='comment-meta'>
-<span class='comment-author'>Matthew</span>
-<time class='comment-time' datetime='2015-01-26'>
-less than a minute ago
-</time>
-</figcaption>
-<blockquote class='comment-text'><p>This is the first paragraph
+    expected_html = "<blockquote class='comment-text'><p>This is the first paragraph
 <br>And the next line</p>
 
-<p>This is a new paragraph</p></blockquote>
-<div class='comment-actions'>
-<a class="comment-action" href="/comments/#{comment.id}/reports/new" title="Report this comment by Matthew for removal">report comment</a>
-</div>
-</figure>
+<p>This is a new paragraph</p></blockquote>"
 
-    EOF
+    render partial: "comment", object: comment
+
+    expect(rendered).to include(expected_html)
   end
 
   it "should get rid of nasty javascript and strip out images" do
     application = mock_model(Application)
     comment = mock_model(Comment, name: "Matthew", updated_at: Time.now, application: application,
       text: "<a href=\"javascript:document.location='http://www.google.com/'\">A nasty link</a><img src=\"http://foo.co\">")
-    render partial: "comment", object: comment
-    rendered.should == <<-EOF
-<figure class='comment-item panel' id='comment#{comment.id}'>
-<figcaption class='comment-meta'>
-<span class='comment-author'>Matthew</span>
-<time class='comment-time' datetime='2015-01-26'>
-less than a minute ago
-</time>
-</figcaption>
-<blockquote class='comment-text'><p><a rel="nofollow">A nasty link</a></p></blockquote>
-<div class='comment-actions'>
-<a class="comment-action" href="/comments/#{comment.id}/reports/new" title="Report this comment by Matthew for removal">report comment</a>
-</div>
-</figure>
+    expected_html = "<blockquote class='comment-text'><p><a rel=\"nofollow\">A nasty link</a></p></blockquote>"
 
-    EOF
+    render partial: "comment", object: comment
+
+    expect(rendered).to include(expected_html)
   end
 end

--- a/spec/views/comments/comment_spec.rb
+++ b/spec/views/comments/comment_spec.rb
@@ -16,13 +16,16 @@ describe "comments/_comment" do
     render partial: "comment", object: comment
     rendered.should == <<-EOF
 <figure class='comment-item panel'>
-<blockquote class='comment-text'><p>This is a link to <a href="http://openaustralia.org" rel="nofollow">openaustralia.org</a></p></blockquote>
 <figcaption class='comment-meta'>
-<span class='comment-author'>by Matthew</span>
+<span class='comment-author'>Matthew</span>
 <time class='comment-time' datetime='2015-01-26'>
 less than a minute ago
 </time>
 </figcaption>
+<blockquote class='comment-text'><p>This is a link to <a href="http://openaustralia.org" rel="nofollow">openaustralia.org</a></p></blockquote>
+<div class='comment-actions'>
+<a class="comment-action" href="/comments/#{comment.id}/reports/new" title="Report this comment by Matthew for removal">report comment</a>
+</div>
 </figure>
 
     EOF
@@ -35,16 +38,19 @@ less than a minute ago
     render partial: "comment", object: comment
     rendered.should == <<-EOF
 <figure class='comment-item panel'>
-<blockquote class='comment-text'><p>This is the first paragraph
-<br>And the next line</p>
-
-<p>This is a new paragraph</p></blockquote>
 <figcaption class='comment-meta'>
-<span class='comment-author'>by Matthew</span>
+<span class='comment-author'>Matthew</span>
 <time class='comment-time' datetime='2015-01-26'>
 less than a minute ago
 </time>
 </figcaption>
+<blockquote class='comment-text'><p>This is the first paragraph
+<br>And the next line</p>
+
+<p>This is a new paragraph</p></blockquote>
+<div class='comment-actions'>
+<a class="comment-action" href="/comments/#{comment.id}/reports/new" title="Report this comment by Matthew for removal">report comment</a>
+</div>
 </figure>
 
     EOF
@@ -57,13 +63,16 @@ less than a minute ago
     render partial: "comment", object: comment
     rendered.should == <<-EOF
 <figure class='comment-item panel'>
-<blockquote class='comment-text'><p><a rel="nofollow">A nasty link</a></p></blockquote>
 <figcaption class='comment-meta'>
-<span class='comment-author'>by Matthew</span>
+<span class='comment-author'>Matthew</span>
 <time class='comment-time' datetime='2015-01-26'>
 less than a minute ago
 </time>
 </figcaption>
+<blockquote class='comment-text'><p><a rel="nofollow">A nasty link</a></p></blockquote>
+<div class='comment-actions'>
+<a class="comment-action" href="/comments/#{comment.id}/reports/new" title="Report this comment by Matthew for removal">report comment</a>
+</div>
 </figure>
 
     EOF

--- a/spec/views/comments/comment_spec.rb
+++ b/spec/views/comments/comment_spec.rb
@@ -15,7 +15,7 @@ describe "comments/_comment" do
       text: 'This is a link to <a href="http://openaustralia.org">openaustralia.org</a>')
     render partial: "comment", object: comment
     rendered.should == <<-EOF
-<figure class='comment panel'>
+<figure class='comment-item panel'>
 <blockquote class='comment-text'><p>This is a link to <a href="http://openaustralia.org" rel="nofollow">openaustralia.org</a></p></blockquote>
 <figcaption class='comment-meta'>
 <span class='comment-author'>by Matthew</span>
@@ -33,7 +33,7 @@ less than a minute ago
       text: "This is the first paragraph\nAnd the next line\n\nThis is a new paragraph")
     render partial: "comment", object: comment
     rendered.should == <<-EOF
-<figure class='comment panel'>
+<figure class='comment-item panel'>
 <blockquote class='comment-text'><p>This is the first paragraph
 <br>And the next line</p>
 
@@ -54,7 +54,7 @@ less than a minute ago
       text: "<a href=\"javascript:document.location='http://www.google.com/'\">A nasty link</a><img src=\"http://foo.co\">")
     render partial: "comment", object: comment
     rendered.should == <<-EOF
-<figure class='comment panel'>
+<figure class='comment-item panel'>
 <blockquote class='comment-text'><p><a rel="nofollow">A nasty link</a></p></blockquote>
 <figcaption class='comment-meta'>
 <span class='comment-author'>by Matthew</span>

--- a/spec/views/comments/comment_spec.rb
+++ b/spec/views/comments/comment_spec.rb
@@ -15,7 +15,7 @@ describe "comments/_comment" do
       text: 'This is a link to <a href="http://openaustralia.org">openaustralia.org</a>')
     expected_html = "<blockquote class='comment-text'><p>This is a link to <a href=\"http://openaustralia.org\" rel=\"nofollow\">openaustralia.org</a></p></blockquote>"
 
-    render partial: "comment", object: comment
+    render partial: "comment", object: comment, locals: { with_link_wrapper: false }
 
     expect(rendered).to include(expected_html)
   end
@@ -29,7 +29,7 @@ describe "comments/_comment" do
 
 <p>This is a new paragraph</p></blockquote>"
 
-    render partial: "comment", object: comment
+    render partial: "comment", object: comment, locals: { with_link_wrapper: false }
 
     expect(rendered).to include(expected_html)
   end
@@ -40,7 +40,7 @@ describe "comments/_comment" do
       text: "<a href=\"javascript:document.location='http://www.google.com/'\">A nasty link</a><img src=\"http://foo.co\">")
     expected_html = "<blockquote class='comment-text'><p><a rel=\"nofollow\">A nasty link</a></p></blockquote>"
 
-    render partial: "comment", object: comment
+    render partial: "comment", object: comment, locals: { with_link_wrapper: false }
 
     expect(rendered).to include(expected_html)
   end

--- a/spec/views/comments/comment_spec.rb
+++ b/spec/views/comments/comment_spec.rb
@@ -9,7 +9,7 @@ describe "comments/_comment" do
     Timecop.return
   end
 
-  it "should remove links in the comment text" do
+  it "should add rel='no-follow' to links in the comment text" do
     application = mock_model(Application)
     comment = mock_model(Comment, name: "Matthew", updated_at: Time.now, application: application,
       text: 'This is a link to <a href="http://openaustralia.org">openaustralia.org</a>')

--- a/spec/views/comments/comment_spec.rb
+++ b/spec/views/comments/comment_spec.rb
@@ -24,6 +24,7 @@ less than a minute ago
 </time>
 </figcaption>
 </figure>
+
     EOF
   end
 
@@ -45,6 +46,7 @@ less than a minute ago
 </time>
 </figcaption>
 </figure>
+
     EOF
   end
 
@@ -63,6 +65,7 @@ less than a minute ago
 </time>
 </figcaption>
 </figure>
+
     EOF
   end
 end


### PR DESCRIPTION
Why:

We want to emphasise humans: humans who will be impacted by planning decisions, humans who you are writing with when you comment, your neighbours. Currently the person who commented is deemphasised in the design. We should change this to give a more human feel to the comment section.

This PR:

* Moves the name and time to the top of the comment.
* Reduces repetition in the comment views
* Fixes the description of one of the comment view tests https://github.com/openaustralia/planningalerts/commit/228acf019461c13860b0d4dcb8a313ef4b0d9fb8
* Makes the comment view tests more focused https://github.com/openaustralia/planningalerts/commit/a5cb579fc6d6f4f1300ed9c8fbe97453c89fc69e

Before:
![screen shot 2015-09-28 at 4 06 40 pm](https://cloud.githubusercontent.com/assets/1239550/10129602/39f0aecc-6603-11e5-938e-61c97042cce9.png)
![screen shot 2015-09-28 at 4 06 21 pm](https://cloud.githubusercontent.com/assets/1239550/10129603/3a31d2bc-6603-11e5-9821-81f2a055a233.png)

After:
![screen shot 2015-09-28 at 4 05 42 pm](https://cloud.githubusercontent.com/assets/1239550/10129605/3de53304-6603-11e5-9f88-a00d20c0d211.png)
![screen shot 2015-09-28 at 4 04 59 pm](https://cloud.githubusercontent.com/assets/1239550/10129604/3de468c0-6603-11e5-91f0-d0b2fe4d6bfa.png)


See #791 

This begins cleaning up this view ahead of adding councillor comments into the mix.