### PR TITLE
Make very long comments less of a problem

### DIFF
--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -144,6 +144,9 @@ ol#comments {
   font-style: normal;
   border: 0;
   padding: 0;
+
+  max-height: 30em;
+  overflow-y: auto;
 }
 
 .comment-location {


### PR DESCRIPTION
Improves but doesn't entirely address #317 - doesn't stop someone posting in a 64kb comment, but you can scroll through the page at least without being forced to read it.

![image](https://cloud.githubusercontent.com/assets/365751/14225484/efbedfd0-f90b-11e5-8731-cab9c6f79f6c.png)

