### PR TITLE
Fix bug in councillor form and improve js performance

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,6 +3,7 @@
 //= require jquery.ui.autocomplete.html.js
 //= require address_autocomplete.js
 //= require geolocation
+//= require applications
 
 $("#menu .toggle").click(function(){
   $("#menu ul").slideToggle("fast", function(){

--- a/app/assets/javascripts/applications.js
+++ b/app/assets/javascripts/applications.js
@@ -24,7 +24,7 @@ if ($('#comment-receiver-inputgroup').length) {
   $('.councillor-select-list').before(councillorTogglerRadio)
                               .before(councillorTogglerLabel);
 
-  $('label[for="councillors-list-toggler"').append('<strong>' + $('.councillor-select-list-intro strong').text() + '</strong><p>' + $('.councillor-select-list-intro p').text() + '</p>');
+  $('label[for="councillors-list-toggler"]').append('<strong>' + $('.councillor-select-list-intro strong').text() + '</strong><p>' + $('.councillor-select-list-intro p').text() + '</p>');
 
   $('.councillor-select-list-intro').remove();
 

--- a/app/views/applications/show.html.haml
+++ b/app/views/applications/show.html.haml
@@ -70,4 +70,3 @@
     })
 
 = javascript_include_tag "maps"
-= javascript_include_tag "applications"


### PR DESCRIPTION
Why:

See bug #827 a really bad bug in Safari where the label for the councillors option wouldn't show.

These commits:

1. e8194be Includes `applications.js` into the compliation for the site wide `application.js` to reduce http requests. Also if the site wide file is already downloaded, but some network error stops the applications.js being downloaded we wouldn't get all the useful stuff in that file. In other words this reduces number of things that could go wrong.
2.  78211a0 Fixes the bug by adding a missing "]"

Safari before:
![screen shot 2015-10-27 at 12 00 35 pm](https://cloud.githubusercontent.com/assets/1239550/10748705/f61a4b48-7cb6-11e5-841c-85edc94718e0.png)

Safari after:
![screen shot 2015-10-27 at 2 20 18 pm](https://cloud.githubusercontent.com/assets/1239550/10748714/16c98b24-7cb7-11e5-8f13-3781ee7b1803.png)
