### PR TITLE
Show and sort comments with the time they were confirmed_at

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -101,7 +101,7 @@ class ApplicationsController < ApplicationController
     end
 
     @application = Application.find(params[:id])
-    @comments = @application.comments.visible.order(:updated_at)
+    @comments = @application.comments.visible.order(:confirmed_at)
     @nearby_count = @application.find_all_nearest_or_recent.size
     @add_comment = AddComment.new(
       application: @application,

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -11,7 +11,7 @@ class CommentsController < ApplicationController
       comments_to_display = Comment.all
     end
 
-    @comments = comments_to_display.visible.order("updated_at DESC").paginate page: params[:page]
+    @comments = comments_to_display.visible.order("confirmed_at DESC").paginate page: params[:page]
     @rss = comments_url(params.merge(format: "rss", page: nil))
 
     respond_to do |format|

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -113,7 +113,11 @@ class Alert < ActiveRecord::Base
 
   # Applications in the area of interest which have new comments made since we were last alerted
   def applications_with_new_comments
-    Application.near([location.lat, location.lng], radius_km, units: :km).joins(:comments).where('comments.updated_at > ?', cutoff_time).where('comments.confirmed' => true).where('comments.hidden' => false).uniq
+    Application.near([location.lat, location.lng], radius_km, units: :km)
+               .joins(:comments)
+               .where('comments.updated_at > ?', cutoff_time)
+               .where('comments.confirmed' => true)
+               .where('comments.hidden' => false).uniq
   end
 
   def applications_with_new_replies

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -115,7 +115,7 @@ class Alert < ActiveRecord::Base
   def applications_with_new_comments
     Application.near([location.lat, location.lng], radius_km, units: :km)
                .joins(:comments)
-               .where('comments.updated_at > ?', cutoff_time)
+               .where('comments.confirmed_at > ?', cutoff_time)
                .where('comments.confirmed' => true)
                .where('comments.hidden' => false).uniq
   end
@@ -131,7 +131,7 @@ class Alert < ActiveRecord::Base
     comments = []
     # Doing this in this roundabout way because I'm not sure how to use "near" together with joins
     applications_with_new_comments.each do |application|
-      comments += application.comments.visible.where('comments.updated_at > ?', cutoff_time)
+      comments += application.comments.visible.where('comments.confirmed_at > ?', cutoff_time)
     end
     comments
   end

--- a/app/models/authority.rb
+++ b/app/models/authority.rb
@@ -189,7 +189,7 @@ class Authority < ActiveRecord::Base
     if applications.any?
       # Have to compensate for MySQL which treats Monday as the beginning of the week
       results = comments.visible.group(
-        "CAST(SUBDATE(updated_at, WEEKDAY(updated_at) + 1) AS DATE)"
+        "CAST(SUBDATE(confirmed_at, WEEKDAY(confirmed_at) + 1) AS DATE)"
       ).count
 
       earliest_week_with_applications = earliest_date.at_beginning_of_week.to_date

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -24,6 +24,17 @@ class Comment < ActiveRecord::Base
     .select {|c| where("email = ? AND created_at < ?", c.email, c.created_at.to_date).any? }
   }
 
