### PR TITLE
Cut duplicate comment heading & add notice about comment options before first input

### DIFF
--- a/app/assets/stylesheets/partials/_form.scss
+++ b/app/assets/stylesheets/partials/_form.scss
@@ -71,14 +71,13 @@ a.btn:hover {
     color: $error-color;
   }
 
-  li.string,
-  li.stringish,
-  li.email,
-  li.text {
-    label {
-      font-weight: 500;
-      font-size: 1.1em;
-    }
+  label {
+    font-weight: 500;
+    font-size: 1.1em;
+  }
+
+  label p {
+    font-weight: normal;
   }
 
   li.string, li.stringish, li.email {

--- a/app/assets/stylesheets/partials/special_forms/_comment_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_comment_form.scss
@@ -43,6 +43,16 @@
   }
 }
 
+#comment-base-inputgroup {
+  h4 {
+    margin: 0;
+  }
+
+  label p {
+    margin: .5em 0 !important;
+  }
+}
+
 #comment-receiver-inputgroup {
   margin-top: 1em !important;
 
@@ -111,8 +121,8 @@
     display: block;
   }
 
-  .p-name {
-    font-weight: bold;
+  .p-org {
+    font-weight: normal;
   }
 
   :hover + &,

--- a/app/helpers/applications_helper.rb
+++ b/app/helpers/applications_helper.rb
@@ -37,12 +37,12 @@ module ApplicationsHelper
 
   def on_notice_text(application)
     if application.on_notice_from && (Date.today < application.on_notice_from)
-      text = "The period for officially responding to this application starts <strong>#{days_in_future_in_words(application.on_notice_from)}</strong> and finishes #{distance_of_time_in_words(application.on_notice_from, application.on_notice_to)} later."
+      text = "The period to have your comment officially considered by the planning authority starts <strong>#{days_in_future_in_words(application.on_notice_from)}</strong> and finishes #{distance_of_time_in_words(application.on_notice_from, application.on_notice_to)} later."
     elsif Date.today == application.on_notice_to
-      text = "<strong>Today</strong> is the last day to officially respond to this application."
+      text = "<strong>Today</strong> is the last day to have your comment officially considered by the planning authority."
       text << " The period for comment started #{days_ago_in_words(application.on_notice_from)}." if application.on_notice_from
     elsif Date.today < application.on_notice_to
-      text = "You have <strong>#{distance_of_time_in_words(Date.today, application.on_notice_to)}</strong> left to officially respond to this application."
+      text = "You have <strong>#{distance_of_time_in_words(Date.today, application.on_notice_to)}</strong> left to have your comment officially considered by the planning authority."
       text << " The period for comment started #{days_ago_in_words(application.on_notice_from)}." if application.on_notice_from
     else
       text = "You're too late! The period for officially commenting on this application finished <strong>#{days_ago_in_words(application.on_notice_to)}</strong>."

--- a/app/helpers/applications_helper.rb
+++ b/app/helpers/applications_helper.rb
@@ -37,15 +37,15 @@ module ApplicationsHelper
 
   def on_notice_text(application)
     if application.on_notice_from && (Date.today < application.on_notice_from)
-      text = "The period to have your comment officially considered by the planning authority starts <strong>#{days_in_future_in_words(application.on_notice_from)}</strong> and finishes #{distance_of_time_in_words(application.on_notice_from, application.on_notice_to)} later."
+      text = "The period to have your comment officially considered by the planning authority <strong>starts #{days_in_future_in_words(application.on_notice_from)}</strong> and finishes #{distance_of_time_in_words(application.on_notice_from, application.on_notice_to)} later."
     elsif Date.today == application.on_notice_to
-      text = "<strong>Today</strong> is the last day to have your comment officially considered by the planning authority."
+      text = "<strong>Today is the last day</strong> to have your comment officially considered by the planning authority."
       text << " The period for comment started #{days_ago_in_words(application.on_notice_from)}." if application.on_notice_from
     elsif Date.today < application.on_notice_to
-      text = "You have <strong>#{distance_of_time_in_words(Date.today, application.on_notice_to)}</strong> left to have your comment officially considered by the planning authority."
+      text = "<strong>You have #{distance_of_time_in_words(Date.today, application.on_notice_to)} left</strong> to have your comment officially considered by the planning authority."
       text << " The period for comment started #{days_ago_in_words(application.on_notice_from)}." if application.on_notice_from
     else
-      text = "You're too late! The period for officially commenting on this application finished <strong>#{days_ago_in_words(application.on_notice_to)}</strong>."
+      text = "You're too late! The period for officially commenting on this application <strong>finished #{days_ago_in_words(application.on_notice_to)}</strong>."
       text << " It lasted for #{distance_of_time_in_words(application.on_notice_from, application.on_notice_to)}." if application.on_notice_from
       text << " If you chose to comment now, your comment will still be displayed here and be sent to the planning authority but it will <strong>not be officially considered</strong> by the planning authority."
     end

--- a/app/views/comments/_comment_form.html.haml
+++ b/app/views/comments/_comment_form.html.haml
@@ -1,10 +1,9 @@
-%h4#add-comment Add your own comment
 - # TODO: Handle situation where the council doesn't have an email
 - #       but there are councillors to contact
 - if @application.authority.contactable? || @application_authority_councillors
-  = render "comments/comment_form_introduction"
   = render "comments/comment_form_inputs"
 - elsif !@application.comment_url.blank?
+  %h4#add-comment Add your own comment
   %p
     = link_to "How to comment", @application.comment_url
     on this application (from #{@application.authority.full_name}).

--- a/app/views/comments/_comment_form_inputs.html.haml
+++ b/app/views/comments/_comment_form_inputs.html.haml
@@ -34,5 +34,5 @@
       = label_tag :little_sweety, 'Little Sweety'
       = text_field_tag :little_sweety, "", placeholder: "Please leave this blank"
   = f.actions do
-    = f.action :submit, label: "Post your #{ "public " if @application_authority_councillors }comment",
+    = f.action :submit, label: "Post your public comment",
                         button_html: {class: "button button-action"}

--- a/app/views/comments/_comment_form_inputs.html.haml
+++ b/app/views/comments/_comment_form_inputs.html.haml
@@ -5,7 +5,10 @@
 
 = semantic_form_for form_target do |f|
   = f.inputs id: "comment-base-inputgroup" do
-    = f.input :text, label: "Have your say on this application",
+    - label_for_text = capture do
+      %h4#add-comment Have your say on this application
+      = render "comments/comment_form_introduction"
+    = f.input :text, label: label_for_text.html_safe,
                      placeholder: "Be polite, clear, and to the point so your comment gets listened to.",
                      hint: "Have you made a donation or gift to a Councillor or Council employee? #{link_to("You may need to disclose this", faq_path(anchor: "disclosure"))}.".html_safe,
                      input_html: { rows: "10" }

--- a/app/views/comments/_comment_form_introduction.html.haml
+++ b/app/views/comments/_comment_form_introduction.html.haml
@@ -11,4 +11,3 @@
     %strong #{@application.authority.full_name}.
     - unless @application.official_submission_period_expired?
       They’ll consider your submission when they decide whether to approve this application.
-    Your name and comment will be posted publicly here as well.

--- a/app/views/comments/_comment_form_introduction.html.haml
+++ b/app/views/comments/_comment_form_introduction.html.haml
@@ -1,13 +1,13 @@
 - if @application.on_notice_to
   - unless @application_authority_councillors && @application.official_submission_period_expired?
     %p= on_notice_text(@application)
-- if @application_authority_councillors
-  %p
+%p
+  - if @application_authority_councillors
     Post a comment for the planning authority
     or one of your elected local councillors.
-- else
-  %p
+  - else
     Your comment and details will be sent to
     %strong #{@application.authority.full_name}.
     - unless @application.official_submission_period_expired?
       They’ll consider your submission when they decide whether to approve this application.
+  Your&nbsp;name and comment will be posted publicly here as well.

--- a/app/views/comments/_comment_form_introduction.html.haml
+++ b/app/views/comments/_comment_form_introduction.html.haml
@@ -10,4 +10,4 @@
     %strong #{@application.authority.full_name}.
     - unless @application.official_submission_period_expired?
       They’ll consider your submission when they decide whether to approve this application.
-  Your&nbsp;name and comment will be posted publicly here as well.
+  Your&nbsp;name and comment will be posted publicly above.

--- a/app/views/comments/_comment_form_introduction.html.haml
+++ b/app/views/comments/_comment_form_introduction.html.haml
@@ -1,7 +1,11 @@
 - if @application.on_notice_to
   - unless @application_authority_councillors && @application.official_submission_period_expired?
     %p= on_notice_text(@application)
-- unless @application_authority_councillors
+- if @application_authority_councillors
+  %p
+    Write to the planning authority
+    or one of your elected local councillors.
+- else
   %p
     Your comment and details will be sent to
     %strong #{@application.authority.full_name}.

--- a/app/views/comments/_comment_form_introduction.html.haml
+++ b/app/views/comments/_comment_form_introduction.html.haml
@@ -3,8 +3,8 @@
     %p= on_notice_text(@application)
 - if @application_authority_councillors
   %p
-    Write to the planning authority
-    or one of your elected local councillors.
+    Post a comment for the planning authority
+    or write to one of your elected local councillors.
 - else
   %p
     Your comment and details will be sent to

--- a/app/views/comments/_comment_form_introduction.html.haml
+++ b/app/views/comments/_comment_form_introduction.html.haml
@@ -4,7 +4,7 @@
 - if @application_authority_councillors
   %p
     Post a comment for the planning authority
-    or write to one of your elected local councillors.
+    or one of your elected local councillors.
 - else
   %p
     Your comment and details will be sent to

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -36,7 +36,7 @@ feature "Give feedback to Council" do
     fill_in("Your name", with: "Matthew Landauer")
     fill_in("Your email", with: "example@example.com")
     # Don't fill in the address
-    click_button("Post your comment")
+    click_button("Post your public comment")
 
     page.should have_content("Some of the comment wasn't filled out completely. See below.")
     page.should_not have_content("Now check your email")
@@ -53,7 +53,7 @@ feature "Give feedback to Council" do
     fill_in("Your name", with: "Matthew Landauer")
     fill_in("Your email", with: "example@example.com")
     fill_in("Your street address", with: "11 Foo Street")
-    click_button("Post your comment")
+    click_button("Post your public comment")
 
     page.should have_content("Now check your email")
     page.should have_content("Click on the link in the email to confirm your comment")
@@ -137,7 +137,7 @@ feature "Give feedback to Council" do
       fill_in("Your name", with: "Matthew Landauer")
       fill_in("Your email", with: "example@example.com")
       # Don't fill in the address
-      click_button("Post your comment")
+      click_button("Post your public comment")
 
       page.should have_content("Some of the comment wasn't filled out completely. See below.")
       page.should_not have_content("Now check your email")

--- a/spec/helpers/applications_helper_spec.rb
+++ b/spec/helpers/applications_helper_spec.rb
@@ -45,7 +45,7 @@ describe ApplicationsHelper do
       @application.stub(:on_notice_from).and_return(Date.today + 2.days)
       @application.stub(:on_notice_to).and_return(Date.today + 16.days)
       helper.on_notice_text(@application).should ==
-        "The period for officially responding to this application starts <strong>in 2 days</strong> and finishes 14 days later."
+        "The period to have your comment officially considered by the planning authority starts <strong>in 2 days</strong> and finishes 14 days later."
     end
 
     describe "period has just started" do
@@ -53,14 +53,14 @@ describe ApplicationsHelper do
         @application.stub(:on_notice_from).and_return(Date.today)
         @application.stub(:on_notice_to).and_return(Date.today + 14.days)
         helper.on_notice_text(@application).should ==
-          "You have <strong>14 days</strong> left to officially respond to this application. The period for comment started today."
+          "You have <strong>14 days</strong> left to have your comment officially considered by the planning authority. The period for comment started today."
       end
 
       it "should say when the application is on notice" do
         @application.stub(:on_notice_from).and_return(Date.today - 1.day)
         @application.stub(:on_notice_to).and_return(Date.today + 13.days)
         helper.on_notice_text(@application).should ==
-          "You have <strong>13 days</strong> left to officially respond to this application. The period for comment started yesterday."
+          "You have <strong>13 days</strong> left to have your comment officially considered by the planning authority. The period for comment started yesterday."
       end
     end
 
@@ -72,13 +72,13 @@ describe ApplicationsHelper do
 
       it "should say when the application is on notice" do
         helper.on_notice_text(@application).should ==
-          "You have <strong>12 days</strong> left to officially respond to this application. The period for comment started 2 days ago."
+          "You have <strong>12 days</strong> left to have your comment officially considered by the planning authority. The period for comment started 2 days ago."
       end
 
       it "should only say when on notice to if there is no on notice from information" do
         @application.stub(:on_notice_from).and_return(nil)
         helper.on_notice_text(@application).should ==
-          "You have <strong>12 days</strong> left to officially respond to this application."
+          "You have <strong>12 days</strong> left to have your comment officially considered by the planning authority."
       end
     end
 
@@ -87,7 +87,7 @@ describe ApplicationsHelper do
         @application.stub(:on_notice_from).and_return(Date.today - 14.day)
         @application.stub(:on_notice_to).and_return(Date.today)
         helper.on_notice_text(@application).should ==
-          "<strong>Today</strong> is the last day to officially respond to this application. The period for comment started 14 days ago."
+          "<strong>Today</strong> is the last day to have your comment officially considered by the planning authority. The period for comment started 14 days ago."
       end
     end
 

--- a/spec/helpers/applications_helper_spec.rb
+++ b/spec/helpers/applications_helper_spec.rb
@@ -45,7 +45,7 @@ describe ApplicationsHelper do
       @application.stub(:on_notice_from).and_return(Date.today + 2.days)
       @application.stub(:on_notice_to).and_return(Date.today + 16.days)
       helper.on_notice_text(@application).should ==
-        "The period to have your comment officially considered by the planning authority starts <strong>in 2 days</strong> and finishes 14 days later."
+        "The period to have your comment officially considered by the planning authority <strong>starts in 2 days</strong> and finishes 14 days later."
     end
 
     describe "period has just started" do
@@ -53,14 +53,14 @@ describe ApplicationsHelper do
         @application.stub(:on_notice_from).and_return(Date.today)
         @application.stub(:on_notice_to).and_return(Date.today + 14.days)
         helper.on_notice_text(@application).should ==
-          "You have <strong>14 days</strong> left to have your comment officially considered by the planning authority. The period for comment started today."
+          "<strong>You have 14 days left</strong> to have your comment officially considered by the planning authority. The period for comment started today."
       end
 
       it "should say when the application is on notice" do
         @application.stub(:on_notice_from).and_return(Date.today - 1.day)
         @application.stub(:on_notice_to).and_return(Date.today + 13.days)
         helper.on_notice_text(@application).should ==
-          "You have <strong>13 days</strong> left to have your comment officially considered by the planning authority. The period for comment started yesterday."
+          "<strong>You have 13 days left</strong> to have your comment officially considered by the planning authority. The period for comment started yesterday."
       end
     end
 
@@ -72,13 +72,13 @@ describe ApplicationsHelper do
 
       it "should say when the application is on notice" do
         helper.on_notice_text(@application).should ==
-          "You have <strong>12 days</strong> left to have your comment officially considered by the planning authority. The period for comment started 2 days ago."
+          "<strong>You have 12 days left</strong> to have your comment officially considered by the planning authority. The period for comment started 2 days ago."
       end
 
       it "should only say when on notice to if there is no on notice from information" do
         @application.stub(:on_notice_from).and_return(nil)
         helper.on_notice_text(@application).should ==
-          "You have <strong>12 days</strong> left to have your comment officially considered by the planning authority."
+          "<strong>You have 12 days left</strong> to have your comment officially considered by the planning authority."
       end
     end
 
@@ -87,7 +87,7 @@ describe ApplicationsHelper do
         @application.stub(:on_notice_from).and_return(Date.today - 14.day)
         @application.stub(:on_notice_to).and_return(Date.today)
         helper.on_notice_text(@application).should ==
-          "<strong>Today</strong> is the last day to have your comment officially considered by the planning authority. The period for comment started 14 days ago."
+          "<strong>Today is the last day</strong> to have your comment officially considered by the planning authority. The period for comment started 14 days ago."
       end
     end
 
@@ -99,13 +99,13 @@ describe ApplicationsHelper do
 
       it "should say when the application is on notice" do
         helper.on_notice_text(@application).should ==
-          "You're too late! The period for officially commenting on this application finished <strong>2 days ago</strong>. It lasted for 14 days. If you chose to comment now, your comment will still be displayed here and be sent to the planning authority but it will <strong>not be officially considered</strong> by the planning authority."
+          "You're too late! The period for officially commenting on this application <strong>finished 2 days ago</strong>. It lasted for 14 days. If you chose to comment now, your comment will still be displayed here and be sent to the planning authority but it will <strong>not be officially considered</strong> by the planning authority."
       end
 
       it "should only say when on notice to if there is no on notice from information" do
         @application.stub(:on_notice_from).and_return(nil)
         helper.on_notice_text(@application).should ==
-          "You're too late! The period for officially commenting on this application finished <strong>2 days ago</strong>. If you chose to comment now, your comment will still be displayed here and be sent to the planning authority but it will <strong>not be officially considered</strong> by the planning authority."
+          "You're too late! The period for officially commenting on this application <strong>finished 2 days ago</strong>. If you chose to comment now, your comment will still be displayed here and be sent to the planning authority but it will <strong>not be officially considered</strong> by the planning authority."
       end
     end
 


### PR DESCRIPTION
The label or the comment text input is saying the same thing as the heading to the comment section. This adds unnecessary text for people to read and takes up space. It’s simpler if there is only one heading here. This makes the comment heading and into into the label and replaces the heading text with the text from the original label 'Have your say on this application'.

This also:
* e708fb3 & 76425a9 adds an introduction par to the comment for with councillors, to give some notice that you can choose who you send your comment to; and
* 87f5540 Removes the 'public comment' notice 'Your name and comment will be posted publicly here as well' from the intro text and makes the button read 'post your *public* comment' for the form without councillors. This makes the way both versions of the form handle this consistent.

There’s lots of explanation on the commit messages also.

TODO’s:
* [x] improve the text intro to the comment form with councillors 'Write to the planning authority or one of your elected local councillors'. I think it could be a bit more specific to re-enforce the concepts behind the different kinds of comments. Something like 'Post a comment for the planning authority or write to one of your elected local councillors'

## Before

![screen shot 2015-11-02 at 4 53 31 pm](https://cloud.githubusercontent.com/assets/1239550/10875119/e6df5f80-8182-11e5-98c1-8d1c289ab08e.png)
![screen shot 2015-11-02 at 4 53 01 pm](https://cloud.githubusercontent.com/assets/1239550/10875120/e6e25dc0-8182-11e5-94b5-b70cc785371b.png)
![screen shot 2015-11-02 at 4 52 04 pm](https://cloud.githubusercontent.com/assets/1239550/10875121/e6e6903e-8182-11e5-8d62-83057ba57838.png)
![screen shot 2015-11-02 at 4 53 48 pm](https://cloud.githubusercontent.com/assets/1239550/10875109/c7a75320-8182-11e5-9464-36ef970c123b.png)


## After
![screen shot 2015-11-02 at 4 51 09 pm](https://cloud.githubusercontent.com/assets/1239550/10875128/f65bc912-8182-11e5-9921-3b7f8cb8b82e.png)
![screen shot 2015-11-02 at 4 54 40 pm](https://cloud.githubusercontent.com/assets/1239550/10875104/c56ae25c-8182-11e5-8e12-56aebb025284.png)
![screen shot 2015-11-02 at 4 54 27 pm](https://cloud.githubusercontent.com/assets/1239550/10875105/c56ece58-8182-11e5-9930-6e8cf32b327a.png)


Fixes #830 