### PR TITLE
Halve the hight of the comment text input textarea

### DIFF
--- a/app/views/comments/_comment_form_inputs.html.haml
+++ b/app/views/comments/_comment_form_inputs.html.haml
@@ -7,7 +7,8 @@
   = f.inputs id: "comment-base-inputgroup" do
     = f.input :text, label: "Have your say on this application",
                      placeholder: "Be polite, clear, and to the point so your comment gets listened to.",
-                     hint: "Have you made a donation or gift to a Councillor or Council employee? #{link_to("You may need to disclose this", faq_path(anchor: "disclosure"))}.".html_safe
+                     hint: "Have you made a donation or gift to a Councillor or Council employee? #{link_to("You may need to disclose this", faq_path(anchor: "disclosure"))}.".html_safe,
+                     input_html: { rows: "10" }
     %div#disclosure_explanation.inline-hints.hidden
       = render partial: 'static/disclosure_explanation'
     = f.input :name, label: "Your name",


### PR DESCRIPTION
From #815:

> The size of an input field should default to the intended length of the
text to be inputed. By my quick look, most comments are either roughly
half the length of the text fields default size, or are much longer. The
textarea can be stretched to be taller by the user.

> By making it bigger we're making the form longer, and seem more involved
than it needs to be. We're also suggesting a length that most people
don't seem to think is necessary. This is in conflict with our direction
that people be 'to the point' in writing their comments.

> Making it shorter will make the form simpler and appear a bit more
approachable and help people scan the inputs—making the form a little
more usable.

## Before
![screen shot 2015-10-19 at 1 44 01 pm](https://cloud.githubusercontent.com/assets/1239550/10568791/7a1b1f62-7668-11e5-9aba-297635be1ee2.png)

## After
![screen shot 2015-10-19 at 1 43 29 pm](https://cloud.githubusercontent.com/assets/1239550/10568797/82412498-7668-11e5-8848-5ed2b7f7afda.png)

Fixes #815