+  # TODO: This was for use in a specific migration,
+  #       inline this code into the migration once it's run and remove
+  #       this method so it's not hanging around here and in the test suit.
+  def self.fill_confirmed_at_for_existing_confirmed_comments
+    Comment.confirmed.each do |comment|
+      if comment.confirmed_at.nil?
+        comment.update!(confirmed_at: comment.updated_at)
+      end
+    end
+  end
+
   # Send the comment to the planning authority
   def after_confirm
     if to_councillor?

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -11,17 +11,17 @@ class Comment < ActiveRecord::Base
   scope :in_past_week, -> { where("created_at > ?", 7.days.ago) }
 
   scope :visible_with_unique_emails_for_date, ->(date) {
-    visible.where("date(created_at) = ?", date).group(:email)
+    visible.where("date(confirmed_at) = ?", date).group(:email)
   }
 
   scope :by_first_time_commenters_for_date, ->(date) {
     visible_with_unique_emails_for_date(date)
-    .select {|c| where("email = ? AND created_at < ?", c.email, c.created_at.to_date).empty? }
+    .select {|c| where("email = ? AND confirmed_at < ?", c.email, c.confirmed_at.to_date).empty? }
   }
 
   scope :by_returning_commenters_for_date, ->(date) {
     visible_with_unique_emails_for_date(date)
-    .select {|c| where("email = ? AND created_at < ?", c.email, c.created_at.to_date).any? }
+    .select {|c| where("email = ? AND confirmed_at < ?", c.email, c.confirmed_at.to_date).any? }
   }
 
   # TODO: This was for use in a specific migration,

--- a/app/views/comments/_comment_meta_sentence.html.haml
+++ b/app/views/comments/_comment_meta_sentence.html.haml
@@ -7,5 +7,5 @@
 %span.comment-time-block
   = "commented" unless comment.to_councillor?
   = link_to comment_path(comment), title: "View comment" do
-    %time.comment-time{datetime: comment.updated_at.strftime("%F")}
-      #{time_ago_in_words(comment.updated_at)} ago
+    %time.comment-time{datetime: comment.confirmed_at.strftime("%F")}
+      #{time_ago_in_words(comment.confirmed_at)} ago

--- a/db/migrate/20160329044846_add_confirmed_at_to_comment.rb
+++ b/db/migrate/20160329044846_add_confirmed_at_to_comment.rb
@@ -1,0 +1,5 @@
+class AddConfirmedAtToComment < ActiveRecord::Migration
+  def change
+    add_column :comments, :confirmed_at, :datetime
+  end
+end

--- a/db/migrate/20160330040409_fill_confirmed_at_for_comments.rb
+++ b/db/migrate/20160330040409_fill_confirmed_at_for_comments.rb
@@ -1,0 +1,5 @@
+class FillConfirmedAtForComments < ActiveRecord::Migration
+  def change
+    Comment.fill_confirmed_at_for_existing_confirmed_comments
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160301033011) do
+ActiveRecord::Schema.define(version: 20160329044846) do
 
   create_table "active_admin_comments", force: true do |t|
     t.string   "resource_id",   null: false
@@ -121,6 +121,7 @@ ActiveRecord::Schema.define(version: 20160301033011) do
     t.boolean  "hidden",         default: false,     null: false
     t.string   "theme",          default: "default", null: false
     t.integer  "councillor_id"
+    t.datetime "confirmed_at"
   end
 
   add_index "comments", ["application_id"], name: "index_comments_on_application_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160329044846) do
+ActiveRecord::Schema.define(version: 20160330040409) do
 
   create_table "active_admin_comments", force: true do |t|
     t.string   "resource_id",   null: false

--- a/lib/email_confirmable/email_confirmable/acts_as_email_confirmable.rb
+++ b/lib/email_confirmable/email_confirmable/acts_as_email_confirmable.rb
@@ -20,6 +20,7 @@ module EmailConfirmable
   module InstanceMethods
     def confirm!
       self.confirmed = true
+      self.confirmed_at = Time.current if self.has_attribute? :confirmed_at
       save!
       after_confirm if self.respond_to?(:after_confirm)
     end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -39,10 +39,10 @@ describe CommentsController do
           id: 1
         )
 
