### PR TITLE
Hotfix panel spacing

### DIFF
--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -40,11 +40,8 @@ ol#comments {
 }
 
 .panel-body {
-  padding: .75em 1em 1em;
-}
-
-.panel-body {
   @include clearfix;
+  padding: .75em 1em 1em;
 }
 
 .comment-location {

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -49,6 +49,7 @@ ol#comments {
 
 .comment-location {
   @extend .panel-body;
+  padding-bottom: .75em;
 }
 
 .comment-item {


### PR DESCRIPTION
The spacing of the panel heading is a bit off, there's more space under the words than above. This fixes that to make them even.

This also includes a tiny refactor of the css on these selectors.

## Before

![screen shot 2015-11-04 at 2 30 50 pm](https://cloud.githubusercontent.com/assets/1239550/10928869/c8439e2c-8300-11e5-90f0-a49ea43f3520.png)

## After

![screen shot 2015-11-04 at 2 27 30 pm](https://cloud.githubusercontent.com/assets/1239550/10928870/c8486cfe-8300-11e5-8877-71a739512ee0.png)