### PR TITLE
When checking state exceptions account for surrounding punctuation.

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -126,7 +126,7 @@ class Application < ActiveRecord::Base
 
     if address
       address.split(' ').map do |word|
-        if word != word.upcase || exceptions.include?(word) || word =~ /\d/
+        if word != word.upcase || exceptions.any? { |exception| word =~ /^\W*#{exception}\W*$/ } || word =~ /\d/
           word
         else
           word.capitalize

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -133,6 +133,10 @@ describe Application do
       build(:application, address: "QLD VIC NSW SA ACT TAS WA NT").address.should == "QLD VIC NSW SA ACT TAS WA NT"
     end
 
+    it "should not affect the state names with punctuation" do
+      build(:application, address: "QLD. ,VIC ,NSW, !SA /ACT/ TAS: WA, NT;").address.should == "QLD. ,VIC ,NSW, !SA /ACT/ TAS: WA, NT;"
+    end
+
     it "should not affect codes" do
       build(:application, address: "R79813 24X").address.should == "R79813 24X"
     end


### PR DESCRIPTION
Issue #625 looks to be caused by the state in the address being immediately bordered by punctuation. This changes the check to use a regexp to allow the possibility of non word characters before and after states.

Fixes #625