### PR TITLE
Keeping the right comment actions available in the right places

### DIFF
--- a/app/views/comments/_comment_item.html.haml
+++ b/app/views/comments/_comment_item.html.haml
@@ -18,4 +18,5 @@
       .comment-actions
         - if current_user && current_user.admin?
           = link_to "admin", admin_application_comment_path(comment), class: 'comment-action'
-        = link_to "report comment", new_comment_report_path(comment), title: "Report this comment by #{comment.name} for removal", class: "comment-action"
+        - unless current_page?(new_comment_report_path(comment.id))
+          = link_to "report comment", new_comment_report_path(comment), title: "Report this comment by #{comment.name} for removal", class: "comment-action"

--- a/app/views/comments/_comment_item.html.haml
+++ b/app/views/comments/_comment_item.html.haml
@@ -14,9 +14,8 @@
         %time.comment-time{datetime: comment.updated_at.strftime("%F")}
           #{time_ago_in_words(comment.updated_at)} ago
     %blockquote.comment-text= comment_as_html(comment.text)
-    - unless current_page?(comments_path)
-      .comment-actions
-        - if current_user && current_user.admin?
-          = link_to "admin", admin_application_comment_path(comment), class: 'comment-action'
-        - unless current_page?(new_comment_report_path(comment.id))
-          = link_to "report comment", new_comment_report_path(comment), title: "Report this comment by #{comment.name} for removal", class: "comment-action"
+    .comment-actions
+      - if current_user && current_user.admin?
+        = link_to "admin", admin_application_comment_path(comment), class: 'comment-action'
+      - unless current_page?(new_comment_report_path(comment.id))
+        = link_to "report comment", new_comment_report_path(comment), title: "Report this comment by #{comment.name} for removal", class: "comment-action"


### PR DESCRIPTION
See #804 and #803 issues about which comment actions should be shown on which pages.

fcbab1a hides the 'report comment' link if you're already on the report page. Fixes #803.

258c577 makes the report and admin links available on the comments index so you can immediately take action if you see a comment that needs it.