-        create(:confirmed_comment, application_id: 1, updated_at: Date.new(2015,12,26))
-        create(:confirmed_comment, application_id: 1, updated_at: Date.new(2015,12,26))
-        create(:confirmed_comment, application_id: 1, updated_at: Date.new(2015,12,26))
-        create(:confirmed_comment, application_id: 1, updated_at: Date.new(2016,1,4))
+        create(:confirmed_comment, application_id: 1, confirmed_at: Date.new(2015,12,26))
+        create(:confirmed_comment, application_id: 1, confirmed_at: Date.new(2015,12,26))
+        create(:confirmed_comment, application_id: 1, confirmed_at: Date.new(2015,12,26))
+        create(:confirmed_comment, application_id: 1, confirmed_at: Date.new(2016,1,4))
       end
 
       get_authority_comments_per_week

--- a/spec/controllers/performance_controller_spec.rb
+++ b/spec/controllers/performance_controller_spec.rb
@@ -19,12 +19,12 @@ describe PerformanceController do
     context "when there are comments" do
       before do
         VCR.use_cassette('planningalerts', allow_playback_repeats: true) do
-          create(:confirmed_comment, created_at: 2.days.ago.to_date, email: "foo@example.com")
-          create(:confirmed_comment, created_at: 2.days.ago.to_date, email: "foo@example.com")
-          create(:confirmed_comment, created_at: 2.days.ago.to_date, email: "bar@example.com")
-          create(:confirmed_comment, created_at: 90.days.ago.to_date, email: "foo@example.com")
-          create(:confirmed_comment, created_at: 90.days.ago.to_date, email: "bar@example.com")
-          create(:confirmed_comment, created_at: 90.days.ago.to_date, email: "wiz@example.com")
+          create(:confirmed_comment, confirmed_at: 2.days.ago.to_date, email: "foo@example.com")
+          create(:confirmed_comment, confirmed_at: 2.days.ago.to_date, email: "foo@example.com")
+          create(:confirmed_comment, confirmed_at: 2.days.ago.to_date, email: "bar@example.com")
+          create(:confirmed_comment, confirmed_at: 90.days.ago.to_date, email: "foo@example.com")
+          create(:confirmed_comment, confirmed_at: 90.days.ago.to_date, email: "bar@example.com")
+          create(:confirmed_comment, confirmed_at: 90.days.ago.to_date, email: "wiz@example.com")
         end
       end
       it "returns an empty Array as json" do

--- a/spec/controllers/performance_controller_spec.rb
+++ b/spec/controllers/performance_controller_spec.rb
@@ -27,6 +27,8 @@ describe PerformanceController do
           create(:confirmed_comment, confirmed_at: 90.days.ago.to_date, email: "wiz@example.com")
         end
       end
+
+      # FIXME: This example description seems wrong/is really confusing.
       it "returns an empty Array as json" do
         get(:comments, format: :json)
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -35,6 +35,7 @@ FactoryGirl.define do
 
     trait :confirmed do
       confirmed true
+      confirmed_at 5.minutes.ago
     end
 
     factory :unconfirmed_comment do
@@ -43,6 +44,7 @@ FactoryGirl.define do
 
     factory :confirmed_comment do
       confirmed true
+      confirmed_at 5.minutes.ago
     end
 
     factory :comment_to_authority do

--- a/spec/features/admin_edits_comment_spec.rb
+++ b/spec/features/admin_edits_comment_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+feature "Admin edits comment" do
+  background do
+    VCR.use_cassette('planningalerts') do
+      create(:confirmed_comment,
+             name: "Alena",
+             id: 1,
+             confirmed_at: 3.days.ago)
+    end
+  end
+
+  scenario "successfully" do
+    sign_in_as_admin
+
+    click_link "Comments"
+
+    within("#comment_1") do
+      click_link "Edit"
+    end
+
+    fill_in "Name", with: "Foo"
+    click_button "Update Comment"
+
+    expect(page).to have_content("Comment was successfully updated")
+
+    visit application_path(Comment.find(1).application)
+
+    expect(page).to have_content "Foo commented 3 days ago"
+  end
+end

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -154,7 +154,7 @@ feature "Give feedback to Council" do
 
   scenario "Reporting abuse on a confirmed comment" do
     VCR.use_cassette('planningalerts') do
