### PR TITLE
Increase the contrast of input text

### DIFF
--- a/app/assets/stylesheets/partials/_form.scss
+++ b/app/assets/stylesheets/partials/_form.scss
@@ -30,7 +30,7 @@ a.btn:hover {
   // Make text field sit nicely at the expected full width
   input, textarea {
     box-sizing: border-box;
-    color: $cool-highlight;
+    color: $font-color;
   }
 
   .placeholder {


### PR DESCRIPTION
The contrast of input text is reduced, making it slightly softer
and less clear.

There’s no obvious reason for this, and it incrementally makes using
the forms for of a task for some users.

I noticed this in usability testing on where a person was squinting
as they checked the comment they had inputed.

## Before

![screen shot 2015-10-30 at 11 43 33 am](https://cloud.githubusercontent.com/assets/1239550/10835936/df2b528c-7efb-11e5-9e5d-87b6bce63d3f.png)
![screen shot 2015-10-30 at 11 43 25 am](https://cloud.githubusercontent.com/assets/1239550/10835937/df317f9a-7efb-11e5-847d-94441c34d3c7.png)


## After

![screen shot 2015-10-30 at 11 38 39 am](https://cloud.githubusercontent.com/assets/1239550/10835938/e6991f5e-7efb-11e5-9981-bb298a6d7052.png)
![screen shot 2015-10-30 at 11 38 13 am](https://cloud.githubusercontent.com/assets/1239550/10835939/e6e03df8-7efb-11e5-8fd3-8513c3690ffd.png)
