### PR TITLE
Add labels to comment and report form inputs

### DIFF
--- a/app/assets/stylesheets/partials/_form.scss
+++ b/app/assets/stylesheets/partials/_form.scss
@@ -52,20 +52,25 @@ a.btn:hover {
       }
     }
   }
+
   .inline-hints {
     @include quiet;
     font-size: 0.8em;
+
     img {
       vertical-align: middle;
       margin-left: 5px;
     }
   }
+
   div.inline-hints p {
     padding-top: 0.5em;
   }
+
   .inline-errors {
     color: $error-color;
   }
+
   li.string, li.stringish, li.email {
     label {
       text-align: right;
@@ -74,17 +79,20 @@ a.btn:hover {
       width: 23%;
       padding: .5em 2% 0 0;
     }
+
     input, textarea {
       font-size: 1.1em;
       padding: .5em;
     }
   }
+
   li.boolean {
     label {
       // This is so nasty and wrong
       margin-left: 25%;
       width: 100%;
     }
+
     input {
       width: 20px;
     }
@@ -117,13 +125,16 @@ a.btn:hover {
     padding-top: 0.8em;
     //font-size: 1em;
   }
+
   textarea {
     padding: 0.5em;
   }
+
   textarea, input {
     font-family: $blueprint-font-family;
     font-size: 100%;
   }
+
   div.inline-hints p {
     padding-top: 0.5em;
   }
@@ -144,6 +155,7 @@ form.donate {
     font-weight: normal;
     margin-left: 1em;
   }
+
   input#amount_donate, label, span {
     font-size: 1.3em;
   }
@@ -164,24 +176,30 @@ form.donate {
       font-size: .8em;
     }
   }
+
   .inline-hints {
     margin-left: 0;
   }
+
   p, .stringish input {
     font-size: 0.9em;
   }
+
   p {
     margin-bottom: 1em;
   }
+
   input, textarea {
     width: 100%;
   }