-      comment = create(:comment, confirmed: true, text: "I'm saying something abusive", name: "Jack Rude", email: "rude@foo.com", id: "23")
+      comment = create(:confirmed_comment, text: "I'm saying something abusive", name: "Jack Rude", email: "rude@foo.com", id: "23")
       visit(new_comment_report_path(comment))
     end
 

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -134,6 +134,15 @@ feature "Give feedback to Council" do
       current_email.default_part_body.to_s.should include("I think this is a really good ideas")
     end
 
+    scenario "Viewing the comment on the application page" do
+      comment = create(:comment, confirmed: false, text: "I think this is a really good ideas", application: application)
+
+      visit(confirmed_comment_path(id: comment.confirm_id))
+
+      expect(page).to have_content("commented less than a minute ago")
+      expect(page).to have_content("I think this is a really good ideas")
+    end
+
     scenario "Sharing new comment on facebook" do
       comment = create(:unconfirmed_comment, application: application)
 

--- a/spec/features/performance_spec.rb
+++ b/spec/features/performance_spec.rb
@@ -24,14 +24,14 @@ feature "Viewing the use of the comments function" do
   context "when there are comments" do
     background do
       VCR.use_cassette('planningalerts', allow_playback_repeats: true) do
-        create(:confirmed_comment, created_at: Time.current.to_date, email: "foo@example.com")
-        create(:confirmed_comment, created_at: Time.current.to_date, email: "bar@example.com")
-        create(:confirmed_comment, created_at: 3.days.ago, email: "foo@example.com")
-        create(:confirmed_comment, created_at: 3.days.ago, email: "bar@example.com")
-        create(:confirmed_comment, created_at: 3.days.ago, email: "zap@example.com")
-        create(:confirmed_comment, created_at: 4.days.ago.to_date, email: "foo@example.com")
-        create(:confirmed_comment, created_at: 4.days.ago.to_date, email: "bar@example.com")
-        create(:confirmed_comment, created_at: 4.days.ago.to_date, email: "wiz@example.com")
+        create(:confirmed_comment, confirmed_at: Time.current.to_date, email: "foo@example.com")
+        create(:confirmed_comment, confirmed_at: Time.current.to_date, email: "bar@example.com")
+        create(:confirmed_comment, confirmed_at: 3.days.ago, email: "foo@example.com")
+        create(:confirmed_comment, confirmed_at: 3.days.ago, email: "bar@example.com")
+        create(:confirmed_comment, confirmed_at: 3.days.ago, email: "zap@example.com")
+        create(:confirmed_comment, confirmed_at: 4.days.ago.to_date, email: "foo@example.com")
+        create(:confirmed_comment, confirmed_at: 4.days.ago.to_date, email: "bar@example.com")
+        create(:confirmed_comment, confirmed_at: 4.days.ago.to_date, email: "wiz@example.com")
       end
     end
 

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -238,20 +238,20 @@ describe Alert do
 
   describe "#new_comments" do
     it "sees a new comment when there are new comments on an application" do
-      alert = create(:alert, email: "matthew@openaustralia.org", address: @address, radius_meters: 2000)
+      alert = create(:alert, address: @address, radius_meters: 2000)
       p1 = alert.location.endpoint(0, 501) # 501 m north of alert
       application = create(:application, lat: p1.lat, lng: p1.lng, suburb: "", state: "", postcode: "")
-      comment1 = create(:comment, application: application, text: "This is a comment", name: "Matthew", email: "matthew@openaustralia.org", address: "Foo street", confirmed: true)
+      comment1 = create(:confirmed_comment, application: application)
 
       expect(alert.new_comments).to eql [comment1]
     end
 
     it "only sees two new comments when there are two new comments on a single application" do
