### PR TITLE
Add fields for primary_url on authority

### DIFF
--- a/app/admin/authorities.rb
+++ b/app/admin/authorities.rb
@@ -23,6 +23,7 @@ ActiveAdmin.register Authority do
       row :full_name
       row :short_name
       row :state
+      row :primary_url
       row :email
       row :write_to_councillors_enabled
       row :population_2011
@@ -58,6 +59,7 @@ ActiveAdmin.register Authority do
       input :short_name
     end
     inputs "Details" do
+      input :primary_url
       input :state
       input :email
       input :population_2011
@@ -103,7 +105,8 @@ ActiveAdmin.register Authority do
     column :morph_name
     column(:number_of_applications) { |a| a.applications.count }
     column(:number_of_comments) { |a| a.comments.count }
+    column :primary_url
   end
 
-  permit_params :full_name, :short_name, :state, :email, :write_to_councillors_enabled, :population_2011, :morph_name, :disabled
+  permit_params :full_name, :short_name, :state, :email, :write_to_councillors_enabled, :population_2011, :morph_name, :disabled, :primary_url
 end

--- a/app/views/authorities/show.html.haml
+++ b/app/views/authorities/show.html.haml
@@ -1,5 +1,8 @@
 - content_for :page_title, @authority.full_name
 %h3= yield :page_title
+- if @authority.primary_url
+  %p
+    <a href="#{@authority.primary_url}" target="_blank">#{@authority.primary_url}</a>
 
 - if @authority.population_2011
   %p

--- a/db/migrate/20160402093711_add_homepage_url.rb
+++ b/db/migrate/20160402093711_add_homepage_url.rb
@@ -1,0 +1,5 @@
+class AddHomepageUrl < ActiveRecord::Migration
+  def change
+    add_column :authorities, :primary_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160301033011) do
+ActiveRecord::Schema.define(version: 20160402093711) do
 
   create_table "active_admin_comments", force: true do |t|
     t.string   "resource_id",   null: false
@@ -95,17 +95,21 @@ ActiveRecord::Schema.define(version: 20160301033011) do
   add_index "applications", ["suburb"], name: "index_applications_on_suburb", using: :btree
 
   create_table "authorities", force: true do |t|
-    t.string  "full_name",            limit: 200, null: false
-    t.string  "short_name",           limit: 100, null: false
+    t.string  "full_name",                    limit: 200,                 null: false
+    t.string  "short_name",                   limit: 100,                 null: false
     t.boolean "disabled"
-    t.string  "state",                limit: 20
+    t.string  "state",                        limit: 20
     t.string  "email"
     t.integer "population_2011"
     t.text    "last_scraper_run_log"
     t.string  "morph_name"
     t.boolean "write_to_councillors_enabled",             default: false, null: false
+    t.string  "lga_name15"
+    t.string  "superceded_by"
+    t.string  "primary_url"
   end
 
+  add_index "authorities", ["lga_name15"], name: "index_authorities_on_lga_name15", using: :btree
   add_index "authorities", ["short_name"], name: "short_name_unique", unique: true, using: :btree
 
   create_table "comments", force: true do |t|


### PR DESCRIPTION
First bit of #442

Probably can infer the majority of the homepages from authority.email.split("@").last; but didn't want to stick that in a migration.