### PR TITLE
Don't render comment as list item if it isn't

### DIFF
--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -1,6 +1,9 @@
-%li
-  - if with_link_wrapper
-    = link_to application_path(comment.application), title: "View application at #{comment.application.address}", class: "panel-link" do
-      = render 'comments/comment_item', comment: comment, with_address: true
-  - else
-    = render 'comments/comment_item', comment: comment, with_address: false
+- if in_list
+  %li
+    - if with_link_wrapper
+      = link_to application_path(comment.application), title: "View application at #{comment.application.address}", class: "panel-link" do
+        = render 'comments/comment_item', comment: comment, with_address: true
+    - else
+      = render 'comments/comment_item', comment: comment, with_address: false
+- else
+  = render 'comments/comment_item', comment: comment, with_address: false

--- a/app/views/comments/_comments_area.html.haml
+++ b/app/views/comments/_comments_area.html.haml
@@ -4,5 +4,5 @@
     %p.small.quiet
       Have your say by #{link_to "adding your own comment", "#add-comment", class: "link-to-comment-form"}.
     %ol#comments
-      = render @comments, with_link_wrapper: false
+      = render @comments, in_list: true, with_link_wrapper: false
   = render "comments/comment_form"

--- a/app/views/comments/index.html.haml
+++ b/app/views/comments/index.html.haml
@@ -2,4 +2,4 @@
 %h1.page-title Recent comments
 = paginated_section @comments, :previous_label => "« Newer", :next_label => "Older »" do
   %ol#comments
-    = render @comments, with_link_wrapper: true
+    = render @comments, in_list: true, with_link_wrapper: true

--- a/app/views/reports/new.html.haml
+++ b/app/views/reports/new.html.haml
@@ -1,6 +1,6 @@
 - content_for :page_title, "Report comment"
 %h3= yield :page_title
-= render @comment, with_link_wrapper: false
+= render @comment, in_list: false
 %p
   This form is for reporting comments that should be removed. Reasons can include that
   the comment is spam, abusive, unlawful or harassing &mdash; in other words, where people are going

--- a/spec/views/comments/comment_spec.rb
+++ b/spec/views/comments/comment_spec.rb
@@ -15,7 +15,7 @@ describe "comments/_comment" do
       text: 'This is a link to <a href="http://openaustralia.org">openaustralia.org</a>')
     expected_html = "<blockquote class='comment-text'><p>This is a link to <a href=\"http://openaustralia.org\" rel=\"nofollow\">openaustralia.org</a></p></blockquote>"
 
-    render partial: "comment", object: comment, locals: { in_list: false }
+    render comment, in_list: false
 
     expect(rendered).to include(expected_html)
   end
@@ -29,7 +29,7 @@ describe "comments/_comment" do
 
 <p>This is a new paragraph</p></blockquote>"
 
-    render partial: "comment", object: comment, locals: { in_list: false }
+    render comment, in_list: false
 
     expect(rendered).to include(expected_html)
   end
@@ -40,7 +40,7 @@ describe "comments/_comment" do
       text: "<a href=\"javascript:document.location='http://www.google.com/'\">A nasty link</a><img src=\"http://foo.co\">")
     expected_html = "<blockquote class='comment-text'><p><a rel=\"nofollow\">A nasty link</a></p></blockquote>"
 
-    render partial: "comment", object: comment, locals: { in_list: false }
+    render comment, in_list: false
 
     expect(rendered).to include(expected_html)
   end

--- a/spec/views/comments/comment_spec.rb
+++ b/spec/views/comments/comment_spec.rb
@@ -15,7 +15,7 @@ describe "comments/_comment" do
       text: 'This is a link to <a href="http://openaustralia.org">openaustralia.org</a>')
     expected_html = "<blockquote class='comment-text'><p>This is a link to <a href=\"http://openaustralia.org\" rel=\"nofollow\">openaustralia.org</a></p></blockquote>"
 
-    render partial: "comment", object: comment, locals: { with_link_wrapper: false }
+    render partial: "comment", object: comment, locals: { in_list: false }
 
     expect(rendered).to include(expected_html)
   end
@@ -29,7 +29,7 @@ describe "comments/_comment" do
 
 <p>This is a new paragraph</p></blockquote>"
 
-    render partial: "comment", object: comment, locals: { with_link_wrapper: false }
+    render partial: "comment", object: comment, locals: { in_list: false }
 
     expect(rendered).to include(expected_html)
   end
@@ -40,7 +40,7 @@ describe "comments/_comment" do
       text: "<a href=\"javascript:document.location='http://www.google.com/'\">A nasty link</a><img src=\"http://foo.co\">")
     expected_html = "<blockquote class='comment-text'><p><a rel=\"nofollow\">A nasty link</a></p></blockquote>"
 
-    render partial: "comment", object: comment, locals: { with_link_wrapper: false }
+    render partial: "comment", object: comment, locals: { in_list: false }
 
     expect(rendered).to include(expected_html)
   end


### PR DESCRIPTION
This is to fix bug #801

## Before
![screen shot 2015-10-09 at 4 24 55 pm](https://cloud.githubusercontent.com/assets/1239550/10386375/5e4b7c6e-6ea2-11e5-8a0a-ca18b65f528a.png)

## After
![screen shot 2015-10-09 at 4 24 40 pm](https://cloud.githubusercontent.com/assets/1239550/10386374/53809eb8-6ea2-11e5-8a8e-50f93133c349.png)

This fixes the bug by introducing an option to render the comment in a list item or not. I think makes the way these partials work clearer and we get to keep using the nice `render @comment` syntax everywhere. From commit 3565d92:

> This fixes #801 "Comment report form has a stray bullet point"
which was caused by wrapping the comment in an `<li>` when it
wasn't part of a list.

> This adds an option to the comment template to say whether or not
it is part of a list. This means we can continue to use the handy
rails helper `render @comment`.

> I tried another solution first, by directly rendering the
`comment_item` template on the report page, but decided this was
a bad solution. If we can't use the `render @comment` syntax to
simply render a comment, because it depends on an additional html
pattern, then we're undermining a really handy rails convention.

> I think this solution is better because it gives us a very clear
way to describe how we want our comment to be rendered.

This also adds a slight refactor of the comment view test to while a was fixing that to use the new option:
 8b69499