-      alert = create(:alert, email: "matthew@openaustralia.org", address: @address, radius_meters: 2000)
+      alert = create(:alert, address: @address, radius_meters: 2000)
       p1 = alert.location.endpoint(0, 501) # 501 m north of alert
       application = create(:application, lat: p1.lat, lng: p1.lng, suburb: "", state: "", postcode: "")
-      comment1 = create(:comment, application: application, text: "This is a comment", name: "Matthew", email: "matthew@openaustralia.org", address: "Foo street", confirmed: true)
-      comment2 = create(:comment, application: application, text: "This is a comment", name: "Matthew", email: "matthew@openaustralia.org", address: "Foo street", confirmed: true)
+      comment1 = create(:confirmed_comment, application: application)
+      comment2 = create(:confirmed_comment, application: application)
 
       expect(alert.new_comments).to eql [comment1, comment2]
     end

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -237,19 +237,17 @@ describe Alert do
   end
 
   describe "#new_comments" do
+    let(:alert) { create(:alert, address: @address, radius_meters: 2000) }
+    let(:p1) { alert.location.endpoint(0, 501) } # 501 m north of alert
+    let(:application) { create(:application, lat: p1.lat, lng: p1.lng, suburb: "", state: "", postcode: "") }
+
     it "sees a new comment when there are new comments on an application" do
-      alert = create(:alert, address: @address, radius_meters: 2000)
-      p1 = alert.location.endpoint(0, 501) # 501 m north of alert
-      application = create(:application, lat: p1.lat, lng: p1.lng, suburb: "", state: "", postcode: "")
       comment1 = create(:confirmed_comment, application: application)
 
       expect(alert.new_comments).to eql [comment1]
     end
 
     it "only sees two new comments when there are two new comments on a single application" do
-      alert = create(:alert, address: @address, radius_meters: 2000)
-      p1 = alert.location.endpoint(0, 501) # 501 m north of alert
-      application = create(:application, lat: p1.lat, lng: p1.lng, suburb: "", state: "", postcode: "")
       comment1 = create(:confirmed_comment, application: application)
       comment2 = create(:confirmed_comment, application: application)
 
@@ -257,18 +255,12 @@ describe Alert do
     end
 
     it "does not see unconfirmed comments" do
-      alert = create(:alert, address: @address, radius_meters: 2000)
-      p1 = alert.location.endpoint(0, 501) # 501 m north of alert
-      application = create(:application, lat: p1.lat, lng: p1.lng, suburb: "", state: "", postcode: "")
       unconfirmed_comment = create(:unconfirmed_comment, application: application)
 
       expect(alert.new_comments).to_not eql [unconfirmed_comment]
     end
 
     it "does not see hidden comments" do
-      alert = create(:alert, address: @address, radius_meters: 2000)
-      p1 = alert.location.endpoint(0, 501) # 501 m north of alert
-      application = create(:application, lat: p1.lat, lng: p1.lng, suburb: "", state: "", postcode: "")
       hidden_comment = create(:confirmed_comment, hidden: true, application: application)
 
       expect(alert.new_comments).to_not eql [hidden_comment]

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -236,22 +236,24 @@ describe Alert do
     end
   end
 
-  describe "comments" do
-    it "should see a new comment when there is a new comments on an application" do
+  describe "#new_comments" do
+    it "sees a new comment when there are new comments on an application" do
       alert = create(:alert, email: "matthew@openaustralia.org", address: @address, radius_meters: 2000)
       p1 = alert.location.endpoint(0, 501) # 501 m north of alert
       application = create(:application, lat: p1.lat, lng: p1.lng, suburb: "", state: "", postcode: "")
       comment1 = create(:comment, application: application, text: "This is a comment", name: "Matthew", email: "matthew@openaustralia.org", address: "Foo street", confirmed: true)
-      alert.new_comments.should == [comment1]
+
+      expect(alert.new_comments).to eql [comment1]
     end
 
