### PR TITLE
Allow admins to control whether people can write to councillors for each authority

### DIFF
--- a/app/admin/authorities.rb
+++ b/app/admin/authorities.rb
@@ -8,6 +8,7 @@ ActiveAdmin.register Authority do
     column "Name", :full_name
     column :state
     column :email
+    column :write_to_councillors_enabled
     column(:number_of_applications) { |a| a.applications.count }
     column(:number_of_comments) { |a| a.comments.count }
     actions
@@ -19,6 +20,7 @@ ActiveAdmin.register Authority do
       row :short_name
       row :state
       row :email
+      row :write_to_councillors_enabled
       row :population_2011
       row :morph_name
       row :disabled
@@ -42,6 +44,7 @@ ActiveAdmin.register Authority do
       input :state
       input :email
       input :population_2011
+      input :write_to_councillors_enabled
     end
     inputs "Scraping" do
       input :morph_name, hint: "The name of the scraper at morph.io", placeholder: "planningalerts-scrapers/scraper-blue-mountains"
@@ -64,6 +67,7 @@ ActiveAdmin.register Authority do
     column :full_name
     column :short_name
     column :disabled
+    column :write_to_councillors_enabled
     column :state
     column :email
     column :population_2011
@@ -72,5 +76,5 @@ ActiveAdmin.register Authority do
     column(:number_of_comments) { |a| a.comments.count }
   end
 
-  permit_params :full_name, :short_name, :state, :email, :population_2011, :morph_name, :disabled
+  permit_params :full_name, :short_name, :state, :email, :write_to_councillors_enabled, :population_2011, :morph_name, :disabled
 end

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -159,6 +159,6 @@ class ApplicationsController < ApplicationController
   private
 
   def writing_to_councillors_enabled?
-    ENV["COUNCILLORS_ENABLED"] == "true" && @theme == "default"
+    @application.authority.write_to_councillors_enabled? && @theme == "default"
   end
 end

--- a/app/models/authority.rb
+++ b/app/models/authority.rb
@@ -244,6 +244,10 @@ class Authority < ActiveRecord::Base
     email && email != ""
   end
 
+  def write_to_councillors_enabled?
+    ENV["COUNCILLORS_ENABLED"] == "true"
+  end
+
   def latest_application
     # The applications are sorted by default by the date_scraped because of the default scope on the model
     applications.first

--- a/app/models/authority.rb
+++ b/app/models/authority.rb
@@ -245,7 +245,7 @@ class Authority < ActiveRecord::Base
   end
 
   def write_to_councillors_enabled?
-    ENV["COUNCILLORS_ENABLED"] == "true"
+    ENV["COUNCILLORS_ENABLED"] == "true" ? write_to_councillors_enabled : false
   end
 
   def latest_application

--- a/db/migrate/20160301033011_add_write_to_councillors_enabled_to_authority.rb
+++ b/db/migrate/20160301033011_add_write_to_councillors_enabled_to_authority.rb
@@ -1,0 +1,9 @@
+class AddWriteToCouncillorsEnabledToAuthority < ActiveRecord::Migration
+  def self.up
+    add_column :authorities, :write_to_councillors_enabled, :boolean, null: false, default: false
+  end
+
+  def self.down
+    remove_column :authorities, :write_to_councillors_enabled
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160104033929) do
+ActiveRecord::Schema.define(version: 20160301033011) do
 
   create_table "active_admin_comments", force: true do |t|
     t.string   "resource_id",   null: false
@@ -103,6 +103,7 @@ ActiveRecord::Schema.define(version: 20160104033929) do
     t.integer "population_2011"
     t.text    "last_scraper_run_log"
     t.string  "morph_name"
+    t.boolean "write_to_councillors_enabled",             default: false, null: false
   end
 
   add_index "authorities", ["short_name"], name: "short_name_unique", unique: true, using: :btree

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -80,7 +80,7 @@ feature "Give feedback to Council" do
       end
 
       background do
-        application.authority.update(write_to_councillors_enabled: true)
+        application.authority.update!(write_to_councillors_enabled: true)
 
         create(:councillor, authority: application.authority)
       end

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -80,7 +80,7 @@ feature "Give feedback to Council" do
       end
 
       background do
-        application.authority.update_attribute(:write_to_councillors_enabled, true)
+        application.authority.update(write_to_councillors_enabled: true)
 
         create(:councillor, authority: application.authority)
       end

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -80,6 +80,8 @@ feature "Give feedback to Council" do
       end
 
       background do
+        application.authority.update_attribute(:write_to_councillors_enabled, true)
+
         create(:councillor, authority: application.authority)
       end
 

--- a/spec/features/write_to_councillors_spec.rb
+++ b/spec/features/write_to_councillors_spec.rb
@@ -6,8 +6,8 @@ feature "Send a message to a councillor" do
   # so that I can get their help or feedback
   # and find out where they stand on this development I care about
 
-  context "when writing to councillors is not globally enabled" do
-    given(:authority) { create(:authority, full_name: "Foo") }
+  context "when writing to councillors is unavailable" do
+    given(:authority) { create(:authority, full_name: "Foo", write_to_councillors_enabled: false) }
 
     background do
       VCR.use_cassette('planningalerts') do
@@ -35,8 +35,8 @@ feature "Send a message to a councillor" do
     end
   end
 
