### PR TITLE
Increase textarea input line-height for readability

### DIFF
--- a/app/assets/stylesheets/partials/_form.scss
+++ b/app/assets/stylesheets/partials/_form.scss
@@ -12,6 +12,10 @@ $fb-gradient-style: matte;
 $fb-font-size: 1.3em;
 $fb-line-height: 1em;
 
+textarea {
+  line-height: 1.5;
+}
+
 .actions input, .btn {
   margin-top: 1em;
   // @include fancy-button-allow-disable($orange);


### PR DESCRIPTION
The line-height of textarea input is too narrow, making it harder
to check what you've written.

This increases it to match the line-height of text in the rest of
the site.

I noticed this problem on a user's computer during testing.

## Before:
![screen shot 2015-10-30 at 11 35 06 am](https://cloud.githubusercontent.com/assets/1239550/10835800/51c2a31a-7efa-11e5-82fb-69aa7ff68182.png)

## After:
![screen shot 2015-10-30 at 11 36 34 am](https://cloud.githubusercontent.com/assets/1239550/10835824/7c52fd14-7efa-11e5-8cca-dcbac351152d.png)