-    it "should only see two new comments when there are two new comments on a single application" do
+    it "only sees two new comments when there are two new comments on a single application" do
       alert = create(:alert, email: "matthew@openaustralia.org", address: @address, radius_meters: 2000)
       p1 = alert.location.endpoint(0, 501) # 501 m north of alert
       application = create(:application, lat: p1.lat, lng: p1.lng, suburb: "", state: "", postcode: "")
       comment1 = create(:comment, application: application, text: "This is a comment", name: "Matthew", email: "matthew@openaustralia.org", address: "Foo street", confirmed: true)
       comment2 = create(:comment, application: application, text: "This is a comment", name: "Matthew", email: "matthew@openaustralia.org", address: "Foo street", confirmed: true)
-      alert.new_comments.should == [comment1, comment2]
+
+      expect(alert.new_comments).to eql [comment1, comment2]
     end
   end
 

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -255,6 +255,24 @@ describe Alert do
 
       expect(alert.new_comments).to eql [comment1, comment2]
     end
+
+    it "does not see unconfirmed comments" do
+      alert = create(:alert, address: @address, radius_meters: 2000)
+      p1 = alert.location.endpoint(0, 501) # 501 m north of alert
+      application = create(:application, lat: p1.lat, lng: p1.lng, suburb: "", state: "", postcode: "")
+      unconfirmed_comment = create(:unconfirmed_comment, application: application)
+
+      expect(alert.new_comments).to_not eql [unconfirmed_comment]
+    end
+
+    it "does not see hidden comments" do
+      alert = create(:alert, address: @address, radius_meters: 2000)
+      p1 = alert.location.endpoint(0, 501) # 501 m north of alert
+      application = create(:application, lat: p1.lat, lng: p1.lng, suburb: "", state: "", postcode: "")
+      hidden_comment = create(:confirmed_comment, hidden: true, application: application)
+
+      expect(alert.new_comments).to_not eql [hidden_comment]
+    end
   end
 
   describe "#new_replies" do

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -254,6 +254,14 @@ describe Alert do
       expect(alert.new_comments).to eql [comment1, comment2]
     end
 
+    it "does not see old confirmed comments" do
+      old_comment = create(:confirmed_comment,
+                           updated_at: alert.cutoff_time - 1,
+                           application: application)
+
+      expect(alert.new_comments).to_not eql [old_comment]
+    end
+
     it "does not see unconfirmed comments" do
       unconfirmed_comment = create(:unconfirmed_comment, application: application)
 

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -256,7 +256,7 @@ describe Alert do
 
     it "does not see old confirmed comments" do
       old_comment = create(:confirmed_comment,
-                           updated_at: alert.cutoff_time - 1,
+                           confirmed_at: alert.cutoff_time - 1,
                            application: application)
 
       expect(alert.new_comments).to_not eql [old_comment]
@@ -361,7 +361,7 @@ describe Alert do
     context "when there is an old comment near by" do
       it "does not return the application it belongs to" do
         create(:confirmed_comment,
-               updated_at: alert.cutoff_time - 1,
+               confirmed_at: alert.cutoff_time - 1,
                application: near_application)
 
         expect(alert.applications_with_new_comments).to eq []

--- a/spec/models/authority_spec.rb
+++ b/spec/models/authority_spec.rb
@@ -122,11 +122,11 @@ describe Authority do
       end
 
       it "doesn't count hidden or unconfirmed comments" do
