### PR TITLE
Use generic label for planning authority option because many people wont recognise authority by name

### DIFF
--- a/app/views/comments/_comment_receiver_options.html.haml
+++ b/app/views/comments/_comment_receiver_options.html.haml
@@ -2,11 +2,11 @@
   %legend Who should this go to?
   %input.receiver-select-radio.receiver-type-option{id: "receiver-to-authority-option", type: "radio", name: "receiver"}
   %label.receiver-select-label{for: "receiver-to-authority-option"}
-    %strong= @application.authority.full_name
+    %strong The planning authority
     - if @application.official_submission_period_expired?
       %p
         You’re too late to have your comment officially considered
-        when they decide on this application.
+        when the planning authority (#{@application.authority.full_name}) decide on this application.
         The period for officially commenting on this application finished
         #{days_ago_in_words(@application.on_notice_to)}.
         - if @application.on_notice_from
@@ -16,7 +16,7 @@
         and displayed here.
     - else
       %p
-        Write to the council if you want your comment considered
+        Write to the planning authority (#{@application.authority.full_name}) if you want your comment considered
         when they decide whether to approve this application.
   .councillor-select-list
     %header.councillor-select-list-intro

--- a/spec/features/write_to_councillors_spec.rb
+++ b/spec/features/write_to_councillors_spec.rb
@@ -32,7 +32,7 @@ feature "Send a message to a councillor" do
       fill_in("Have your say on this application", with: "I think this is a really good idea")
       fill_in("Your name", with: "Matthew Landauer")
 
-      expect(page).to have_content("Write to the council if you want your comment considered when they decide whether to approve this application.")
+      expect(page).to have_content("Write to the planning authority (#{application.authority.full_name}) if you want your comment considered when they decide whether to approve this application.")
 
       within("#comment-receiver-inputgroup") do
         choose "councillor-2"


### PR DESCRIPTION
People shouldn’t have to know the name of the planning authority to
decide whether or not they want to send a comment to them.

Throughout PlanningAlerts we use the generic term 'planning authority'
to refer to these institutions.

Instead of using the authority name for the option label,
name the authority in the label description text so that
people are still informed of precisely who their message will go to.
This should be done in addition to repeating the
term 'planning authority' to make sure people make that connection:

> Write to the planning authority (Rockdale City Council) ...

## Before
![screen shot 2015-11-01 at 1 58 24 pm](https://cloud.githubusercontent.com/assets/1239550/10867030/dfdb4498-80a0-11e5-9c20-43f6dd5420ed.png)

## After
![screen shot 2015-11-01 at 1 58 07 pm](https://cloud.githubusercontent.com/assets/1239550/10867033/e47d0f40-80a0-11e5-9d49-c5a521f4a201.png)

Fixes #829