### PR TITLE
Tolerate looser geocoding

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -46,19 +46,19 @@ class ApplicationsController < ApplicationController
     per_page = 30
     @page = params[:page]
     if @q
-      location = Location.geocode(@q)
-      if location.error
+      @location = Location.geocode(@q)
+      if @location.error
         @other_addresses = []
-        @error = location.error
+        @error = @location.error
       else
-        @q = location.full_address
+        @q = @location.full_address
         @alert = Alert.new(address: @q)
-        @other_addresses = location.all[1..-1].map{|l| l.full_address}
+        @other_addresses = @location.all[1..-1].map{|l| l.full_address}
         @applications = case @sort
                         when 'distance'
-                          Application.near([location.lat, location.lng], @radius / 1000, units: :km).reorder('distance').paginate(page: params[:page], per_page: per_page)
+                          Application.near([@location.lat, @location.lng], @radius / 1000, units: :km).reorder('distance').paginate(page: params[:page], per_page: per_page)
                         else # date_scraped
-                          Application.near([location.lat, location.lng], @radius / 1000, units: :km).paginate(page: params[:page], per_page: per_page)
+                          Application.near([@location.lat, @location.lng], @radius / 1000, units: :km).paginate(page: params[:page], per_page: per_page)
                         end
         @rss = applications_path(format: 'rss', address: @q, radius: @radius)
       end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -49,6 +49,10 @@ class Location < SimpleDelegator
     end
   end
 
+  def less_than_street_level_accuracy?
+    accuracy < 5
+  end
+
   # Distance given is in metres
   def endpoint(bearing, distance)
     Location.new(__getobj__.endpoint(bearing, distance / 1000.0, units: :kms))

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -43,8 +43,8 @@ class Location < SimpleDelegator
         "Sorry we don’t understand that address. Try one like ‘1 Sowerby St, Goulburn, NSW’"
       elsif !in_correct_country?
         "Unfortunately we only cover Australia. It looks like that address is in another country."
-      elsif accuracy < 5
-        "Please enter a full street address like ‘36 Sowerby St, Goulburn, NSW’"
+      elsif accuracy < 4
+        "Please enter a more detailed address like ‘Sowerby St, Goulburn, NSW’"
       end
     end
   end

--- a/app/views/applications/address_results.html.haml
+++ b/app/views/applications/address_results.html.haml
@@ -1,6 +1,9 @@
 - content_for :meta_description, @themer.default_meta_description
 
 %h3 Applications within #{meters_in_words(@radius)} of #{@q}
+- if @location.less_than_street_level_accuracy?
+  %p.attention
+    We didn't fully recognize your exact address, so you may not see the most relevant applications. Search with a street level or exact address to get better results. #{link_to "Search again", root_path}.
 
 - unless @other_addresses.empty?
   %h4 Or did you want?

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -70,11 +70,11 @@ describe "Location" do
     l.error.should be_nil
   end
 
-  it "should error if the address is not a full street address but rather a suburb name or similar" do
-    Geokit::Geocoders::GoogleGeocoder3.stub(:geocode).and_return(double(all: [double(country_code: "AU", lat: 1, lng: 2, accuracy: 4, full_address: "Glenbrook NSW, Australia")]))
+  it "should error if the address is not a full street address, street address or suburb but rather place vaguer than a suburb" do
+    Geokit::Geocoders::GoogleGeocoder3.stub(:geocode).and_return(double(all: [double(country_code: "AU", lat: 1, lng: 2, accuracy: 3, full_address: "Glenbrook NSW, Australia")]))
 
-    l = Location.geocode("Glenbrook, NSW")
-    l.error.should == "Please enter a full street address like ‘36 Sowerby St, Goulburn, NSW’"
+    l = Location.geocode("New South Wales")
+    l.error.should == "Please enter a more detailed address like ‘Sowerby St, Goulburn, NSW’"
   end
 
   it "should list potential matches and they should be in Australia" do


### PR DESCRIPTION
As per #889 convos

Before; users get stuck here

![](https://cloud.githubusercontent.com/assets/1239550/12275724/c6f6ee56-b9c5-11e5-92fb-01eed27993a0.png)

Now:

This changes the hints for "Please enter a full street address like ..." to indicate a vaguer, street level address is OK 

```
Please enter a more detailed address like ‘Sowerby St, Goulburn, NSW’
```

... though I can't convince the geocoder to cough up a result of that accuracy).


Adds Polite nudge UI on search results for a vague address:
![image](https://cloud.githubusercontent.com/assets/365751/14237820/4e00fcec-fa68-11e5-9ead-3a401e61321d.png)

and doesn't reject suburb level addresses