-        create(:unconfirmed_comment, application_id: 1, updated_at: Date.new(2015,12,26))
-        create(:unconfirmed_comment, application_id: 1, updated_at: Date.new(2015,12,26))
-        create(:unconfirmed_comment, application_id: 1, updated_at: Date.new(2015,12,26))
-        create(:unconfirmed_comment, application_id: 1, updated_at: Date.new(2016,1,4))
-        create(:confirmed_comment, hidden: true, application_id: 1, updated_at: Date.new(2016,1,4))
+        create(:unconfirmed_comment, application_id: 1, created_at: Date.new(2015,12,26))
+        create(:unconfirmed_comment, application_id: 1, created_at: Date.new(2015,12,26))
+        create(:unconfirmed_comment, application_id: 1, created_at: Date.new(2015,12,26))
+        create(:unconfirmed_comment, application_id: 1, created_at: Date.new(2016,1,4))
+        create(:confirmed_comment, hidden: true, application_id: 1, confirmed_at: Date.new(2016,1,4))
 
         expect(authority.comments_per_week).to eq [
           [ Date.new(2015,12,20), 0 ],
@@ -136,10 +136,10 @@ describe Authority do
       end
 
       it "returns count of visible comments for each week since the first application was scraped" do
-        create(:confirmed_comment, application_id: 1, updated_at: Date.new(2015,12,26))
-        create(:confirmed_comment, application_id: 1, updated_at: Date.new(2015,12,26))
-        create(:confirmed_comment, application_id: 1, updated_at: Date.new(2015,12,26))
-        create(:confirmed_comment, application_id: 1, updated_at: Date.new(2016,1,4))
+        create(:confirmed_comment, application_id: 1, confirmed_at: Date.new(2015,12,26))
+        create(:confirmed_comment, application_id: 1, confirmed_at: Date.new(2015,12,26))
+        create(:confirmed_comment, application_id: 1, confirmed_at: Date.new(2015,12,26))
+        create(:confirmed_comment, application_id: 1, confirmed_at: Date.new(2016,1,4))
 
         expect(authority.comments_per_week).to eq [
           [ Date.new(2015,12,20), 3 ],

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -19,7 +19,7 @@ describe Comment do
     context "when there are no comments on this date" do
       before :each do
         VCR.use_cassette('planningalerts') do
-          create(:confirmed_comment, created_at: Date.yesterday)
+          create(:confirmed_comment, confirmed_at: Date.yesterday)
         end
       end
 
@@ -39,7 +39,7 @@ describe Comment do
     context "when there is a confirmed comments on this date" do
       before :each do
         VCR.use_cassette('planningalerts') do
-          @comment = create(:confirmed_comment, created_at: Date.today)
+          @comment = create(:confirmed_comment, confirmed_at: Date.today)
         end
       end
 
@@ -49,8 +49,8 @@ describe Comment do
     context "when there is a confirmed comments on this date and on another date" do
       before :each do
         VCR.use_cassette('planningalerts') do
-          @todays_comment = create(:confirmed_comment, created_at: Date.today)
-          @yesterdays_comment = create(:confirmed_comment, created_at: Date.yesterday)
+          @todays_comment = create(:confirmed_comment, confirmed_at: Date.today)
+          @yesterdays_comment = create(:confirmed_comment, confirmed_at: Date.yesterday)
         end
       end
 
@@ -60,8 +60,8 @@ describe Comment do
     context "when there are two confirmed comments on this date with the same email" do
       before :each do
         VCR.use_cassette('planningalerts') do
-          @comment1 = create(:confirmed_comment, created_at: Date.today, email: "foo@example.com")
-          @comment2 = create(:confirmed_comment, created_at: Date.today, email: "foo@example.com")
+          @comment1 = create(:confirmed_comment, confirmed_at: Date.today, email: "foo@example.com")
+          @comment2 = create(:confirmed_comment, confirmed_at: Date.today, email: "foo@example.com")
         end
       end
 
@@ -77,7 +77,7 @@ describe Comment do
     context "there is a first time commenter" do
       before :each do
         VCR.use_cassette('planningalerts') do
-          @comment = create(:confirmed_comment, created_at: Date.today, email: "foo@example.com")
+          @comment = create(:confirmed_comment, confirmed_at: Date.today, email: "foo@example.com")
         end
       end
 
@@ -87,8 +87,8 @@ describe Comment do
     context "when a person has commented on two dates" do
       before :each do
         VCR.use_cassette('planningalerts') do
-          @yesterdays_comment = create(:confirmed_comment, created_at: Date.yesterday, email: "foo@example.com")
-          @todays_comment = create(:confirmed_comment, created_at: Date.today, email: "foo@example.com")
+          @yesterdays_comment = create(:confirmed_comment, confirmed_at: Date.yesterday, email: "foo@example.com")
+          @todays_comment = create(:confirmed_comment, confirmed_at: Date.today, email: "foo@example.com")
         end
       end
 
@@ -107,10 +107,10 @@ describe Comment do
       it { expect(Comment.by_returning_commenters_for_date("2015-09-22")).to eq [] }
     end
 
-    context "there is a first time commenter" do
+    context "when there is a first time commenter" do
       before :each do
         VCR.use_cassette('planningalerts') do
-          create(:confirmed_comment, created_at: Date.today, email: "foo@example.com")
+          create(:confirmed_comment, confirmed_at: Date.today, email: "foo@example.com")
         end
       end
 
@@ -120,8 +120,8 @@ describe Comment do
     context "when a person has commented on two dates" do
       before :each do
         VCR.use_cassette('planningalerts') do
-          @yesterdays_comment = create(:confirmed_comment, created_at: Date.yesterday, email: "foo@example.com")
-          @todays_comment = create(:confirmed_comment, created_at: Date.today, email: "foo@example.com")
+          @yesterdays_comment = create(:confirmed_comment, confirmed_at: Date.yesterday, email: "foo@example.com")
+          @todays_comment = create(:confirmed_comment, confirmed_at: Date.today, email: "foo@example.com")
         end
       end
 

--- a/spec/views/comments/comment_spec.rb
+++ b/spec/views/comments/comment_spec.rb
@@ -12,7 +12,7 @@ describe "comments/_comment" do
   end
 
   it "should add rel='no-follow' to links in the comment text" do
-    comment = create(:comment,
+    comment = create(:confirmed_comment,
                      text: 'This is a link to <a href="http://openaustralia.org">openaustralia.org</a>',
                      application: application)
     expected_html = "<blockquote class='comment-text'><p>This is a link to <a href=\"http://openaustralia.org\" rel=\"nofollow\">openaustralia.org</a></p></blockquote>"
@@ -23,7 +23,7 @@ describe "comments/_comment" do
   end
 
   it "should format simple text in separate paragraphs with p tags" do
-    comment = create(:comment,
+    comment = create(:confirmed_comment,
                      text: "This is the first paragraph\nAnd the next line\n\nThis is a new paragraph",
                      application: application)
     expected_html = "<blockquote class='comment-text'><p>This is the first paragraph
@@ -37,7 +37,7 @@ describe "comments/_comment" do
   end
 
   it "should get rid of nasty javascript and strip out images" do
-    comment = create(:comment,
+    comment = create(:confirmed_comment,
                      text: "<a href=\"javascript:document.location='http://www.google.com/'\">A nasty link</a><img src=\"http://foo.co\">",
                      application: application)
     expected_html = "<blockquote class='comment-text'><p><a rel=\"nofollow\">A nasty link</a></p></blockquote>"


### PR DESCRIPTION
Fixes #930

Currently the time we say the person made a comment is the `updated_at`
time. For most comments this ends up being the time the `confirmed`
attribute was updated, i.e. when they confirmed the comment. But when an
Admin updates the comment for some reason, the `updated_at` time changes
and we then wrongly say that is when the person commented.
This has lead to situations where the website says someone commented
days after they actually commented.

These commits add new attribute 'confirmed_at' which is set when the person
confirms their comment.

This also adds a migration to add the `confirmed_at` value for existing confirmed comments. It uses the `updated_at` value, which is what we currently use to show and sort comments.

Lots of detail in the commit messages.

@henare could you please review this?