### PR TITLE
Order comments to show most recent one first

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -101,7 +101,7 @@ class ApplicationsController < ApplicationController
     end
 
     @application = Application.find(params[:id])
-    @comments = @application.comments.visible.order(:updated_at)
+    @comments = @application.comments.visible.order("updated_at DESC")
     @nearby_count = @application.find_all_nearest_or_recent.size
     @comment = Comment.new
     # Required for new email alert signup form

--- a/spec/features/viewing_comments_spec.rb
+++ b/spec/features/viewing_comments_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+feature "View comments on an application" do
+  scenario "seeing the latest comment first" do
+    VCR.use_cassette('planningalerts') do
+      application = create(:application)
+      create(:confirmed_comment, text: "newest", updated_at: Date.today, application: application)
+      create(:confirmed_comment, text: "middle", updated_at: Date.yesterday, application: application)
+      create(:confirmed_comment, text: "oldest", updated_at: 3.days.ago, application: application)
+
+      visit(application_path(application))
+    end
+
+    expect(page.all('.comment-item').map {|c| c.find('.comment-text').text})
+      .to eq ["newest", "middle", "oldest"]
+  end
+end


### PR DESCRIPTION
See #798 "As someone interested in a local development, show me the
most recent comments on an application first, so I get the most recent
information from people and see that other locals have commented
recently"

Assigning to @henare for review