### PR TITLE
De-emphasise non-commercial subscription section so the subscription page is simpler

### DIFF
--- a/app/assets/stylesheets/partials/special_forms/_payment_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_payment_form.scss
@@ -16,6 +16,9 @@
       font-size: 1.175em;
     }
   }
+  .small {
+    font-size: 0.8em;
+  }
 }
 
 p.form-processing {

--- a/app/assets/stylesheets/partials/special_forms/_payment_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_payment_form.scss
@@ -17,7 +17,7 @@
     }
   }
   .small {
-    font-size: 0.8em;
+    font-size: 0.9em;
   }
 }
 

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -8,12 +8,12 @@
       %strong Subscribe here to get alerts for several addresses if you use PlanningAlerts for your work.
       Once you’re subscribed you can sign up for alerts from as many locations as you need.
 
-    %p
+    %p= render partial: "stripe_button", locals: {email: @email, price: @price}
+
+    %p.quiet.small
       %strong Non-commercial use of PlanningAlerts is free for any number of addresses.
       If this sounds like you, please #{mail_to "contact@planningalerts.org.au", "email us"}—we’ll
       be happy to help with a free,
       - # This prevents the term breaking over two lines, remove this hack if copy changes make it possible
       %span{style: "white-space: nowrap;"}non-commercial
       subscription.
-
-    = render partial: "stripe_button", locals: {email: @email, price: @price}


### PR DESCRIPTION
Make the subscription page simpler by pushing the information about non-commercial subscription down the page and de-emphasising it.

Mentioned as something to try on #782.

## Before
![selection_002](https://cloud.githubusercontent.com/assets/48945/10627992/a9664856-780b-11e5-8770-195dadf10145.png)
![selection_003](https://cloud.githubusercontent.com/assets/48945/10627989/a49c2930-780b-11e5-87ec-12850ad22128.png)

## After
![selection_001](https://cloud.githubusercontent.com/assets/48945/10627997/b9ecc830-780b-11e5-962b-967d1e1a7815.png)
![selection_004](https://cloud.githubusercontent.com/assets/48945/10627998/c05adc5c-780b-11e5-8256-ed9ddc7296c0.png)