-  context "when writing to councillors is globally enabled" do
-    given(:authority) { create(:contactable_authority, full_name: "Marrickville Council") }
+  context "when writing to councillors is available" do
+    given(:authority) { create(:contactable_authority, full_name: "Marrickville Council", write_to_councillors_enabled: true) }
     given(:application) { VCR.use_cassette('planningalerts') { create(:application, id: "1", authority: authority) } }
 
     around do |test|

--- a/spec/models/authority_spec.rb
+++ b/spec/models/authority_spec.rb
@@ -40,6 +40,34 @@ describe Authority do
     end
   end
 
+  describe "#write_to_councillors_enabled?" do
+    let(:authority) { build_stubbed(:authority) }
+
+    context "when it is globally not enabled" do
+      around do |test|
+        with_modified_env COUNCILLORS_ENABLED: nil do
+          test.run
+        end
+      end
+
+      it { expect(authority.write_to_councillors_enabled?).to eq false }
+    end
+
+    context "when it is globally enabled" do
+      around do |test|
+        with_modified_env COUNCILLORS_ENABLED: "true" do
+          test.run
+        end
+      end
+
+      it { expect(authority.write_to_councillors_enabled?).to eq true }
+    end
+
+    def with_modified_env(options, &block)
+      ClimateControl.modify(options, &block)
+    end
+  end
+
   describe "#comments_per_week" do
     let(:authority) { create(:authority) }
 

--- a/spec/models/authority_spec.rb
+++ b/spec/models/authority_spec.rb
@@ -41,8 +41,6 @@ describe Authority do
   end
 
   describe "#write_to_councillors_enabled?" do
-    let(:authority) { build_stubbed(:authority) }
-
     context "when it is globally not enabled" do
       around do |test|
         with_modified_env COUNCILLORS_ENABLED: nil do
@@ -50,7 +48,17 @@ describe Authority do
         end
       end
 
-      it { expect(authority.write_to_councillors_enabled?).to eq false }
+      context "and it is disabled on the authority" do
+        let(:authority) { build_stubbed(:authority, write_to_councillors_enabled: false) }
+
+        it { expect(authority.write_to_councillors_enabled?).to eq false }
+      end
+
+      context "and it is enabled on the authority" do
+        let(:authority) { build_stubbed(:authority, write_to_councillors_enabled: true) }
+
+        it { expect(authority.write_to_councillors_enabled?).to eq false }
+      end
     end
 
     context "when it is globally enabled" do
@@ -60,7 +68,17 @@ describe Authority do
         end
       end
 
-      it { expect(authority.write_to_councillors_enabled?).to eq true }
+      context "and it is disabled on the authority" do
+        let(:authority) { build_stubbed(:authority, write_to_councillors_enabled: false) }
+
+        it { expect(authority.write_to_councillors_enabled?).to eq false }
+      end
+
+      context "and it is enabled on the authority" do
+        let(:authority) { build_stubbed(:authority, write_to_councillors_enabled: true) }
+
+        it { expect(authority.write_to_councillors_enabled?).to eq true }
+      end
     end
 
     def with_modified_env(options, &block)

--- a/spec/views/applications/show_spec.rb
+++ b/spec/views/applications/show_spec.rb
@@ -12,7 +12,7 @@ describe "applications/show" do
     assigns[:comment] = mock_model(Comment, errors: errors, text: nil, name: nil, email: nil)
     Vanity.context = Struct.new(:vanity_identity).new('1')
   end
-  
+
   describe "show" do
     before :each do
       @application.stub(:address).and_return("foo")
@@ -20,15 +20,15 @@ describe "applications/show" do
       @application.stub(:lng).and_return(2.0)
       @application.stub(:location).and_return(Location.new(1.0, 2.0))
     end
-    
+
     it "should display the map" do
       @application.stub(:date_received).and_return(nil)
       @application.stub(:date_scraped).and_return(Time.now)
       assigns[:application] = @application
       render
-      rendered.should have_selector("div#map_div")      
+      rendered.should have_selector("div#map_div")
     end
-    
+
     it "should say nothing about notice period when there is no information" do
       @application.stub(:date_received).and_return(nil)
       @application.stub(:date_scraped).and_return(Time.now)
@@ -39,7 +39,7 @@ describe "applications/show" do
       rendered.should_not have_selector("p.on_notice")
     end
   end
-  
+
   describe "show with application with no location" do
     it "should not display the map" do
       @application.stub(:address).and_return("An address that can't be geocoded")
@@ -49,7 +49,7 @@ describe "applications/show" do
       @application.stub(:date_received).and_return(nil)
       @application.stub(:date_scraped).and_return(Time.now)
       assigns[:application] = @application
-        
+
       render
       rendered.should_not have_selector("div#map_div")
     end


### PR DESCRIPTION
To control the roll out of the Write To Councillors feature, admins should be able to toggle the feature on or off for an individual authority.

These commits add that control by adding “Write to councillors enabled” checkbox to the authority admin page. Under the hood it's a new boolean attribute to authorities `write_to_councillors_enabled`.

This now means that both the global feature flag (environment variable) and the flag for the authority must be enabled to make Write To Councillors available for an authority. This adjusts the integration tests for commenting and writing to councillors accordingly.

![screen shot 2016-03-01 at 5 40 55 pm](https://cloud.githubusercontent.com/assets/1239550/13419782/e6d45a4e-dfd4-11e5-8237-9bb27272c771.png)
![screen shot 2016-03-01 at 5 40 44 pm](https://cloud.githubusercontent.com/assets/1239550/13419783/e6d647e6-dfd4-11e5-961d-1cdbdc2cb1f3.png)

**Very sloppily this PR includes a clean up of whitespace on a view spec where I first started this working through this :( **