### PR TITLE
Set radius to float as expected by meters_in_words helper method.

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -41,7 +41,7 @@ class ApplicationsController < ApplicationController
 
   def address
     @q = params[:q]
-    @radius = params[:radius] || 2000
+    @radius = params[:radius].to_f || 2000
     @sort = params[:sort] || 'time'
     per_page = 30
     @page = params[:page]
@@ -56,9 +56,9 @@ class ApplicationsController < ApplicationController
         @other_addresses = location.all[1..-1].map{|l| l.full_address}
         @applications = case @sort
                         when 'distance'
-                          Application.near([location.lat, location.lng], @radius.to_f / 1000, units: :km).reorder('distance').paginate(page: params[:page], per_page: per_page)
+                          Application.near([location.lat, location.lng], @radius / 1000, units: :km).reorder('distance').paginate(page: params[:page], per_page: per_page)
                         else # date_scraped
-                          Application.near([location.lat, location.lng], @radius.to_f / 1000, units: :km).paginate(page: params[:page], per_page: per_page)
+                          Application.near([location.lat, location.lng], @radius / 1000, units: :km).paginate(page: params[:page], per_page: per_page)
                         end
         @rss = applications_path(format: 'rss', address: @q, radius: @radius)
       end


### PR DESCRIPTION
Make radius instance variable a float to stop errors on radius searches.

Fixes #670 and what appears to be a duplicate issue #776