+
   .actions {
     padding: 0;
 
     &, li {
       width: 100%;
     }
+
     li {
       display: block;
       float: none;
@@ -195,23 +213,29 @@ form.donate {
       width: 25%;
       float: left;
     }
+
     ol {
       display: inline-block;
     }
+
     input {
       width: 9em;
     }
+
     li {
       margin-right: 1em;
       display: inline-block;
       float: left;
     }
+
     label {
       display: none;
     }
+
     .inline-errors {
       margin-left: 0;
     }
+
     .error {
       padding-top: 0;
     }

--- a/app/assets/stylesheets/partials/_form.scss
+++ b/app/assets/stylesheets/partials/_form.scss
@@ -71,6 +71,9 @@ a.btn:hover {
     color: $error-color;
   }
 
+  li.string,
+  li.stringish,
+  li.email,
   li.text {
     label {
       font-weight: 500;
@@ -81,8 +84,6 @@ a.btn:hover {
   li.string, li.stringish, li.email {
     label {
       text-align: right;
-      font-size: 1.1em;
-      font-weight: 500;
       width: 23%;
       padding: .5em 2% 0 0;
     }

--- a/app/assets/stylesheets/partials/_form.scss
+++ b/app/assets/stylesheets/partials/_form.scss
@@ -146,7 +146,7 @@ a.btn:hover {
 
   .inline-hints,
   .inline-errors {
-    margin: 0%;
+    margin: 0;
   }
 
   label abbr[title="required"] {

--- a/app/assets/stylesheets/partials/_form.scss
+++ b/app/assets/stylesheets/partials/_form.scss
@@ -123,6 +123,7 @@ a.btn:hover {
 
 .formtastic#new_comment, .formtastic#new_report {
   @include float-form(100%, 100%, 100%, 0, "buttons-left", left, "select-auto");
+  margin-top: 0;
 
   label {
     margin: .75em 0 .25em;

--- a/app/assets/stylesheets/partials/_form.scss
+++ b/app/assets/stylesheets/partials/_form.scss
@@ -124,6 +124,10 @@ a.btn:hover {
 .formtastic#new_comment, .formtastic#new_report {
   @include float-form(100%, 100%, 100%, 0, "buttons-left", left, "select-auto");
 
+  label {
+    font-size: 1em;
+  }
+
   /* This is only used when the placeholder polyfill is active */
   .label span.placeholder {
     padding-top: 0.8em;

--- a/app/assets/stylesheets/partials/_form.scss
+++ b/app/assets/stylesheets/partials/_form.scss
@@ -114,12 +114,8 @@ a.btn:hover {
 }
 
 .formtastic#new_comment, .formtastic#new_report {
-  @include float-form(100%, 0%, 100%, 0, "buttons-left", left, "select-auto");
-  // Hide the labels
-  li label.label {
-    left: -999em;
-    position: absolute;
-  }
+  @include float-form(100%, 100%, 100%, 0, "buttons-left", left, "select-auto");
+
   /* This is only used when the placeholder polyfill is active */
   .label span.placeholder {
     padding-top: 0.8em;
@@ -135,8 +131,16 @@ a.btn:hover {
     font-size: 100%;
   }
 
+  .inline-hints {
+    margin: 0%;
+  }
+
   div.inline-hints p {
     padding-top: 0.5em;
+  }
+
+  .actions {
+    padding: 0;
   }
 }
 

--- a/app/assets/stylesheets/partials/_form.scss
+++ b/app/assets/stylesheets/partials/_form.scss
@@ -151,10 +151,6 @@ a.btn:hover {
     @include sr-only();
   }
 
-  div.inline-hints p {
-    padding-top: 0.5em;
-  }
-
   .actions {
     padding: 0;
   }

--- a/app/assets/stylesheets/partials/_form.scss
+++ b/app/assets/stylesheets/partials/_form.scss
@@ -23,7 +23,7 @@ a.btn:hover {
 }
 
 .formtastic {
-  @include float-form(100%, 25%, 75%, 0, "buttons-left", "left", "select-auto");
+  @include float-form(100%, 25%, 75%, 0, "buttons-left", left, "select-auto");
   margin-top: 2em;
   margin-bottom: 2em;
 
@@ -114,7 +114,7 @@ a.btn:hover {
 }
 
 .formtastic#new_comment, .formtastic#new_report {
-  @include float-form(100%, 0%, 100%, 0, "buttons-left", "left", "select-auto");
+  @include float-form(100%, 0%, 100%, 0, "buttons-left", left, "select-auto");
   // Hide the labels
   li label.label {
     left: -999em;

--- a/app/assets/stylesheets/partials/_form.scss
+++ b/app/assets/stylesheets/partials/_form.scss
@@ -144,7 +144,8 @@ a.btn:hover {
     font-size: 100%;
   }
 
-  .inline-hints {
+  .inline-hints,
+  .inline-errors {
     margin: 0%;
   }
 

--- a/app/assets/stylesheets/partials/_form.scss
+++ b/app/assets/stylesheets/partials/_form.scss
@@ -143,6 +143,10 @@ a.btn:hover {
     margin: 0%;
   }
 
+  label abbr[title="required"] {
+    @include sr-only();
+  }
+
   div.inline-hints p {
     padding-top: 0.5em;
   }

--- a/app/assets/stylesheets/partials/_form.scss
+++ b/app/assets/stylesheets/partials/_form.scss
@@ -125,7 +125,8 @@ a.btn:hover {
   @include float-form(100%, 100%, 100%, 0, "buttons-left", left, "select-auto");
 
   label {
-    margin-bottom: .25em;
+    margin: .75em 0 .25em;
+    padding: 0;
     font-size: 1em;
   }
 

--- a/app/assets/stylesheets/partials/_form.scss
+++ b/app/assets/stylesheets/partials/_form.scss
@@ -71,6 +71,13 @@ a.btn:hover {
     color: $error-color;
   }
 
+  li.text {
+    label {
+      font-weight: 500;
+      font-size: 1.1em;
+    }
+  }
+
   li.string, li.stringish, li.email {
     label {
       text-align: right;

--- a/app/assets/stylesheets/partials/_form.scss
+++ b/app/assets/stylesheets/partials/_form.scss
@@ -125,6 +125,7 @@ a.btn:hover {
   @include float-form(100%, 100%, 100%, 0, "buttons-left", left, "select-auto");
 
   label {
+    margin-bottom: .25em;
     font-size: 1em;
   }
 

--- a/app/views/comments/_comment_form.html.haml
+++ b/app/views/comments/_comment_form.html.haml
@@ -13,8 +13,8 @@
     #{link_to("need to disclose this", faq_path(anchor: "disclosure"))}.
   = semantic_form_for [@application, @comment] do |f|
     = f.inputs do
-      = f.input :text, label: "What do you think about this application?",
-        hint: "Explain why you think this application should be approved or not. Please be polite, concise and to the point."
+      = f.input :text, label: "Explain why you think this application should be approved or not",
+        placeholder: "Please be polite, concise and to the point."
       = f.input :name, label: "Your name", placeholder: "e.g. Jane Citizen", hint: "Please use your real full name if possible."
       = f.input :email, label: "Your email", placeholder: "e.g. your@email.com", hint: "We never display your email address."
       - hint = capture do

--- a/app/views/comments/_comment_form.html.haml
+++ b/app/views/comments/_comment_form.html.haml
@@ -16,11 +16,11 @@
       = f.input :text, :label => "Write your comment",
         :hint => "Explain why you think this application should be approved or not. Please be polite, concise and to the point."
       = f.input :name, :label => "Your name", :hint => "Please use your real full name if possible."
-      = f.input :email, :label => "Your email", :hint => "We never display your email address"
+      = f.input :email, :label => "Your email", :placeholder => "e.g. your@email.com", :hint => "We never display your email address"
       - hint = capture do
         e.g. 1 Sowerby St, Goulburn (we never display this).
         = link_to("Why do you need my address?", faq_path(:anchor => "address"))
-      = f.input :address, :label => "Your street address", :hint => hint
+      = f.input :address, :label => "Your street address", :placeholder => "e.g. 1 Sowerby St, Goulburn, NSW 2580", :hint => hint
       %div#faq_commenting_address.inline-hints.hidden
         = render :partial => 'static/faq_commenting_address'
       -# This is a spam bot honeytrap. A human being should not be filling this in

--- a/app/views/comments/_comment_form.html.haml
+++ b/app/views/comments/_comment_form.html.haml
@@ -15,7 +15,7 @@
     = f.inputs do
       = f.input :text, :label => "Write your comment",
         :hint => "Explain why you think this application should be approved or not. Please be polite, concise and to the point."
-      = f.input :name, :label => "Your name", :hint => "Please use your real full name if possible."
+      = f.input :name, :label => "Your name", :placeholder => "e.g. Jane Citizen", :hint => "Please use your real full name if possible."
       = f.input :email, :label => "Your email", :placeholder => "e.g. your@email.com", :hint => "We never display your email address."
       - hint = capture do
         We never display your street address.

--- a/app/views/comments/_comment_form.html.haml
+++ b/app/views/comments/_comment_form.html.haml
@@ -13,14 +13,14 @@
     #{link_to("need to disclose this", faq_path(:anchor => "disclosure"))}.
   = semantic_form_for [@application, @comment] do |f|
     = f.inputs do
-      = f.input :text, :label => "Write your comment", :placeholder => "Comment",
+      = f.input :text, :label => "Write your comment",
         :hint => "Explain why you think this application should be approved or not. Please be polite, concise and to the point."
-      = f.input :name, :label => "Your name", :placeholder => "Name", :hint => "Please use your real full name if possible."
-      = f.input :email, :label => "Your email", :placeholder => "Email", :hint => "We never display your email address"
+      = f.input :name, :label => "Your name", :hint => "Please use your real full name if possible."
+      = f.input :email, :label => "Your email", :hint => "We never display your email address"
       - hint = capture do
         e.g. 1 Sowerby St, Goulburn (we never display this).
         = link_to("Why do you need my address?", faq_path(:anchor => "address"))
-      = f.input :address, :label => "Your street address", :placeholder => "Address", :hint => hint
+      = f.input :address, :label => "Your street address", :hint => hint
       %div#faq_commenting_address.inline-hints.hidden
         = render :partial => 'static/faq_commenting_address'
       -# This is a spam bot honeytrap. A human being should not be filling this in

--- a/app/views/comments/_comment_form.html.haml
+++ b/app/views/comments/_comment_form.html.haml
@@ -16,7 +16,7 @@
       = f.input :text, :label => "Write your comment",
         :hint => "Explain why you think this application should be approved or not. Please be polite, concise and to the point."
       = f.input :name, :label => "Your name", :hint => "Please use your real full name if possible."
-      = f.input :email, :label => "Your email", :placeholder => "e.g. your@email.com", :hint => "We never display your email address"
+      = f.input :email, :label => "Your email", :placeholder => "e.g. your@email.com", :hint => "We never display your email address."
       - hint = capture do
         We never display your street address.
         = link_to("Why do you need my address?", faq_path(:anchor => "address"))

--- a/app/views/comments/_comment_form.html.haml
+++ b/app/views/comments/_comment_form.html.haml
@@ -13,14 +13,14 @@
     #{link_to("need to disclose this", faq_path(:anchor => "disclosure"))}.
   = semantic_form_for [@application, @comment] do |f|
     = f.inputs do
-      = f.input :text, :label => 'Comment', :placeholder => "Comment",
+      = f.input :text, :label => "Write your comment", :placeholder => "Comment",
         :hint => "Explain why you think this application should be approved or not. Please be polite, concise and to the point."
-      = f.input :name, :placeholder => "Name", :hint => "Please use your real full name if possible."
-      = f.input :email, :placeholder => "Email", :hint => "We never display your email address"
+      = f.input :name, :label => "Your name", :placeholder => "Name", :hint => "Please use your real full name if possible."
+      = f.input :email, :label => "Your email", :placeholder => "Email", :hint => "We never display your email address"
       - hint = capture do
         e.g. 1 Sowerby St, Goulburn (we never display this).
         = link_to("Why do you need my address?", faq_path(:anchor => "address"))
-      = f.input :address, :placeholder => "Address", :hint => hint
+      = f.input :address, :label => "Your street address", :placeholder => "Address", :hint => hint
       %div#faq_commenting_address.inline-hints.hidden
         = render :partial => 'static/faq_commenting_address'
       -# This is a spam bot honeytrap. A human being should not be filling this in

--- a/app/views/comments/_comment_form.html.haml
+++ b/app/views/comments/_comment_form.html.haml
@@ -18,7 +18,7 @@
       = f.input :name, :label => "Your name", :hint => "Please use your real full name if possible."
       = f.input :email, :label => "Your email", :placeholder => "e.g. your@email.com", :hint => "We never display your email address"
       - hint = capture do
-        e.g. 1 Sowerby St, Goulburn (we never display this).
+        We never display your street address.
         = link_to("Why do you need my address?", faq_path(:anchor => "address"))
       = f.input :address, :label => "Your street address", :placeholder => "e.g. 1 Sowerby St, Goulburn, NSW 2580", :hint => hint
       %div#faq_commenting_address.inline-hints.hidden

--- a/app/views/comments/_comment_form.html.haml
+++ b/app/views/comments/_comment_form.html.haml
@@ -13,7 +13,7 @@
     #{link_to("need to disclose this", faq_path(anchor: "disclosure"))}.
   = semantic_form_for [@application, @comment] do |f|
     = f.inputs do
-      = f.input :text, label: "Explain why you think this application should be approved or not",
+      = f.input :text, label: "Have your say on this application",
         placeholder: "Please be polite, concise and to the point."
       = f.input :name, label: "Your name", placeholder: "e.g. Jane Citizen", hint: "Please use your real full name if possible."
       = f.input :email, label: "Your email", placeholder: "e.g. your@email.com", hint: "We never display your email address."

--- a/app/views/comments/_comment_form.html.haml
+++ b/app/views/comments/_comment_form.html.haml
@@ -13,7 +13,7 @@
     #{link_to("need to disclose this", faq_path(anchor: "disclosure"))}.
   = semantic_form_for [@application, @comment] do |f|
     = f.inputs do
-      = f.input :text, label: "Write your comment",
+      = f.input :text, label: "What do you think about this application?",
         hint: "Explain why you think this application should be approved or not. Please be polite, concise and to the point."
       = f.input :name, label: "Your name", placeholder: "e.g. Jane Citizen", hint: "Please use your real full name if possible."
       = f.input :email, label: "Your email", placeholder: "e.g. your@email.com", hint: "We never display your email address."

--- a/app/views/comments/_comment_form.html.haml
+++ b/app/views/comments/_comment_form.html.haml
@@ -10,19 +10,19 @@
     Your name and comment will be posted publicly here as well.
   %p
     If you have made a donation to a Councillor and/or gift to a Councillor or Council employee you may
-    #{link_to("need to disclose this", faq_path(:anchor => "disclosure"))}.
+    #{link_to("need to disclose this", faq_path(anchor: "disclosure"))}.
   = semantic_form_for [@application, @comment] do |f|
     = f.inputs do
-      = f.input :text, :label => "Write your comment",
-        :hint => "Explain why you think this application should be approved or not. Please be polite, concise and to the point."
-      = f.input :name, :label => "Your name", :placeholder => "e.g. Jane Citizen", :hint => "Please use your real full name if possible."
-      = f.input :email, :label => "Your email", :placeholder => "e.g. your@email.com", :hint => "We never display your email address."
+      = f.input :text, label: "Write your comment",
+        hint: "Explain why you think this application should be approved or not. Please be polite, concise and to the point."
+      = f.input :name, label: "Your name", placeholder: "e.g. Jane Citizen", hint: "Please use your real full name if possible."
+      = f.input :email, label: "Your email", placeholder: "e.g. your@email.com", hint: "We never display your email address."
       - hint = capture do
         We never display your street address.
-        = link_to("Why do you need my address?", faq_path(:anchor => "address"))
-      = f.input :address, :label => "Your street address", :placeholder => "e.g. 1 Sowerby St, Goulburn, NSW 2580", :hint => hint
+        = link_to("Why do you need my address?", faq_path(anchor: "address"))
+      = f.input :address, label: "Your street address", placeholder: "e.g. 1 Sowerby St, Goulburn, NSW 2580", hint: hint
       %div#faq_commenting_address.inline-hints.hidden
-        = render :partial => 'static/faq_commenting_address'
+        = render partial: 'static/faq_commenting_address'
       -# This is a spam bot honeytrap. A human being should not be filling this in
       -# It's not awesome for screenreaders though
       %li{style: "display: none;"}

--- a/app/views/comments/_comment_form.html.haml
+++ b/app/views/comments/_comment_form.html.haml
@@ -14,7 +14,7 @@
   = semantic_form_for [@application, @comment] do |f|
     = f.inputs do
       = f.input :text, label: "Have your say on this application",
-        placeholder: "Effective comments are polite, concise and to the point."
+        placeholder: "Effective comments are polite, clear and to the point."
       = f.input :name, label: "Your name", placeholder: "e.g. Jane Citizen", hint: "Please use your real full name if possible."
       = f.input :email, label: "Your email", placeholder: "e.g. your@email.com", hint: "We never display your email address."
       - hint = capture do

--- a/app/views/comments/_comment_form.html.haml
+++ b/app/views/comments/_comment_form.html.haml
@@ -14,7 +14,7 @@
   = semantic_form_for [@application, @comment] do |f|
     = f.inputs do
       = f.input :text, label: "Have your say on this application",
-        placeholder: "Effective comments are polite, clear and to the point."
+        placeholder: "Be polite, clear, and to the point so your comment gets listened to."
       = f.input :name, label: "Your name", placeholder: "e.g. Jane Citizen", hint: "Please use your real full name if possible."
       = f.input :email, label: "Your email", placeholder: "e.g. your@email.com", hint: "We never display your email address."
       - hint = capture do

--- a/app/views/comments/_comment_form.html.haml
+++ b/app/views/comments/_comment_form.html.haml
@@ -14,7 +14,7 @@
   = semantic_form_for [@application, @comment] do |f|
     = f.inputs do
       = f.input :text, label: "Have your say on this application",
-        placeholder: "Please be polite, concise and to the point."
+        placeholder: "Effective comments are polite, concise and to the point."
       = f.input :name, label: "Your name", placeholder: "e.g. Jane Citizen", hint: "Please use your real full name if possible."
       = f.input :email, label: "Your email", placeholder: "e.g. your@email.com", hint: "We never display your email address."
       - hint = capture do

--- a/app/views/reports/new.html.haml
+++ b/app/views/reports/new.html.haml
@@ -9,7 +9,7 @@
 = semantic_form_for [@comment, @report] do |f|
   = f.inputs do
     = f.input :name, label: "Your name"
-    = f.input :email, label: "Your email"
+    = f.input :email, label: "Your email", :placeholder => "e.g. your@email.com"
     = f.input :details, label: "Why should this comment be removed?", as: :text
     -# This is a spam bot honeytrap. A human being should not be filling this in
     -# It's not awesome for screenreaders though

--- a/app/views/reports/new.html.haml
+++ b/app/views/reports/new.html.haml
@@ -8,8 +8,8 @@
   you think the comment should be removed.
 = semantic_form_for [@comment, @report] do |f|
   = f.inputs do
-    = f.input :name, label: "Your name", placeholder: "Name"
-    = f.input :email, label: "Your email", placeholder: "Email"
+    = f.input :name, label: "Your name"
+    = f.input :email, label: "Your email"
     = f.input :details, label: "Why should this comment be removed?", as: :text
     -# This is a spam bot honeytrap. A human being should not be filling this in
     -# It's not awesome for screenreaders though

--- a/app/views/reports/new.html.haml
+++ b/app/views/reports/new.html.haml
@@ -1,6 +1,6 @@
 - content_for :page_title, "Report comment"
 %h3= yield :page_title
-= render :partial => 'comments/comment', :locals => {:comment => @comment}
+= render @comment
 %p
   This form is for reporting comments that should be removed. Reasons can include that
   the comment is spam, abusive, unlawful or harassing &mdash; in other words, where people are going

--- a/app/views/reports/new.html.haml
+++ b/app/views/reports/new.html.haml
@@ -10,7 +10,7 @@
   = f.inputs do
     = f.input :name, label: "Your name", placeholder: "Name"
     = f.input :email, label: "Your email", placeholder: "Email"
-    = f.input :details, label: "Why should this comment be removed?", as: :text, placeholder: "Why you think the comment should be removed"
+    = f.input :details, label: "Why should this comment be removed?", as: :text
     -# This is a spam bot honeytrap. A human being should not be filling this in
     -# It's not awesome for screenreaders though
     %li{style: "display: none;"}

--- a/app/views/reports/new.html.haml
+++ b/app/views/reports/new.html.haml
@@ -8,8 +8,8 @@
   you think the comment should be removed.
 = semantic_form_for [@comment, @report] do |f|
   = f.inputs do
-    = f.input :name, label: "Your name", :placeholder => "e.g. Jane Citizen"
-    = f.input :email, label: "Your email", :placeholder => "e.g. your@email.com"
+    = f.input :name, label: "Your name", placeholder: "e.g. Jane Citizen"
+    = f.input :email, label: "Your email", placeholder: "e.g. your@email.com"
     = f.input :details, label: "Why should this comment be removed?", as: :text
     -# This is a spam bot honeytrap. A human being should not be filling this in
     -# It's not awesome for screenreaders though

--- a/app/views/reports/new.html.haml
+++ b/app/views/reports/new.html.haml
@@ -1,6 +1,6 @@
 - content_for :page_title, "Report comment"
 %h3= yield :page_title
-= render @comment
+= render :partial => 'comments/comment', :locals => {:comment => @comment}
 %p
   This form is for reporting comments that should be removed. Reasons can include that
   the comment is spam, abusive, unlawful or harassing &mdash; in other words, where people are going

--- a/app/views/reports/new.html.haml
+++ b/app/views/reports/new.html.haml
@@ -8,7 +8,7 @@
   you think the comment should be removed.
 = semantic_form_for [@comment, @report] do |f|
   = f.inputs do
-    = f.input :name, label: "Your name"
+    = f.input :name, label: "Your name", :placeholder => "e.g. Jane Citizen"
     = f.input :email, label: "Your email", :placeholder => "e.g. your@email.com"
     = f.input :details, label: "Why should this comment be removed?", as: :text
     -# This is a spam bot honeytrap. A human being should not be filling this in

--- a/app/views/reports/new.html.haml
+++ b/app/views/reports/new.html.haml
@@ -10,7 +10,7 @@
   = f.inputs do
     = f.input :name, label: "Your name", placeholder: "Name"
     = f.input :email, label: "Your email", placeholder: "Email"
-    = f.input :details, as: :text, placeholder: "Why you think the comment should be removed"
+    = f.input :details, label: "Why should this comment be removed?", as: :text, placeholder: "Why you think the comment should be removed"
     -# This is a spam bot honeytrap. A human being should not be filling this in
     -# It's not awesome for screenreaders though
     %li{style: "display: none;"}

--- a/app/views/reports/new.html.haml
+++ b/app/views/reports/new.html.haml
@@ -8,13 +8,13 @@
   you think the comment should be removed.
 = semantic_form_for [@comment, @report] do |f|
   = f.inputs do
-    = f.input :name, :label => "Your name", placeholder: "Name"
-    = f.input :email, :label => "Your email", placeholder: "Email"
-    = f.input :details, :as => :text, placeholder: "Why you think the comment should be removed"
+    = f.input :name, label: "Your name", placeholder: "Name"
+    = f.input :email, label: "Your email", placeholder: "Email"
+    = f.input :details, as: :text, placeholder: "Why you think the comment should be removed"
     -# This is a spam bot honeytrap. A human being should not be filling this in
     -# It's not awesome for screenreaders though
     %li{style: "display: none;"}
       = label_tag :little_sweety, 'Little Sweety'
       = text_field_tag :little_sweety, "", placeholder: "Please leave this blank"
   = f.actions do
-    = f.action :submit, :label => "Send report"
+    = f.action :submit, label: "Send report"

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -32,7 +32,7 @@ feature "Give feedback to Council" do
       visit(application_path(application))
     end
 
-    fill_in("Explain why you think this application should be approved or not", with: "I think this is a really good idea")
+    fill_in("Have your say on this application", with: "I think this is a really good idea")
     fill_in("Your name", with: "Matthew Landauer")
     fill_in("Your email", with: "example@example.com")
     # Don't fill in the address
@@ -49,7 +49,7 @@ feature "Give feedback to Council" do
       visit(application_path(application))
     end
 
-    fill_in("Explain why you think this application should be approved or not", with: "I think this is a really good ideas")
+    fill_in("Have your say on this application", with: "I think this is a really good ideas")
     fill_in("Your name", with: "Matthew Landauer")
     fill_in("Your email", with: "example@example.com")
     fill_in("Your street address", with: "11 Foo Street")
@@ -133,7 +133,7 @@ feature "Give feedback to Council" do
         visit(application_path(application))
       end
 
-      fill_in("Explain why you think this application should be approved or not", with: "I think this is a really good idea")
+      fill_in("Have your say on this application", with: "I think this is a really good idea")
       fill_in("Your name", with: "Matthew Landauer")
       fill_in("Your email", with: "example@example.com")
       # Don't fill in the address

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -32,9 +32,9 @@ feature "Give feedback to Council" do
       visit(application_path(application))
     end
 
-    fill_in("Comment", with: "I think this is a really good idea")
-    fill_in("Name", with: "Matthew Landauer")
-    fill_in("Email", with: "example@example.com")
+    fill_in("Write your comment", with: "I think this is a really good idea")
+    fill_in("Your name", with: "Matthew Landauer")
+    fill_in("Your email", with: "example@example.com")
     # Don't fill in the address
     click_button("Post your comment")
 
@@ -49,10 +49,10 @@ feature "Give feedback to Council" do
       visit(application_path(application))
     end
 
-    fill_in("Comment", with: "I think this is a really good ideas")
-    fill_in("Name", with: "Matthew Landauer")
-    fill_in("Email", with: "example@example.com")
-    fill_in("Address", with: "11 Foo Street")
+    fill_in("Write your comment", with: "I think this is a really good ideas")
+    fill_in("Your name", with: "Matthew Landauer")
+    fill_in("Your email", with: "example@example.com")
+    fill_in("Your street address", with: "11 Foo Street")
     click_button("Post your comment")
 
     page.should have_content("Now check your email")
@@ -101,7 +101,7 @@ feature "Give feedback to Council" do
 
     fill_in("Your name", with: "Joe Reporter")
     fill_in("Your email", with: "reporter@foo.com")
-    fill_in("Details", with: "You can't be rude to people!")
+    fill_in("Why should this comment be removed?", with: "You can't be rude to people!")
     click_button("Send report")
 
     page.should have_content("The comment has been reported and a moderator will look into it as soon as possible.")
@@ -133,9 +133,9 @@ feature "Give feedback to Council" do
         visit(application_path(application))
       end
 
-      fill_in("Comment", with: "I think this is a really good idea")
-      fill_in("Name", with: "Matthew Landauer")
-      fill_in("Email", with: "example@example.com")
+      fill_in("Write your comment", with: "I think this is a really good idea")
+      fill_in("Your name", with: "Matthew Landauer")
+      fill_in("Your email", with: "example@example.com")
       # Don't fill in the address
       click_button("Post your comment")
 

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -32,7 +32,7 @@ feature "Give feedback to Council" do
       visit(application_path(application))
     end
 
-    fill_in("Write your comment", with: "I think this is a really good idea")
+    fill_in("Explain why you think this application should be approved or not", with: "I think this is a really good idea")
     fill_in("Your name", with: "Matthew Landauer")
     fill_in("Your email", with: "example@example.com")
     # Don't fill in the address
@@ -49,7 +49,7 @@ feature "Give feedback to Council" do
       visit(application_path(application))
     end
 
-    fill_in("Write your comment", with: "I think this is a really good ideas")
+    fill_in("Explain why you think this application should be approved or not", with: "I think this is a really good ideas")
     fill_in("Your name", with: "Matthew Landauer")
     fill_in("Your email", with: "example@example.com")
     fill_in("Your street address", with: "11 Foo Street")
@@ -133,7 +133,7 @@ feature "Give feedback to Council" do
         visit(application_path(application))
       end
 
-      fill_in("Write your comment", with: "I think this is a really good idea")
+      fill_in("Explain why you think this application should be approved or not", with: "I think this is a really good idea")
       fill_in("Your name", with: "Matthew Landauer")
       fill_in("Your email", with: "example@example.com")
       # Don't fill in the address


### PR DESCRIPTION
Why:
  #795 explains why not having visible labels causes a number of usability problems, especially for people with limited eye sight, mobility or memory issues.

These commits:

* add labels for each input on the comment and comment report forms
* add placeholder text that gives an example of the expected input, like the signup and search forms.
* cleans up the forms scss partial a little bit e8c6a7a , 8db6c42 , f5cc1f1 &  a2d3cdd

I haven't added placeholder text on the comment or report text input because I don't think there's an obvious choise. I think we have to be particularly careful with it cause we'll be shaping the kind of comment people make. It's something we should do experiments with. I've just tried to get this to a basic win to iterate from.

This effects all users and is separate from the councillor options PR #788 . This can be merged into master before that stuff and then merged back into the `write-to-councillors` branch (which won't be automatic). I thought that was a more isolated approach as that other PR is too big. This is a general commenting improvement that relates to one of the [TODOs on the councillor options PR](https://github.com/openaustralia/planningalerts/pull/788#issuecomment-143950833) and will help step it forward.

## Before

![screen shot 2015-09-30 at 3 43 35 pm](https://cloud.githubusercontent.com/assets/1239550/10185412/2dab8bb2-678b-11e5-9fc5-237986745f13.png)
![screen shot 2015-09-30 at 3 43 08 pm](https://cloud.githubusercontent.com/assets/1239550/10185413/2dafe0ea-678b-11e5-91c4-aedec7897339.png)

## After

![screen shot 2015-09-30 at 3 51 33 pm](https://cloud.githubusercontent.com/assets/1239550/10185421/387fdeee-678b-11e5-900a-1adef3974aec.png)
![screen shot 2015-09-30 at 3 50 44 pm](https://cloud.githubusercontent.com/assets/1239550/10185422/3886d000-678b-11e5-82cd-ec051a59dea0.png)

Assigning to @henare for review.