### PR TITLE
Improve the asthetics and usability of the charts on the authority pages

### DIFF
--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -21,8 +21,15 @@ function barGraph(selector, url, title) {
     var margin = { top: 20, right: 50, bottom: 20, left: 50 };
 
     var maxYValue = d3.max(data, function(datum) { return datum.values; });
-    var x = d3.time.scale().domain(d3.extent(data, function(datum) { return datum.key})).range([0, width]);
-    var y = d3.scale.linear()
+
+    var x = d3.time.scale()
+      .domain(
+        d3.extent(data, function(datum) { return datum.key; })
+      )
+      .range([0, width]);
+
+    var y = d3.scale
+      .linear()
       .domain([0, maxYValue])
       .rangeRound([height, 0]);
 

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -51,6 +51,25 @@ function barGraph(selector, url, metric) {
       .tickFormat(d3.format(0))
       .orient("left");
 
+    var xTickCount,
+        xDomainMonths = d3.time.months(x.domain()[0], x.domain()[1]).length;
+    if (xDomainMonths < 9) {
+      xTickCount = 2;
+    } else {
+      xTickCount = (d3.time.months, 10);
+    }
+
+    var xAxisDateFormats = d3.time.format.multi([
+        ["%_d %b", function(d) { return d.getDate() != 1; }],
+        ["%b", function(d) { return d.getMonth(); }],
+        ["%Y", function() { return true; }]
+    ]);
+
+    var xAxis = d3.svg.axis()
+      .scale(x)
+      .ticks(xTickCount)
+      .tickFormat(xAxisDateFormats);
+
     // add the canvas to the DOM
     var chart = d3.select(selector)
       .append("svg:svg")
@@ -70,36 +89,10 @@ function barGraph(selector, url, metric) {
       .y(function(d) { return y(d.values); })
       .interpolate("monotone");
 
-    chart.selectAll(".xTicks")
-      .data(x.ticks(d3.time.months.utc, 1))
-      .enter().append("svg:line")
-      .attr("class", "xTicks")
-      .attr("x1", x)
-      .attr("y1", height + 5)
-      .attr("x2", x)
-      .attr("y2", height + 10)
-      .attr("stroke", "#888")
-      .attr("stroke-width", "1px");
-
-    chart.selectAll("text.xAxisMonth")
-      .data(x.ticks(d3.time.months.utc, 3))
-      .enter().append("text")
-      .attr("class", "xAxisMonth")
-      .attr("x", x)
-      .attr("y", height)
-      .attr("dy", "25")
-      .attr("text-anchor", "middle")
-      .text(d3.time.format("%b"));
-
-    chart.selectAll("text.xAxisYear")
-      .data(x.ticks(d3.time.years.utc, 1))
-      .enter().append("text")
-      .attr("class", "xAxisYear")
-      .attr("x", x)
-      .attr("y", height + 8)
-      .attr("dy", "35")
-      .attr("text-anchor", "middle")
-      .text(d3.time.format("%Y"));
+    chart.append("g")
+      .attr("class", "x-axis")
+      .attr("transform", "translate(0, " + height + ")")
+      .call(xAxis);
 
     chart.append("g")
       .attr("class", "y-axis")

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -18,7 +18,7 @@ function barGraph(selector, url, title) {
     var width = 800;
     var barWidth = 5;
     var height = 200;
-    var margin = 30;
+    var margin = { top: 20, right: 50, bottom: 20, left: 50 };
 
     var maxYValue = d3.max(data, function(datum) { return datum.values; });
     var x = d3.time.scale().domain(d3.extent(data, function(datum) { return datum.key})).range([0, width]);
@@ -38,12 +38,12 @@ function barGraph(selector, url, title) {
     // add the canvas to the DOM
     var chart = d3.select(selector)
       .append("svg:svg")
-      .attr("width", width + 2 * margin)
-      .attr("height", height + 3 * margin);
+      .attr("width", margin.left + width + margin.right)
+      .attr("height", margin.top + height + margin.bottom);
 
     var axisGroup = chart
       .append("g")
-      .attr("transform", "translate(" + margin + "," + margin + ")");
+      .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
     axisGroup.selectAll(".xTicks")
       .data(x.ticks(d3.time.months.utc, 1))

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -45,6 +45,12 @@ function barGraph(selector, url, metric) {
       yTickCount = 5;
     }
 
+    var yAxis = d3.svg.axis()
+      .scale(y)
+      .ticks(yTickCount)
+      .tickFormat(d3.format(0))
+      .orient("left");
+
     // add the canvas to the DOM
     var chart = d3.select(selector)
       .append("svg:svg")
@@ -95,16 +101,9 @@ function barGraph(selector, url, metric) {
       .attr("text-anchor", "middle")
       .text(d3.time.format("%Y"));
 
-    chart.selectAll("text.yAxis")
-      .data(y.ticks(yTickCount))
-      .enter().append("text")
-      .attr("class", "yAxis")
-      .attr("x", 0)
-      .attr("y", y)
-      .attr("dx", "-8")
-      .attr("dy", "3")
-      .attr("text-anchor", "end")
-      .text(y.tickFormat(0));
+    chart.append("g")
+      .attr("class", "y-axis")
+      .call(yAxis);
 
     chart.append("svg:path")
       .attr("d", areaValues(data))

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -92,16 +92,15 @@ function barGraph(selector, url, title) {
       .attr("text-anchor", "end")
       .text(y.tickFormat(0));
 
-    var areaValues = d3.svg.area().
-      x(function(d) { return x(d.key); }).
-      y0(height).
-      y1(function(d) { return y(d.values); }).
-      interpolate("monotone");
+    var areaValues = d3.svg.area()
+      .x(function(d) { return x(d.key); })
+      .y0(height)
+      .y1(function(d) { return y(d.values); })
+      .interpolate("monotone");
 
-    chart.
-      append("svg:path").
-      attr("d", areaValues(data)).
-      attr("fill", "steelblue");
+    chart.append("svg:path")
+      .attr("d", areaValues(data))
+      .attr("fill", "steelblue");
 
     var yGridTickCount;
     if (yTickCount === 5) { yGridTickCount = 10 } else { yGridTickCount = yTickCount };

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -101,6 +101,13 @@ function barGraph(selector, url, metric) {
       .attr("transform", "translate(-8, 0)")
       .call(yAxis);
 
+    chart.append("line")
+      .attr("class", "x-axis-baseline")
+      .attr("x1", 0)
+      .attr("y1", height)
+      .attr("x2", width)
+      .attr("y2", height);
+
     chart.append("svg:path")
       .attr("d", areaValues(data))
       .attr("class", "chart-area");

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -18,7 +18,7 @@ function barGraph(selector, url, metric) {
 
     var width = 600;
     var barWidth = 5;
-    var height = 200;
+    var height = 100;
     var margin = { top: 20, right: 50, bottom: 100, left: 60 };
     var viewPortWidth = margin.left + width + margin.right;
     var viewPortHeight = margin.top + height + margin.bottom;

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -129,23 +129,6 @@ function barGraph(selector, url, title) {
       .attr("clip-path", function(d) { return "url(#clip-" + d + ")"; })
       .datum(data)
       .attr("d", lineValues);
-
-    var yGridTickCount;
-    if (yTickCount === 5) { yGridTickCount = 10 } else { yGridTickCount = yTickCount };
-    chart.selectAll(".yTicks")
-      .data(y.ticks(yGridTickCount))
-      .enter().append("svg:line")
-      .attr("class", "yTicks")
-      .attr("x1", 0)
-      .attr("y1", y)
-      .attr("x2", width)
-      .attr("y2", y)
-      .attr("stroke", function(d, i) {
-        if ( i === 0 ) { return "#888"; } else { return "rgba(255,255,255,.4)"; }
-      })
-      .attr("stroke-width", function(d, i) {
-        if ( i === 0 ) { return "4px"; } else { return "2px"; }
-      });
   });
 
 }

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -41,10 +41,8 @@ function barGraph(selector, url, metric) {
     var yTickCount;
     if (maxYValue < 2) {
       yTickCount = 1;
-    } else if (maxYValue < 5) {
-      yTickCount = 2;
     } else  {
-      yTickCount = 5;
+      yTickCount = 3;
     }
 
     var yAxis = d3.svg.axis()

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -98,9 +98,19 @@ function barGraph(selector, url, title) {
       .y1(function(d) { return y(d.values); })
       .interpolate("monotone");
 
+    var lineValues = d3.svg.line()
+      .x(function(d) { return x(d.key); })
+      .y(function(d) { return y(d.values); })
+      .interpolate("monotone");
+
     chart.append("svg:path")
       .attr("d", areaValues(data))
       .attr("class", "chart-area");
+
+    chart.append("svg:path")
+      .datum(data)
+      .attr("d", lineValues)
+      .attr("class", "chart-line");
 
     var yGridTickCount;
     if (yTickCount === 5) { yGridTickCount = 10 } else { yGridTickCount = yTickCount };

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -18,7 +18,7 @@ function barGraph(selector, url, metric) {
     var width = 600;
     var barWidth = 5;
     var height = 200;
-    var margin = { top: 20, right: 50, bottom: 100, left: 50 };
+    var margin = { top: 20, right: 50, bottom: 100, left: 40 };
     var calloutWidth = 200;
 
     var maxYValue = d3.max(data, function(datum) { return datum.values; });

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -15,10 +15,11 @@ function barGraph(selector, url, metric) {
       return {key: new Date(d[0]), values: d[1]};
     });
 
-    var width = 800;
+    var width = 600;
     var barWidth = 5;
     var height = 200;
     var margin = { top: 20, right: 50, bottom: 20, left: 50 };
+    var calloutWidth = 200;
 
     var maxYValue = d3.max(data, function(datum) { return datum.values; });
 
@@ -135,6 +136,16 @@ function barGraph(selector, url, metric) {
     var focus = chart.append("g")
       .attr("class", "focus");
 
+    var focusCallout = d3.select(selector)
+          .append("div")
+          .style("width", calloutWidth + "px")
+          .attr("class", "chart-callout")
+          .append("h5"),
+        focusCalloutValue = focusCallout.append("span")
+          .attr("class", "chart-callout-heading"),
+        focusCalloutDate = focusCallout.append("span")
+          .attr("class", "chart-callout-subheading");
+
     focus.append("circle")
       .attr("r", 5);
 
@@ -160,6 +171,18 @@ function barGraph(selector, url, metric) {
 
       focus.attr("transform", "translate(" + focusDefaultPosition.x + "," + focusDefaultPosition.y + ")");
       focus.select("text").text(finalPoint.values);
+
+      setCalloutText(finalPoint);
+    }
+
+    function setCalloutText(point) {
+      var weekEnd = d3.time.week.offset(point.key, 1),
+          weekStartFormat = d3.time.format("%d %b"),
+          weekEndFormat = d3.time.format("%d %b %Y"),
+          dateSpan = weekStartFormat(point.key) + " – " + weekEndFormat(weekEnd);
+
+      focusCalloutValue.text(point.values + " " + metric);
+      focusCalloutDate.text(dateSpan);
     }
 
     function mousemove() {
@@ -171,6 +194,8 @@ function barGraph(selector, url, metric) {
       yValue = height - y(d.values);
       focus.attr("transform", "translate(" + x(d.key) + "," + y(d.values) + ")");
       focus.select("text").text(d.values);
+
+      setCalloutText(d);
     }
   });
 

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -1,10 +1,10 @@
-function barGraph(selector, url, title) {
+function barGraph(selector, url, metric) {
 
   // Add the title
   var wrapper_element = document.querySelectorAll(selector)[0];
 
   var title_element = document.createElement('h4');
-  title_element.textContent = title;
+  title_element.textContent = "Number of " + metric + " over time";
 
   wrapper_element.insertBefore(title_element, wrapper_element.firstChild);
 

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -75,9 +75,9 @@ function barGraph(selector, url, metric) {
       .enter().append("svg:line")
       .attr("class", "xTicks")
       .attr("x1", x)
-      .attr("y1", height)
+      .attr("y1", height + 5)
       .attr("x2", x)
-      .attr("y2", height + 5)
+      .attr("y2", height + 10)
       .attr("stroke", "#888")
       .attr("stroke-width", "2px");
 
@@ -87,7 +87,7 @@ function barGraph(selector, url, metric) {
       .attr("class", "xAxisMonth")
       .attr("x", x)
       .attr("y", height)
-      .attr("dy", "20")
+      .attr("dy", "25")
       .attr("text-anchor", "middle")
       .text(d3.time.format("%b"));
 
@@ -97,7 +97,7 @@ function barGraph(selector, url, metric) {
       .attr("class", "xAxisYear")
       .attr("x", x)
       .attr("y", height + 8)
-      .attr("dy", "30")
+      .attr("dy", "35")
       .attr("text-anchor", "middle")
       .text(d3.time.format("%Y"));
 

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -39,13 +39,11 @@ function barGraph(selector, url, title) {
     var chart = d3.select(selector)
       .append("svg:svg")
       .attr("width", margin.left + width + margin.right)
-      .attr("height", margin.top + height + margin.bottom);
-
-    var axisGroup = chart
+      .attr("height", margin.top + height + margin.bottom)
       .append("g")
       .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
-    axisGroup.selectAll(".xTicks")
+    chart.selectAll(".xTicks")
       .data(x.ticks(d3.time.months.utc, 1))
       .enter().append("svg:line")
       .attr("class", "xTicks")
@@ -56,7 +54,7 @@ function barGraph(selector, url, title) {
       .attr("stroke", "#888")
       .attr("stroke-width", "2px");
 
-    axisGroup.selectAll("text.xAxisMonth")
+    chart.selectAll("text.xAxisMonth")
       .data(x.ticks(d3.time.months.utc, 3))
       .enter().append("text")
       .attr("class", "xAxisMonth")
@@ -66,7 +64,7 @@ function barGraph(selector, url, title) {
       .attr("text-anchor", "middle")
       .text(d3.time.format("%b"));
 
-    axisGroup.selectAll("text.xAxisYear")
+    chart.selectAll("text.xAxisYear")
       .data(x.ticks(d3.time.years.utc, 1))
       .enter().append("text")
       .attr("class", "xAxisYear")
@@ -76,7 +74,7 @@ function barGraph(selector, url, title) {
       .attr("text-anchor", "middle")
       .text(d3.time.format("%Y"));
 
-    axisGroup.selectAll("text.yAxis")
+    chart.selectAll("text.yAxis")
       .data(y.ticks(yTickCount))
       .enter().append("text")
       .attr("class", "yAxis")
@@ -93,14 +91,14 @@ function barGraph(selector, url, title) {
       y1(function(d) { return y(d.values); }).
       interpolate("monotone");
 
-    axisGroup.
+    chart.
       append("svg:path").
       attr("d", l(data)).
       attr("fill", "steelblue");
 
     var yGridTickCount;
     if (yTickCount === 5) { yGridTickCount = 10 } else { yGridTickCount = yTickCount };
-    axisGroup.selectAll(".yTicks")
+    chart.selectAll(".yTicks")
       .data(y.ticks(yGridTickCount))
       .enter().append("svg:line")
       .attr("class", "yTicks")

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -91,7 +91,7 @@ function barGraph(selector, url, title) {
       x(function(d) { return x(d.key); }).
       y0(height).
       y1(function(d) { return y(d.values); }).
-      interpolate("step-before");
+      interpolate("monotone");
 
     axisGroup.
       append("svg:path").

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -19,7 +19,7 @@ function barGraph(selector, url, metric) {
     var width = 600;
     var barWidth = 5;
     var height = 100;
-    var margin = { top: 20, right: 50, bottom: 100, left: 60 };
+    var margin = { top: 20, right: 30, bottom: 100, left: 50 };
     var viewPortWidth = margin.left + width + margin.right;
     var viewPortHeight = margin.top + height + margin.bottom;
 
@@ -48,7 +48,7 @@ function barGraph(selector, url, metric) {
     var yAxis = d3.svg.axis()
       .scale(y)
       .ticks(yTickCount)
-      .tickFormat(d3.format(0))
+      .tickFormat(d3.format("s"))
       .tickPadding(8)
       .orient("left");
 

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -18,7 +18,7 @@ function barGraph(selector, url, metric) {
     var width = 600;
     var barWidth = 5;
     var height = 200;
-    var margin = { top: 20, right: 50, bottom: 100, left: 40 };
+    var margin = { top: 20, right: 50, bottom: 100, left: 60 };
     var calloutWidth = 200;
 
     var maxYValue = d3.max(data, function(datum) { return datum.values; });
@@ -49,6 +49,7 @@ function barGraph(selector, url, metric) {
       .scale(y)
       .ticks(yTickCount)
       .tickFormat(d3.format(0))
+      .tickPadding(8)
       .orient("left");
 
     var xTickCount,
@@ -68,7 +69,8 @@ function barGraph(selector, url, metric) {
     var xAxis = d3.svg.axis()
       .scale(x)
       .ticks(xTickCount)
-      .tickFormat(xAxisDateFormats);
+      .tickFormat(xAxisDateFormats)
+      .tickPadding(8);
 
     // add the canvas to the DOM
     var chart = d3.select(selector)
@@ -91,11 +93,12 @@ function barGraph(selector, url, metric) {
 
     chart.append("g")
       .attr("class", "x-axis")
-      .attr("transform", "translate(0, " + height + ")")
+      .attr("transform", "translate(0, " + (height + 8) + ")")
       .call(xAxis);
 
     chart.append("g")
       .attr("class", "y-axis")
+      .attr("transform", "translate(-8, 0)")
       .call(yAxis);
 
     chart.append("svg:path")

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -33,6 +33,8 @@ function barGraph(selector, url, title) {
       .domain([0, maxYValue])
       .rangeRound([height, 0]);
 
+    var bisectDate = d3.bisector(function(d) { return d.key; }).left
+
     var yTickCount;
     if (maxYValue < 2) {
       yTickCount = 1;
@@ -129,6 +131,47 @@ function barGraph(selector, url, title) {
       .attr("clip-path", function(d) { return "url(#clip-" + d + ")"; })
       .datum(data)
       .attr("d", lineValues);
+
+    var focus = chart.append("g")
+      .attr("class", "focus");
+
+    focus.append("circle")
+      .attr("r", 5);
+
+    focus.append("text")
+      .attr("x", 9)
+      .attr("dy", -10);
+
+    focusDefault();
+
+    chart.append("rect")
+      .attr("class", "chart-overlay")
+      .attr("width", width)
+      .attr("height", height)
+      .on("mouseout", focusDefault)
+      .on("mousemove", mousemove);
+
+    function focusDefault() {
+      var finalPoint = data[data.length - 1],
+          focusDefaultPosition = {
+            x: x(finalPoint.key),
+            y: y(finalPoint.values)
+          };
+
+      focus.attr("transform", "translate(" + focusDefaultPosition.x + "," + focusDefaultPosition.y + ")");
+      focus.select("text").text(finalPoint.values);
+    }
+
+    function mousemove() {
+      var x0 = x.invert(d3.mouse(this)[0]),
+      i = bisectDate(data, x0, 1),
+      d0 = data[i - 1],
+      d1 = data[i],
+      d = x0 - d0.date > d1.date - x0 ? d1 : d0,
+      yValue = height - y(d.values);
+      focus.attr("transform", "translate(" + x(d.key) + "," + y(d.values) + ")");
+      focus.select("text").text(d.values);
+    }
   });
 
 }

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -72,6 +72,16 @@ function barGraph(selector, url, metric) {
       .tickFormat(xAxisDateFormats)
       .tickPadding(8);
 
+    var focusCallout = d3.select(selector)
+          .append("div")
+          .style("width", calloutWidth + "px")
+          .attr("class", "chart-callout")
+          .append("h5"),
+        focusCalloutValue = focusCallout.append("span")
+          .attr("class", "chart-callout-heading"),
+        focusCalloutDate = focusCallout.append("span")
+          .attr("class", "chart-callout-subheading");
+
     // add the canvas to the DOM
     var chart = d3.select(selector)
       .append("svg:svg")
@@ -137,16 +147,6 @@ function barGraph(selector, url, metric) {
 
     var focus = chart.append("g")
       .attr("class", "focus");
-
-    var focusCallout = d3.select(selector)
-          .append("div")
-          .style("width", calloutWidth + "px")
-          .attr("class", "chart-callout")
-          .append("h5"),
-        focusCalloutValue = focusCallout.append("span")
-          .attr("class", "chart-callout-heading"),
-        focusCalloutDate = focusCallout.append("span")
-          .attr("class", "chart-callout-subheading");
 
     focus.append("circle")
       .attr("r", 5);

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -98,6 +98,20 @@ function barGraph(selector, url, title) {
       .y1(function(d) { return y(d.values); })
       .interpolate("monotone");
 
+    // Clip the line a y(0) so 0 values are more prominent
+    chart.append("clipPath")
+      .attr("id", "clip-above")
+      .append("rect")
+      .attr("width", width)
+      .attr("height", y(0) - 1);
+
+    chart.append("clipPath")
+      .attr("id", "clip-below")
+      .append("rect")
+      .attr("y", y(0))
+      .attr("width", width)
+      .attr("height", height);
+
     var lineValues = d3.svg.line()
       .x(function(d) { return x(d.key); })
       .y(function(d) { return y(d.values); })
@@ -107,10 +121,14 @@ function barGraph(selector, url, title) {
       .attr("d", areaValues(data))
       .attr("class", "chart-area");
 
-    chart.append("svg:path")
+    chart.selectAll(".chart-line")
+      .data(["above", "below"])
+      .enter()
+      .append("path")
+      .attr("class", function(d) { return "chart-line chart-clipping-" + d; })
+      .attr("clip-path", function(d) { return "url(#clip-" + d + ")"; })
       .datum(data)
-      .attr("d", lineValues)
-      .attr("class", "chart-line");
+      .attr("d", lineValues);
 
     var yGridTickCount;
     if (yTickCount === 5) { yGridTickCount = 10 } else { yGridTickCount = yTickCount };

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -85,7 +85,7 @@ function barGraph(selector, url, title) {
       .attr("text-anchor", "end")
       .text(y.tickFormat(0));
 
-    var l = d3.svg.area().
+    var areaValues = d3.svg.area().
       x(function(d) { return x(d.key); }).
       y0(height).
       y1(function(d) { return y(d.values); }).
@@ -93,7 +93,7 @@ function barGraph(selector, url, title) {
 
     chart.
       append("svg:path").
-      attr("d", l(data)).
+      attr("d", areaValues(data)).
       attr("fill", "steelblue");
 
     var yGridTickCount;

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -79,7 +79,7 @@ function barGraph(selector, url, metric) {
       .attr("x2", x)
       .attr("y2", height + 10)
       .attr("stroke", "#888")
-      .attr("stroke-width", "2px");
+      .attr("stroke-width", "1px");
 
     chart.selectAll("text.xAxisMonth")
       .data(x.ticks(d3.time.months.utc, 3))

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -100,7 +100,7 @@ function barGraph(selector, url, title) {
 
     chart.append("svg:path")
       .attr("d", areaValues(data))
-      .attr("fill", "steelblue");
+      .attr("class", "chart-area");
 
     var yGridTickCount;
     if (yTickCount === 5) { yGridTickCount = 10 } else { yGridTickCount = yTickCount };

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -18,7 +18,7 @@ function barGraph(selector, url, metric) {
     var width = 600;
     var barWidth = 5;
     var height = 200;
-    var margin = { top: 20, right: 50, bottom: 20, left: 50 };
+    var margin = { top: 20, right: 50, bottom: 100, left: 50 };
     var calloutWidth = 200;
 
     var maxYValue = d3.max(data, function(datum) { return datum.values; });

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -4,6 +4,7 @@ function barGraph(selector, url, metric) {
   var wrapper_element = document.querySelectorAll(selector)[0];
 
   var title_element = document.createElement('h4');
+  title_element.classList.add("chart-title");
   title_element.textContent = "Number of " + metric + " over time";
 
   wrapper_element.insertBefore(title_element, wrapper_element.firstChild);
@@ -19,7 +20,8 @@ function barGraph(selector, url, metric) {
     var barWidth = 5;
     var height = 200;
     var margin = { top: 20, right: 50, bottom: 100, left: 60 };
-    var calloutWidth = 200;
+    var viewPortWidth = margin.left + width + margin.right;
+    var viewPortHeight = margin.top + height + margin.bottom;
 
     var maxYValue = d3.max(data, function(datum) { return datum.values; });
 
@@ -74,7 +76,6 @@ function barGraph(selector, url, metric) {
 
     var focusCallout = d3.select(selector)
           .append("div")
-          .style("width", calloutWidth + "px")
           .attr("class", "chart-callout")
           .append("h5"),
         focusCalloutValue = focusCallout.append("span")
@@ -84,9 +85,11 @@ function barGraph(selector, url, metric) {
 
     // add the canvas to the DOM
     var chart = d3.select(selector)
+      .attr("class", "chart chart-with-callout")
       .append("svg:svg")
-      .attr("width", margin.left + width + margin.right)
-      .attr("height", margin.top + height + margin.bottom)
+      .attr("width", "100%")
+      .attr("height", "100%")
+      .attr("viewBox", "0 0 " + viewPortWidth + " " + viewPortHeight )
       .append("g")
       .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -50,6 +50,17 @@ function barGraph(selector, url, title) {
       .append("g")
       .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
+    var areaValues = d3.svg.area()
+      .x(function(d) { return x(d.key); })
+      .y0(height)
+      .y1(function(d) { return y(d.values); })
+      .interpolate("monotone");
+
+    var lineValues = d3.svg.line()
+      .x(function(d) { return x(d.key); })
+      .y(function(d) { return y(d.values); })
+      .interpolate("monotone");
+
     chart.selectAll(".xTicks")
       .data(x.ticks(d3.time.months.utc, 1))
       .enter().append("svg:line")
@@ -92,11 +103,9 @@ function barGraph(selector, url, title) {
       .attr("text-anchor", "end")
       .text(y.tickFormat(0));
 
-    var areaValues = d3.svg.area()
-      .x(function(d) { return x(d.key); })
-      .y0(height)
-      .y1(function(d) { return y(d.values); })
-      .interpolate("monotone");
+    chart.append("svg:path")
+      .attr("d", areaValues(data))
+      .attr("class", "chart-area");
 
     // Clip the line a y(0) so 0 values are more prominent
     chart.append("clipPath")
@@ -111,15 +120,6 @@ function barGraph(selector, url, title) {
       .attr("y", y(0))
       .attr("width", width)
       .attr("height", height);
-
-    var lineValues = d3.svg.line()
-      .x(function(d) { return x(d.key); })
-      .y(function(d) { return y(d.values); })
-      .interpolate("monotone");
-
-    chart.append("svg:path")
-      .attr("d", areaValues(data))
-      .attr("class", "chart-area");
 
     chart.selectAll(".chart-line")
       .data(["above", "below"])

--- a/app/assets/javascripts/stacked_area_chart.js
+++ b/app/assets/javascripts/stacked_area_chart.js
@@ -66,7 +66,7 @@ function stackedAreaTimeseries(selector, url, title) {
       .append("g")
       .attr("transform", "translate(" + margin + "," + margin + ")");
 
-    d3.json(url, function(data, error) {
+    d3.json(url, function(error, data) {
       if (error) return console.warn(error);
 
       data.forEach(function(d) {

--- a/app/assets/stylesheets/partials/_charts.scss
+++ b/app/assets/stylesheets/partials/_charts.scss
@@ -20,8 +20,7 @@ $chart-line-color: lighten($dark, 20%);
   .x-axis {
     line {
       stroke: #888;
-      stroke-width: .125em;
-      shape-rendering: crispEdges;
+      stroke-width: 1px;
     }
 
     .domain {

--- a/app/assets/stylesheets/partials/_charts.scss
+++ b/app/assets/stylesheets/partials/_charts.scss
@@ -9,6 +9,12 @@ $chart-line-color: lighten($dark, 20%);
   .chart-area {
     fill: $chart-fill-color;
   }
+
+  .y-axis {
+    .domain {
+      display: none;
+    }
+  }
 }
 
 .chart-line {
@@ -28,12 +34,6 @@ $chart-line-color: lighten($dark, 20%);
       fill: none;
       stroke: #888;
       stroke-width: 2px;
-    }
-  }
-
-  .y-axis {
-    .domain {
-      display: none;
     }
   }
 }

--- a/app/assets/stylesheets/partials/_charts.scss
+++ b/app/assets/stylesheets/partials/_charts.scss
@@ -1,0 +1,23 @@
+.chart {
+  text {
+    fill: $font-color;
+    font-size: .875em;
+  }
+}
+
+.chart-area-stacked {
+  .axis {
+    line,
+    path {
+      fill: none;
+      stroke: #888;
+      stroke-width: 2px;
+    }
+  }
+
+  .y-axis {
+    .domain {
+      display: none;
+    }
+  }
+}

--- a/app/assets/stylesheets/partials/_charts.scss
+++ b/app/assets/stylesheets/partials/_charts.scss
@@ -1,6 +1,8 @@
 $chart-fill-color: lighten($dark, 65%);
 $chart-line-color: lighten($dark, 20%);
 .chart {
+  @include clearfix();
+
   text {
     fill: $font-color;
     font-size: .875em;
@@ -52,8 +54,9 @@ $chart-line-color: lighten($dark, 20%);
 }
 
 .chart-callout {
-  display: block;
-  float: right;
+  @include at-breakpoint(40em) {
+    float: right;
+  }
 }
 
 .chart-callout-heading {

--- a/app/assets/stylesheets/partials/_charts.scss
+++ b/app/assets/stylesheets/partials/_charts.scss
@@ -1,3 +1,5 @@
+$chart-fill-color: lighten($dark, 65%);
+$chart-line-color: lighten($dark, 20%);
 .chart {
   text {
     fill: $font-color;
@@ -5,13 +7,13 @@
   }
 
   .chart-area {
-    fill: lighten($dark, 40%);
+    fill: $chart-fill-color;
   }
 }
 
 .chart-line {
   fill: none;
-  stroke: $dark;
+  stroke: $chart-line-color;
   stroke-width: 2px;
 
   &.chart-clipping-below {

--- a/app/assets/stylesheets/partials/_charts.scss
+++ b/app/assets/stylesheets/partials/_charts.scss
@@ -3,6 +3,10 @@ $chart-line-color: lighten($dark, 20%);
 .chart {
   @include clearfix();
 
+  svg {
+    overflow: visible;
+  }
+
   text {
     fill: $font-color;
     font-size: .875em;
@@ -24,6 +28,12 @@ $chart-line-color: lighten($dark, 20%);
       display: none;
     }
   }
+}
+
+.chart-title {
+  width: 100%;
+  float: none;
+  clear: both;
 }
 
 .x-axis-baseline {
@@ -53,9 +63,31 @@ $chart-line-color: lighten($dark, 20%);
   }
 }
 
-.chart-callout {
-  @include at-breakpoint(40em) {
-    float: right;
+.chart-with-callout {
+  svg {
+    width: 100%;
+    height: auto;
+
+    @include at-breakpoint(40em) {
+      float: left;
+      clear: left;
+      width: 80%;
+    }
+  }
+
+  .chart-callout {
+    @include at-breakpoint(40em) {
+      float: right;
+      width: 20%;
+    }
+  }
+
+  text {
+    font-size: 1em;
+
+    @include at-breakpoint(40em) {
+      font-size: .875em;
+    }
   }
 }
 

--- a/app/assets/stylesheets/partials/_charts.scss
+++ b/app/assets/stylesheets/partials/_charts.scss
@@ -37,3 +37,16 @@ $chart-line-color: lighten($dark, 20%);
     }
   }
 }
+
+.chart-overlay {
+  fill: none;
+  pointer-events: all;
+}
+
+.focus {
+  circle {
+    stroke: $chart-line-color;
+    stroke-width: 2px;
+    fill: transparent;
+  }
+}

--- a/app/assets/stylesheets/partials/_charts.scss
+++ b/app/assets/stylesheets/partials/_charts.scss
@@ -17,15 +17,7 @@ $chart-line-color: lighten($dark, 20%);
       stroke-width: .125em;
       shape-rendering: crispEdges;
     }
-  }
 
-  .y-axis {
-    .domain {
-      display: none;
-    }
-  }
-
-  .x-axis {
     .domain {
       display: none;
     }

--- a/app/assets/stylesheets/partials/_charts.scss
+++ b/app/assets/stylesheets/partials/_charts.scss
@@ -10,7 +10,22 @@ $chart-line-color: lighten($dark, 20%);
     fill: $chart-fill-color;
   }
 
+  .y-axis,
+  .x-axis {
+    line {
+      stroke: #888;
+      stroke-width: .125em;
+      shape-rendering: crispEdges;
+    }
+  }
+
   .y-axis {
+    .domain {
+      display: none;
+    }
+  }
+
+  .x-axis {
     .domain {
       display: none;
     }

--- a/app/assets/stylesheets/partials/_charts.scss
+++ b/app/assets/stylesheets/partials/_charts.scss
@@ -24,6 +24,12 @@ $chart-line-color: lighten($dark, 20%);
   }
 }
 
+.x-axis-baseline {
+  fill: none;
+  stroke: #ccc;
+  stroke-width: 2px;
+}
+
 .chart-line {
   fill: none;
   stroke: $chart-line-color;

--- a/app/assets/stylesheets/partials/_charts.scss
+++ b/app/assets/stylesheets/partials/_charts.scss
@@ -3,6 +3,10 @@
     fill: $font-color;
     font-size: .875em;
   }
+
+  .chart-area {
+    fill: steelblue;
+  }
 }
 
 .chart-area-stacked {

--- a/app/assets/stylesheets/partials/_charts.scss
+++ b/app/assets/stylesheets/partials/_charts.scss
@@ -12,7 +12,7 @@
 .chart-line {
   fill: none;
   stroke: $dark;
-  stroke-width: 3px;
+  stroke-width: 2px;
 
   &.chart-clipping-below {
     display: none;

--- a/app/assets/stylesheets/partials/_charts.scss
+++ b/app/assets/stylesheets/partials/_charts.scss
@@ -5,8 +5,14 @@
   }
 
   .chart-area {
-    fill: steelblue;
+    fill: lighten($dark, 40%);
   }
+}
+
+.chart-line {
+  fill: none;
+  stroke: $dark;
+  stroke-width: 3px;
 }
 
 .chart-area-stacked {

--- a/app/assets/stylesheets/partials/_charts.scss
+++ b/app/assets/stylesheets/partials/_charts.scss
@@ -38,6 +38,20 @@ $chart-line-color: lighten($dark, 20%);
   }
 }
 
+.chart-callout {
+  display: block;
+  float: right;
+}
+
+.chart-callout-heading {
+  display: block;
+}
+
+.chart-callout-subheading {
+  display: block;
+  font-weight: normal;
+}
+
 .chart-overlay {
   fill: none;
   pointer-events: all;

--- a/app/assets/stylesheets/partials/_charts.scss
+++ b/app/assets/stylesheets/partials/_charts.scss
@@ -13,6 +13,10 @@
   fill: none;
   stroke: $dark;
   stroke-width: 3px;
+
+  &.chart-clipping-below {
+    display: none;
+  }
 }
 
 .chart-area-stacked {

--- a/app/assets/stylesheets/partials/_page.scss
+++ b/app/assets/stylesheets/partials/_page.scss
@@ -563,31 +563,6 @@ form.address-search {
   }
 }
 
-// Style chart on authority detail page
-.chart {
-  text {
-    fill: $font-color;
-    font-size: .875em;
-  }
-}
-
-.chart-area-stacked {
-  .axis {
-    line,
-    path {
-      fill: none;
-      stroke: #888;
-      stroke-width: 2px;
-    }
-  }
-
-  .y-axis {
-    .domain {
-      display: none;
-    }
-  }
-}
-
 // Prototype of possible widget for signing up to email alerts
 .widget-prototype {
   width: 700px;

--- a/app/assets/stylesheets/screen.scss
+++ b/app/assets/stylesheets/screen.scss
@@ -26,6 +26,7 @@ body {
 @import "partials/grid";
 @import "partials/comments";
 @import "partials/flash_messages";
+@import "partials/charts";
 
 @import "atdis";
 @import "jquery-ui/core";

--- a/app/views/authorities/show.html.haml
+++ b/app/views/authorities/show.html.haml
@@ -35,13 +35,13 @@
       barGraph(
         "#applications-chart",
         "#{per_week_authority_applications_url(@authority.short_name_encoded, :format => 'js')}",
-        "Number of applications scraped each week"
+        "applications scraped"
       );
 
       barGraph(
         "#comments-chart",
         "#{per_week_authority_comments_url(@authority.short_name_encoded, format: :json)}",
-        "Number of comments posted each week"
+        "comments posted"
       );
 
   = render "under_the_hood"

--- a/app/views/authorities/show.html.haml
+++ b/app/views/authorities/show.html.haml
@@ -29,7 +29,7 @@
     #applications-chart.chart
     #comments-chart.chart
 
-    = javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/d3/2.10.0/d3.v2.min.js"
+    = javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.12/d3.min.js"
     = javascript_include_tag "bar_graph"
     :javascript
       barGraph(

--- a/app/views/performance/index.html.haml
+++ b/app/views/performance/index.html.haml
@@ -22,7 +22,7 @@
         %td= day[:first_time_commenters]
         %td= day[:returning_commenters]
 
-= javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/d3/2.10.0/d3.v2.min.js"
+= javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.12/d3.min.js"
 = javascript_include_tag "stacked_area_chart"
 :javascript
   stackedAreaTimeseries(


### PR DESCRIPTION
This iterates on the previous update of the charts on the authority pages, to keep and improve the current usefulness of the chart and make them also look nicer.

This removes the noisy horizontal lines and changes the stepped chart for a slight curved interpolated line. This visually simplifies the chart, I think making it simpler to read. To compensate for removing the lines and interpolating the data, this adds tick marks back to the axis and also adds a 'callout' of the values and period under the cursor so you can still (and I think even more) get the precise detail of what you're looking at.

The 'callout' design pattern comes from the [GDS performance](https://www.gov.uk/performance/carers-allowance) examples, but this is a basic version. I wish we could just use their scripts completely, but as far as I can tell that would be pretty tricky.

@henare could you review this please? Is there anything else you can think to improve it at this point?

Fixes #884

## Before
![screen shot 2016-01-12 at 4 10 38 pm](https://cloud.githubusercontent.com/assets/1239550/12255550/ee54f61e-b948-11e5-93f1-0819c1eb9380.png)

## After
![screen shot 2016-01-12 at 4 08 02 pm](https://cloud.githubusercontent.com/assets/1239550/12255547/eb42a598-b948-11e5-9de7-66ab7e0f727b.png)