### PR TITLE
WriteIt for WriteToCouncillors

### DIFF
--- a/.env
+++ b/.env
@@ -43,6 +43,12 @@ SECRET_KEY_BASE=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # councillors associated with them.
 #COUNCILLORS_ENABLED=true
 
+# WriteIt configuration
+#WRITEIT_BASE_URL=http://writeit.ciudadanointeligente.org
+#WRITEIT_URL=/api/v1/instance/1927/
+#WRITEIT_USERNAME=henare
+#WRITEIT_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
 ##################################################################################
 ## These are set in `.env.production` when deployed. You probably don't need them
 ## in development

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,8 @@ gem 'stripe'
 gem 'dotenv-rails'
 gem 'climate_control'
 gem 'everypolitician-popolo', git: 'https://github.com/everypolitician/everypolitician-popolo.git', branch: 'master'
+# Using master until an updated version of the Gem is released https://github.com/ciudadanointeligente/writeit-rails/issues/4
+gem 'writeit-rails', git: 'https://github.com/ciudadanointeligente/writeit-rails.git', branch: 'master'
 
 group :test do
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/ciudadanointeligente/writeit-rails.git
+  revision: a3d8382ec4f74313ca12eb9213d93724ab5d6cf5
+  branch: master
+  specs:
+    writeit-rails (0.0.4)
+      rest-client (= 1.6.7)
+
+GIT
   remote: https://github.com/everypolitician/everypolitician-popolo.git
   revision: be22bd81c598ae0602c5ddf8e9fdb8a783745877
   branch: master
@@ -141,8 +149,6 @@ GEM
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
-    domain_name (0.5.24)
-      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.0.2)
     dotenv-rails (2.0.2)
       dotenv (= 2.0.2)
@@ -202,8 +208,6 @@ GEM
     hike (1.2.3)
     hitimes (1.2.2)
     honeybadger (2.1.3)
-    http-cookie (1.0.2)
-      domain_name (~> 0.5)
     http_parser.rb (0.6.0)
     httparty (0.10.2)
       multi_json (~> 1.0)
@@ -266,7 +270,6 @@ GEM
     net-ssh (2.7.0)
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
-    netrc (0.10.3)
     newrelic_rpm (3.6.8.164)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
@@ -329,10 +332,8 @@ GEM
     refills (0.1.0)
     responders (1.1.2)
       railties (>= 3.2, < 4.2)
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
     rgeo (0.3.20)
     rgeo-geojson (0.3.1)
       rgeo (~> 0.3)
@@ -432,9 +433,6 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.1)
     validate_url (0.2.2)
       activemodel (>= 3.0.0)
       addressable
@@ -528,6 +526,7 @@ DEPENDENCIES
   vcr
   webmock
   will_paginate
+  writeit-rails!
 
 BUNDLED WITH
    1.11.2

--- a/app/admin/comments.rb
+++ b/app/admin/comments.rb
@@ -39,7 +39,7 @@ ActiveAdmin.register Comment do
 
   action_item :load_replies, only: :show do
     if resource.to_councillor? && resource.writeit_message_id
-      button_to("Check WriteIt for replies", load_replies_admin_comment_path)
+      button_to("Load replies from WriteIt", load_replies_admin_comment_path)
     end
   end
 

--- a/app/admin/comments.rb
+++ b/app/admin/comments.rb
@@ -37,17 +37,19 @@ ActiveAdmin.register Comment do
     actions
   end
 
-  action_item :load_reply, only: :show do
+  action_item :load_replies, only: :show do
     if resource.to_councillor? && resource.writeit_message_id
-      button_to("Check WriteIt for replies", load_reply_admin_comment_path)
+      button_to("Check WriteIt for replies", load_replies_admin_comment_path)
     end
   end
 
-  member_action :load_reply, method: :post do
-    if resource.create_reply_from_writeit!
-      redirect_to({action: :show}, notice: "Reply loaded")
+  member_action :load_replies, method: :post do
+    replies = resource.create_replies_from_writeit!
+    if replies.present?
+      # TODO: Fix pluralisation: "Loaded 1 replies"
+      redirect_to({action: :show}, notice: "Loaded #{replies.count} replies")
     else
-      redirect_to({action: :show}, notice: "No reply loaded")
+      redirect_to({action: :show}, notice: "No replies loaded")
     end
   end
 

--- a/app/admin/comments.rb
+++ b/app/admin/comments.rb
@@ -37,5 +37,19 @@ ActiveAdmin.register Comment do
     actions
   end
 
+  action_item :load_reply, only: :show do
+    if resource.to_councillor? && resource.writeit_message_id
+      button_to("Check WriteIt for replies", load_reply_admin_comment_path)
+    end
+  end
+
+  member_action :load_reply, method: :post do
+    if resource.create_reply_from_writeit!
+      redirect_to({action: :show}, notice: "Reply loaded")
+    else
+      redirect_to({action: :show}, notice: "No reply loaded")
+    end
+  end
+
   permit_params :text, :email, :name, :confirmed, :address, :hidden
 end

--- a/app/admin/comments.rb
+++ b/app/admin/comments.rb
@@ -38,7 +38,7 @@ ActiveAdmin.register Comment do
   end
 
   action_item :load_replies, only: :show do
-    if resource.to_councillor? && resource.writeit_message_id
+    if ENV["WRITEIT_BASE_URL"] && resource.to_councillor? && resource.writeit_message_id
       button_to("Load replies from WriteIt", load_replies_admin_comment_path)
     end
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -41,7 +41,7 @@ class CommentsController < ApplicationController
 
   def reply_webhook
     if params[:message_id] && comment = Comment.find_by(writeit_message_id: params[:message_id][/\/api\/v1\/message\/(\d*)\//, 1])
-      comment.create_reply_from_writeit!
+      comment.create_replies_from_writeit!
       render text: "Processing inbound message.", status: 200
     else
       render text: "No message_id or comment not found.", status: 404

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -38,4 +38,13 @@ class CommentsController < ApplicationController
       format.json { render json: authority.comments_per_week }
     end
   end
+
+  def reply_webhook
+    if params[:message_id] && comment = Comment.find_by(writeit_message_id: params[:message_id][/\/api\/v1\/message\/(\d*)\//, 1])
+      comment.create_reply_from_writeit!
+      render text: "Processing inbound message.", status: 200
+    else
+      render text: "No message_id or comment not found.", status: 404
+    end
+  end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -39,7 +39,7 @@ class CommentsController < ApplicationController
     end
   end
 
-  def reply_webhook
+  def writeit_reply_webhook
     if params[:message_id] && comment = Comment.find_by(writeit_message_id: params[:message_id][/\/api\/v1\/message\/(\d*)\//, 1])
       comment.create_replies_from_writeit!
       render text: "Processing inbound message.", status: 200

--- a/app/mailers/comment_notifier.rb
+++ b/app/mailers/comment_notifier.rb
@@ -22,4 +22,19 @@ class CommentNotifier < ActionMailer::Base
       reply_to: "#{comment.name} <#{from_address}>",
       to: comment.councillor.email, subject: "Planning application at #{comment.application.address}")
   end
+
+  # FIXME: This probably shouldn't be in the mailer
+  def send_comment_via_writeit!(comment)
+    # TODO: Put this on the background queue
+    message = Message.new
+    message.subject = "Planning application at #{comment.application.address}"
+    # TODO: Add boiler plate
+    message.content = comment.text
+    message.author_name = comment.name
+    message.author_email = ENV["EMAIL_COUNCILLOR_REPLIES_TO"]
+    message.writeitinstance = comment.writeitinstance
+    message.recipients = [comment.councillor.writeit_id]
+    message.push_to_api
+    comment.update!(writeit_message_id: message.remote_id)
+  end
 end

--- a/app/mailers/comment_notifier.rb
+++ b/app/mailers/comment_notifier.rb
@@ -25,11 +25,11 @@ class CommentNotifier < ActionMailer::Base
 
   # FIXME: This probably shouldn't be in the mailer
   def send_comment_via_writeit!(comment)
-    # TODO: Put this on the background queue
+    @comment = comment
+
     message = Message.new
     message.subject = "Planning application at #{comment.application.address}"
-    # TODO: Add boiler plate
-    message.content = comment.text
+    message.content = render_to_string("notify_councillor.text.erb")
     message.author_name = comment.name
     message.author_email = ENV["EMAIL_COUNCILLOR_REPLIES_TO"]
     message.writeitinstance = comment.writeitinstance

--- a/app/models/authority.rb
+++ b/app/models/authority.rb
@@ -259,7 +259,7 @@ class Authority < ActiveRecord::Base
 
     persons.map do |person|
       councillor = councillors.find_or_create_by(name: person.name)
-      councillor.update(email: person.email, image_url: person.image, party: person.party)
+      councillor.update(email: person.email, image_url: person.image, party: person.party, popolo_id: person.id)
       councillor
     end
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -73,6 +73,7 @@ class Comment < ActiveRecord::Base
     writeitinstance
   end
 
+  # TODO: Change this to add multiple replies
   def create_reply_from_writeit!
     if replies.present? || writeit_message_id.blank?
       false

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -43,8 +43,8 @@ class Comment < ActiveRecord::Base
       message.author_email = ENV["EMAIL_COUNCILLOR_REPLIES_TO"]
       message.writeitinstance = writeitinstance
       message.recipients = [councillor.writeit_id]
-      # TODO: Store the result that contains the message ID. It looks like "/api/v1/message/5650/"
       message.push_to_api
+      update!(writeit_message_id: message.remote_id)
     elsif to_councillor?
       CommentNotifier.delay.notify_councillor("default", self)
     else

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -60,9 +60,7 @@ class Comment < ActiveRecord::Base
   end
 
   def create_replies_from_writeit!
-    if writeit_message_id.blank?
-      false
-    else
+    if writeit_message_id.present?
       # TODO: This should be done in the writeit-rails gem
       api_response = RestClient.get(ENV["WRITEIT_BASE_URL"] + "/api/v1/message/" + writeit_message_id.to_s,
                                     {params: {format: "json",

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -29,6 +29,7 @@ class Comment < ActiveRecord::Base
   # Send the comment to the planning authority
   def after_confirm
     if to_councillor? && ENV["WRITEIT_BASE_URL"]
+      # TODO: Put this on the background queue
       CommentNotifier.send_comment_via_writeit!(self)
     elsif to_councillor?
       CommentNotifier.delay.notify_councillor("default", self)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -48,14 +48,7 @@ class Comment < ActiveRecord::Base
   end
 
   def send_via_writeit!
-    # TODO: Extract this
     # TODO: Put this on the background queue
-    writeitinstance = WriteItInstance.new
-    writeitinstance.base_url = ENV["WRITEIT_BASE_URL"]
-    writeitinstance.url = ENV["WRITEIT_URL"]
-    writeitinstance.username = ENV["WRITEIT_USERNAME"]
-    writeitinstance.api_key = ENV["WRITEIT_API_KEY"]
-
     message = Message.new
     message.subject = "Planning application at #{application.address}"
     # TODO: Add boiler plate
@@ -66,5 +59,15 @@ class Comment < ActiveRecord::Base
     message.recipients = [councillor.writeit_id]
     message.push_to_api
     update!(writeit_message_id: message.remote_id)
+  end
+
+  def writeitinstance
+    writeitinstance = WriteItInstance.new
+    writeitinstance.base_url = ENV["WRITEIT_BASE_URL"]
+    writeitinstance.url = ENV["WRITEIT_URL"]
+    writeitinstance.username = ENV["WRITEIT_USERNAME"]
+    writeitinstance.api_key = ENV["WRITEIT_API_KEY"]
+
+    writeitinstance
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -85,7 +85,10 @@ class Comment < ActiveRecord::Base
       message = JSON.parse(api_response.body, symbolize_names: true)
 
       if answer = message[:answers].first
-        replies.create!(councillor: councillor, text: answer[:content], received_at: answer[:created])
+        replies.create!(councillor: councillor,
+                        text: answer[:content],
+                        received_at: answer[:created],
+                        writeit_id: answer[:id])
       end
     end
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -29,8 +29,7 @@ class Comment < ActiveRecord::Base
   # Send the comment to the planning authority
   def after_confirm
     if to_councillor? && ENV["WRITEIT_BASE_URL"]
-      # TODO: Put this on the background queue
-      CommentNotifier.send_comment_via_writeit!(self)
+      CommentNotifier.delay.send_comment_via_writeit!(self)
     elsif to_councillor?
       CommentNotifier.delay.notify_councillor("default", self)
     else

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -62,10 +62,12 @@ class Comment < ActiveRecord::Base
   def create_replies_from_writeit!
     if writeit_message_id.present?
       # TODO: This should be done in the writeit-rails gem
-      api_response = RestClient.get(ENV["WRITEIT_BASE_URL"] + "/api/v1/message/" + writeit_message_id.to_s,
-                                    {params: {format: "json",
-                                              username: writeitinstance.username,
-                                              api_key: writeitinstance.api_key}})
+      api_response = RestClient.get(
+        ENV["WRITEIT_BASE_URL"] + "/api/v1/message/" + writeit_message_id.to_s,
+        params: { format: "json",
+                  username: writeitinstance.username,
+                  api_key: writeitinstance.api_key }
+      )
       message = JSON.parse(api_response.body, symbolize_names: true)
       answers = message[:answers]
 

--- a/app/models/councillor.rb
+++ b/app/models/councillor.rb
@@ -9,4 +9,8 @@ class Councillor < ActiveRecord::Base
   def prefixed_name
     "local councillor #{name}"
   end
+
+  def writeit_id
+    authority.popolo_url + "/person/" + popolo_id
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,6 +84,9 @@ PlanningalertsApp::Application.routes.draw do
     member do
       get :confirmed
     end
+    collection do
+      post :reply_webhook
+    end
     resources :reports, only: [:new, :create]
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,7 +85,7 @@ PlanningalertsApp::Application.routes.draw do
       get :confirmed
     end
     collection do
-      post :reply_webhook
+      post :writeit_reply_webhook
     end
     resources :reports, only: [:new, :create]
   end

--- a/db/migrate/20160404052617_add_popolo_id_to_councillors.rb
+++ b/db/migrate/20160404052617_add_popolo_id_to_councillors.rb
@@ -1,0 +1,5 @@
+class AddPopoloIdToCouncillors < ActiveRecord::Migration
+  def change
+    add_column :councillors, :popolo_id, :string
+  end
+end

--- a/db/migrate/20160404090215_add_writeit_message_id_to_comment.rb
+++ b/db/migrate/20160404090215_add_writeit_message_id_to_comment.rb
@@ -1,0 +1,5 @@
+class AddWriteitMessageIdToComment < ActiveRecord::Migration
+  def change
+    add_column :comments, :writeit_message_id, :integer
+  end
+end

--- a/db/migrate/20160404094847_add_writeit_id_to_replies.rb
+++ b/db/migrate/20160404094847_add_writeit_id_to_replies.rb
@@ -1,0 +1,5 @@
+class AddWriteitIdToReplies < ActiveRecord::Migration
+  def change
+    add_column :replies, :writeit_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160404090215) do
+ActiveRecord::Schema.define(version: 20160404094847) do
 
   create_table "active_admin_comments", force: true do |t|
     t.string   "resource_id",   null: false
@@ -170,6 +170,7 @@ ActiveRecord::Schema.define(version: 20160404090215) do
     t.datetime "received_at"
     t.integer  "comment_id"
     t.integer  "councillor_id"
+    t.integer  "writeit_id"
   end
 
   add_index "replies", ["comment_id"], name: "index_replies_on_comment_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160330040409) do
+ActiveRecord::Schema.define(version: 20160404052617) do
 
   create_table "active_admin_comments", force: true do |t|
     t.string   "resource_id",   null: false
@@ -137,6 +137,7 @@ ActiveRecord::Schema.define(version: 20160330040409) do
     t.datetime "updated_at"
     t.string   "email"
     t.integer  "authority_id"
+    t.string   "popolo_id"
   end
 
   create_table "delayed_jobs", force: true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160404052617) do
+ActiveRecord::Schema.define(version: 20160404090215) do
 
   create_table "active_admin_comments", force: true do |t|
     t.string   "resource_id",   null: false
@@ -122,6 +122,7 @@ ActiveRecord::Schema.define(version: 20160404052617) do
     t.string   "theme",          default: "default", null: false
     t.integer  "councillor_id"
     t.datetime "confirmed_at"
+    t.integer  "writeit_message_id"
   end
 
   add_index "comments", ["application_id"], name: "index_comments_on_application_id", using: :btree

--- a/spec/features/admin_hides_comment_spec.rb
+++ b/spec/features/admin_hides_comment_spec.rb
@@ -40,8 +40,4 @@ feature "Admin hides comment" do
       expect(page).to have_content("Hidden true")
     end
   end
-
-  def with_modified_env(options, &block)
-    ClimateControl.modify(options, &block)
-  end
 end

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -194,8 +194,4 @@ feature "Give feedback to Council" do
       page.should_not have_content("Now check your email")
     end
   end
-
-  def with_modified_env(options, &block)
-    ClimateControl.modify(options, &block)
-  end
 end

--- a/spec/features/reply_from_councillor_spec.rb
+++ b/spec/features/reply_from_councillor_spec.rb
@@ -49,14 +49,7 @@ feature "Councillor replies to a message sent to them" do
     end
 
     around do |test|
-      writeit_env_variables = {
-        WRITEIT_BASE_URL: "http://writeit.ciudadanointeligente.org",
-        WRITEIT_URL: "/api/v1/instance/1927/",
-        WRITEIT_USERNAME: "henare",
-        WRITEIT_API_KEY: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-      }
-
-      with_modified_env(writeit_env_variables) do
+      with_modified_env(writeit_config_variables) do
         test.run
       end
     end

--- a/spec/features/reply_from_councillor_spec.rb
+++ b/spec/features/reply_from_councillor_spec.rb
@@ -43,7 +43,7 @@ feature "Councillor replies to a message sent to them" do
 
   context "WriteIt is configured" do
     given(:writeit_comment) do
-      create(:confirmed_comment, writeit_message_id: 5652,
+      create(:confirmed_comment, writeit_message_id: 1234,
                                  application: application,
                                  councillor: councillor)
     end
@@ -72,7 +72,7 @@ feature "Councillor replies to a message sent to them" do
 
       visit application_path(writeit_comment.application)
 
-      expect(page).to have_content "Test to Henare from Chris."
+      expect(page).to have_content "I agree, thanks for your comment"
     end
   end
 end

--- a/spec/features/reply_from_councillor_spec.rb
+++ b/spec/features/reply_from_councillor_spec.rb
@@ -64,7 +64,7 @@ feature "Councillor replies to a message sent to them" do
     scenario "it’s loaded from WriteIt by an admin" do
       sign_in_as_admin
       visit admin_comment_path(writeit_comment)
-      VCR.use_cassette('planningalerts', record: :new_episodes) do
+      VCR.use_cassette('planningalerts') do
         click_button "Load replies from WriteIt"
       end
 

--- a/spec/features/write_to_councillors_spec.rb
+++ b/spec/features/write_to_councillors_spec.rb
@@ -135,10 +135,6 @@ feature "Send a message to a councillor" do
         end
       end
     end
-
-    def with_modified_env(options, &block)
-      ClimateControl.modify(options, &block)
-    end
   end
 
   context "when a message for a councillor is confirmed" do

--- a/spec/fixtures/vcr_cassettes/planningalerts.yml
+++ b/spec/fixtures/vcr_cassettes/planningalerts.yml
@@ -917,4 +917,96 @@ http_interactions:
         "updated": "2016-04-04T06:53:28", "writeitinstance": "/api/v1/instance/1927/"}'
     http_version: 
   recorded_at: Tue, 05 Apr 2016 05:15:33 GMT
+- request:
+    method: post
+    uri: http://writeit.ciudadanointeligente.org/api/v1/message/
+    body:
+      encoding: UTF-8
+      string: '{"author_name":"Matthew Landauer","author_email":"replies@planningalerts.org.au","subject":"Planning
+        application at A test address","content":"Hi Louise Councillor,\n\nYou’ve
+        got a new message from Matthew Landauer in relation to a local\nplanning application:\n\nAddress:
+        A test address\nDescription: Pretty\nLink: https://dev.planningalerts.org.au/applications/8?utm_campaign=view-application\u0026utm_medium=email\u0026utm_source=councillor-notifications\n\nMatthew
+        Landauer writes:\n\na comment\n\n=========================================================================\n\nThis
+        message was posted publicly on PlanningAlerts. You can publicly\nrespond to
+        this message by simply replying to this email.\n\nBest wishes,\n\nPlanningAlerts\n","writeitinstance":"/api/v1/instance/1927/","persons":["https://raw.githubusercontent.com/openaustralia/australian_local_councillors_popolo/master/nsw_local_councillor_popolo.json/person/marrickville_council/chris_woods"]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - ApiKey henare:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Content-Length:
+      - '967'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Wed, 06 Apr 2016 05:29:43 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - gunicorn/19.2.1
+      Vary:
+      - Accept, Accept-Language, Host, Cookie
+      Location:
+      - http://writeit.ciudadanointeligente.org/api/v1/message/5665/
+      Content-Language:
+      - en
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJhbnN3ZXJzIjogW10sICJhdXRob3JfZW1haWwiOiAicmVwbGllc0BwbGFu
+        bmluZ2FsZXJ0cy5vcmcuYXUiLCAiYXV0aG9yX25hbWUiOiAiTWF0dGhldyBM
+        YW5kYXVlciIsICJjb25maXJtYXRlZCI6IHRydWUsICJjb250ZW50IjogIkhp
+        IExvdWlzZSBDb3VuY2lsbG9yLFxuXG5Zb3XigJl2ZSBnb3QgYSBuZXcgbWVz
+        c2FnZSBmcm9tIE1hdHRoZXcgTGFuZGF1ZXIgaW4gcmVsYXRpb24gdG8gYSBs
+        b2NhbFxucGxhbm5pbmcgYXBwbGljYXRpb246XG5cbkFkZHJlc3M6IEEgdGVz
+        dCBhZGRyZXNzXG5EZXNjcmlwdGlvbjogUHJldHR5XG5MaW5rOiBodHRwczov
+        L2Rldi5wbGFubmluZ2FsZXJ0cy5vcmcuYXUvYXBwbGljYXRpb25zLzg/dXRt
+        X2NhbXBhaWduPXZpZXctYXBwbGljYXRpb24mdXRtX21lZGl1bT1lbWFpbCZ1
+        dG1fc291cmNlPWNvdW5jaWxsb3Itbm90aWZpY2F0aW9uc1xuXG5NYXR0aGV3
+        IExhbmRhdWVyIHdyaXRlczpcblxuYSBjb21tZW50XG5cbj09PT09PT09PT09
+        PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09
+        PT09PT09PT09PT09PT09PT1cblxuVGhpcyBtZXNzYWdlIHdhcyBwb3N0ZWQg
+        cHVibGljbHkgb24gUGxhbm5pbmdBbGVydHMuIFlvdSBjYW4gcHVibGljbHlc
+        bnJlc3BvbmQgdG8gdGhpcyBtZXNzYWdlIGJ5IHNpbXBseSByZXBseWluZyB0
+        byB0aGlzIGVtYWlsLlxuXG5CZXN0IHdpc2hlcyxcblxuUGxhbm5pbmdBbGVy
+        dHNcbiIsICJjcmVhdGVkIjogIjIwMTYtMDQtMDZUMDU6Mjk6NDIuOTQ3MjQ0
+        IiwgImlkIjogNTY2NSwgIm1vZGVyYXRlZCI6IG51bGwsICJwZW9wbGUiOiBb
+        eyJpZCI6IDQzNDA1LCAiaW1hZ2UiOiAiaHR0cHM6Ly93d3cubWFycmlja3Zp
+        bGxlLm5zdy5nb3YuYXUvR2xvYmFsL21hcnIvbWFycndyL19hc3NldHMvbWFp
+        bi9saWI2NTA4MS9jbHIlMjB3b29kcyUyMHdlYi5qcGciLCAibmFtZSI6ICJD
+        aHJpcyBXb29kcyIsICJwb3BpdF9pZCI6ICJwZXJzb24vbWFycmlja3ZpbGxl
+        X2NvdW5jaWwvY2hyaXNfd29vZHMiLCAicG9waXRfdXJsIjogImh0dHBzOi8v
+        cmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbS9vcGVuYXVzdHJhbGlhL2F1c3Ry
+        YWxpYW5fbG9jYWxfY291bmNpbGxvcnNfcG9wb2xvL21hc3Rlci9uc3dfbG9j
+        YWxfY291bmNpbGxvcl9wb3BvbG8uanNvbi9wZXJzb24vbWFycmlja3ZpbGxl
+        X2NvdW5jaWwvY2hyaXNfd29vZHMiLCAicmVzb3VyY2VfdXJpIjogImh0dHBz
+        Oi8vcmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbS9vcGVuYXVzdHJhbGlhL2F1
+        c3RyYWxpYW5fbG9jYWxfY291bmNpbGxvcnNfcG9wb2xvL21hc3Rlci9uc3df
+        bG9jYWxfY291bmNpbGxvcl9wb3BvbG8uanNvbi9wZXJzb24vbWFycmlja3Zp
+        bGxlX2NvdW5jaWwvY2hyaXNfd29vZHMiLCAic3VtbWFyeSI6ICIifV0sICJw
+        ZXJzb25zIjogWyJodHRwczovL3Jhdy5naXRodWJ1c2VyY29udGVudC5jb20v
+        b3BlbmF1c3RyYWxpYS9hdXN0cmFsaWFuX2xvY2FsX2NvdW5jaWxsb3JzX3Bv
+        cG9sby9tYXN0ZXIvbnN3X2xvY2FsX2NvdW5jaWxsb3JfcG9wb2xvLmpzb24v
+        cGVyc29uL21hcnJpY2t2aWxsZV9jb3VuY2lsL2NocmlzX3dvb2RzIl0sICJw
+        dWJsaWMiOiB0cnVlLCAicmVzb3VyY2VfdXJpIjogIi9hcGkvdjEvbWVzc2Fn
+        ZS81NjY1LyIsICJzbHVnIjogInBsYW5uaW5nLWFwcGxpY2F0aW9uLWF0LWEt
+        dGVzdC1hZGRyZXNzLTMiLCAic3ViamVjdCI6ICJQbGFubmluZyBhcHBsaWNh
+        dGlvbiBhdCBBIHRlc3QgYWRkcmVzcyIsICJ1cGRhdGVkIjogIjIwMTYtMDQt
+        MDZUMDU6Mjk6NDIuOTk2Nzg3IiwgIndyaXRlaXRpbnN0YW5jZSI6ICIvYXBp
+        L3YxL2luc3RhbmNlLzE5MjcvIn0=
+    http_version: 
+  recorded_at: Wed, 06 Apr 2016 05:29:43 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/vcr_cassettes/planningalerts.yml
+++ b/spec/fixtures/vcr_cassettes/planningalerts.yml
@@ -823,4 +823,98 @@ http_interactions:
       string: "{\"errors\":[{\"message\":\"Invalid or expired token\",\"code\":89}]}"
     http_version: 
   recorded_at: Sun, 22 Sep 2013 19:43:33 GMT
+- request:
+    method: get
+    uri: http://writeit.ciudadanointeligente.org/api/v1/message/5652?api_key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&format=json&username=henare
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - '*/*; q=0.5, application/xml'
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Date:
+      - Tue, 05 Apr 2016 05:15:33 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - gunicorn/19.2.1
+      Vary:
+      - Accept-Language, Host, Cookie
+      Location:
+      - http://writeit.ciudadanointeligente.org/api/v1/message/5652/?format=json&username=henare&api_key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Content-Language:
+      - en
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 05 Apr 2016 05:15:33 GMT
+- request:
+    method: get
+    uri: http://writeit.ciudadanointeligente.org/api/v1/message/5652/?api_key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&format=json&username=henare
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - '*/*; q=0.5, application/xml'
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 05 Apr 2016 05:15:33 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - gunicorn/19.2.1
+      Vary:
+      - Accept, Accept-Language, Host, Cookie
+      Content-Language:
+      - en
+      Cache-Control:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '{"answers": [{"content": "Test to Henare from Chris.", "content_html":
+        "", "created": "2016-04-04T06:58:38", "id": 629, "message_id": 5652, "person":
+        {"id": 43405, "image": "https://www.marrickville.nsw.gov.au/Global/marr/marrwr/_assets/main/lib65081/clr%20woods%20web.jpg",
+        "name": "Chris Woods", "popit_id": "person/marrickville_council/chris_woods",
+        "popit_url": "https://raw.githubusercontent.com/openaustralia/australian_local_councillors_popolo/master/nsw_local_councillor_popolo.json/person/marrickville_council/chris_woods",
+        "resource_uri": "https://raw.githubusercontent.com/openaustralia/australian_local_councillors_popolo/master/nsw_local_councillor_popolo.json/person/marrickville_council/chris_woods",
+        "summary": ""}, "resource_uri": ""}], "author_email": "replies@planningalerts.org.au",
+        "author_name": "Henare Degan", "confirmated": true, "content": "Hey, this
+        is just a test.", "created": "2016-04-04T06:53:28", "id": 5652, "moderated":
+        null, "people": [{"id": 43405, "image": "https://www.marrickville.nsw.gov.au/Global/marr/marrwr/_assets/main/lib65081/clr%20woods%20web.jpg",
+        "name": "Chris Woods", "popit_id": "person/marrickville_council/chris_woods",
+        "popit_url": "https://raw.githubusercontent.com/openaustralia/australian_local_councillors_popolo/master/nsw_local_councillor_popolo.json/person/marrickville_council/chris_woods",
+        "resource_uri": "https://raw.githubusercontent.com/openaustralia/australian_local_councillors_popolo/master/nsw_local_councillor_popolo.json/person/marrickville_council/chris_woods",
+        "summary": ""}], "persons": ["https://raw.githubusercontent.com/openaustralia/australian_local_councillors_popolo/master/nsw_local_councillor_popolo.json/person/marrickville_council/chris_woods"],
+        "public": true, "resource_uri": "/api/v1/message/5652/", "slug": "planning-application-at-33-westbourne-street-stanmore-nsw-2048",
+        "subject": "Planning application at 33 Westbourne Street Stanmore NSW 2048",
+        "updated": "2016-04-04T06:53:28", "writeitinstance": "/api/v1/instance/1927/"}'
+    http_version: 
+  recorded_at: Tue, 05 Apr 2016 05:15:33 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/vcr_cassettes/planningalerts.yml
+++ b/spec/fixtures/vcr_cassettes/planningalerts.yml
@@ -825,7 +825,7 @@ http_interactions:
   recorded_at: Sun, 22 Sep 2013 19:43:33 GMT
 - request:
     method: get
-    uri: http://writeit.ciudadanointeligente.org/api/v1/message/5652?api_key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&format=json&username=henare
+    uri: http://writeit.ciudadanointeligente.org/api/v1/message/1234?api_key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&format=json&username=henare
     body:
       encoding: US-ASCII
       string: ''
@@ -854,7 +854,7 @@ http_interactions:
       Vary:
       - Accept-Language, Host, Cookie
       Location:
-      - http://writeit.ciudadanointeligente.org/api/v1/message/5652/?format=json&username=henare&api_key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      - http://writeit.ciudadanointeligente.org/api/v1/message/1234/?format=json&username=henare&api_key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       Content-Language:
       - en
     body:
@@ -864,7 +864,7 @@ http_interactions:
   recorded_at: Tue, 05 Apr 2016 05:15:33 GMT
 - request:
     method: get
-    uri: http://writeit.ciudadanointeligente.org/api/v1/message/5652/?api_key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&format=json&username=henare
+    uri: http://writeit.ciudadanointeligente.org/api/v1/message/1234/?api_key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&format=json&username=henare
     body:
       encoding: US-ASCII
       string: ''
@@ -898,21 +898,21 @@ http_interactions:
       - no-cache
     body:
       encoding: UTF-8
-      string: '{"answers": [{"content": "Test to Henare from Chris.", "content_html":
-        "", "created": "2016-04-04T06:58:38", "id": 629, "message_id": 5652, "person":
+      string: '{"answers": [{"content": "I agree, thanks for your comment", "content_html":
+        "", "created": "2016-04-04T06:58:38", "id": 567, "message_id": 1234, "person":
         {"id": 43405, "image": "https://www.marrickville.nsw.gov.au/Global/marr/marrwr/_assets/main/lib65081/clr%20woods%20web.jpg",
         "name": "Chris Woods", "popit_id": "person/marrickville_council/chris_woods",
         "popit_url": "https://raw.githubusercontent.com/openaustralia/australian_local_councillors_popolo/master/nsw_local_councillor_popolo.json/person/marrickville_council/chris_woods",
         "resource_uri": "https://raw.githubusercontent.com/openaustralia/australian_local_councillors_popolo/master/nsw_local_councillor_popolo.json/person/marrickville_council/chris_woods",
         "summary": ""}, "resource_uri": ""}], "author_email": "replies@planningalerts.org.au",
         "author_name": "Henare Degan", "confirmated": true, "content": "Hey, this
-        is just a test.", "created": "2016-04-04T06:53:28", "id": 5652, "moderated":
+        is just a test.", "created": "2016-04-04T06:53:28", "id": 1234, "moderated":
         null, "people": [{"id": 43405, "image": "https://www.marrickville.nsw.gov.au/Global/marr/marrwr/_assets/main/lib65081/clr%20woods%20web.jpg",
         "name": "Chris Woods", "popit_id": "person/marrickville_council/chris_woods",
         "popit_url": "https://raw.githubusercontent.com/openaustralia/australian_local_councillors_popolo/master/nsw_local_councillor_popolo.json/person/marrickville_council/chris_woods",
         "resource_uri": "https://raw.githubusercontent.com/openaustralia/australian_local_councillors_popolo/master/nsw_local_councillor_popolo.json/person/marrickville_council/chris_woods",
         "summary": ""}], "persons": ["https://raw.githubusercontent.com/openaustralia/australian_local_councillors_popolo/master/nsw_local_councillor_popolo.json/person/marrickville_council/chris_woods"],
-        "public": true, "resource_uri": "/api/v1/message/5652/", "slug": "planning-application-at-33-westbourne-street-stanmore-nsw-2048",
+        "public": true, "resource_uri": "/api/v1/message/1234/", "slug": "planning-application-at-33-westbourne-street-stanmore-nsw-2048",
         "subject": "Planning application at 33 Westbourne Street Stanmore NSW 2048",
         "updated": "2016-04-04T06:53:28", "writeitinstance": "/api/v1/instance/1927/"}'
     http_version: 

--- a/spec/mailers/comment_notifier_spec.rb
+++ b/spec/mailers/comment_notifier_spec.rb
@@ -92,14 +92,7 @@ describe CommentNotifier do
 
   describe "#send_comment_via_writeit!" do
     around do |test|
-      writeit_env_variables = {
-        WRITEIT_BASE_URL: "http://writeit.ciudadanointeligente.org",
-        WRITEIT_URL: "/api/v1/instance/1927/",
-        WRITEIT_USERNAME: "henare",
-        WRITEIT_API_KEY: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-      }
-
-      with_modified_env(writeit_env_variables) do
+      with_modified_env(writeit_config_variables) do
         test.run
       end
     end

--- a/spec/mailers/comment_notifier_spec.rb
+++ b/spec/mailers/comment_notifier_spec.rb
@@ -91,6 +91,30 @@ describe CommentNotifier do
   end
 
   describe "#send_comment_via_writeit!" do
-    pending
+    around do |test|
+      writeit_env_variables = {
+        WRITEIT_BASE_URL: "http://writeit.ciudadanointeligente.org",
+        WRITEIT_URL: "/api/v1/instance/1927/",
+        WRITEIT_USERNAME: "henare",
+        WRITEIT_API_KEY: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      }
+
+      with_modified_env(writeit_env_variables) do
+        test.run
+      end
+    end
+
+    let(:comment) do
+      councillor = create(:councillor, popolo_id: "marrickville_council/chris_woods")
+      create(:comment, councillor: councillor)
+    end
+
+    it "sends the comment to the WriteIt API, and stores the created WriteIt message’s id on the comment" do
+      VCR.use_cassette('planningalerts') do
+        CommentNotifier.send_comment_via_writeit!(comment)
+      end
+
+      expect(comment.writeit_message_id).to eq 5665
+    end
   end
 end

--- a/spec/mailers/comment_notifier_spec.rb
+++ b/spec/mailers/comment_notifier_spec.rb
@@ -89,4 +89,8 @@ describe CommentNotifier do
       # It should not be enabled for the NSW theme
     end
   end
+
+  describe "#send_comment_via_writeit!" do
+    pending
+  end
 end

--- a/spec/models/add_comment_spec.rb
+++ b/spec/models/add_comment_spec.rb
@@ -250,8 +250,4 @@ describe AddComment do
       expect(add_comment_form.address).to be_nil
     end
   end
-
-  def with_modified_env(options, &block)
-    ClimateControl.modify(options, &block)
-  end
 end

--- a/spec/models/authority_spec.rb
+++ b/spec/models/authority_spec.rb
@@ -80,10 +80,6 @@ describe Authority do
         it { expect(authority.write_to_councillors_enabled?).to eq true }
       end
     end
-
-    def with_modified_env(options, &block)
-      ClimateControl.modify(options, &block)
-    end
   end
 
   describe "#comments_per_week" do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -271,6 +271,14 @@ describe Comment do
       expect(comment.replies.first.received_at).to eql Time.utc(2016, 4, 4, 6, 58, 38)
     end
 
+    it "returns an empty Array if all the replies on WriteIt have already been added" do
+      VCR.use_cassette('planningalerts') do
+        create(:reply, comment: comment, writeit_id: 567)
+
+        expect(comment.create_replies_from_writeit!).to be_empty
+      end
+    end
+
     it "does nothing if the comment has no writeit_message_id" do
       VCR.use_cassette('planningalerts') do
         expect(create(:comment).create_replies_from_writeit!).to be_false

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -243,14 +243,7 @@ describe Comment do
 
   describe "#create_replies_from_writeit!" do
     around do |test|
-      writeit_env_variables = {
-        WRITEIT_BASE_URL: "http://writeit.ciudadanointeligente.org",
-        WRITEIT_URL: "/api/v1/instance/1927/",
-        WRITEIT_USERNAME: "henare",
-        WRITEIT_API_KEY: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-      }
-
-      with_modified_env(writeit_env_variables) do
+      with_modified_env(writeit_config_variables) do
         test.run
       end
     end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -270,5 +270,11 @@ describe Comment do
       expect(comment.replies.first.councillor).to eql comment.councillor
       expect(comment.replies.first.received_at).to eql Time.utc(2016, 4, 4, 6, 58, 38)
     end
+
+    it "does nothing if the comment has no writeit_message_id" do
+      VCR.use_cassette('planningalerts') do
+        expect(create(:comment).create_replies_from_writeit!).to be_false
+      end
+    end
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -284,5 +284,9 @@ describe Comment do
         expect(create(:comment).create_replies_from_writeit!).to be_false
       end
     end
+
+    it "returns an empty Array if there are no replies on WriteIt" do
+      pending
+    end
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -256,7 +256,7 @@ describe Comment do
     end
 
     let(:comment) do
-      create(:comment_to_councillor, writeit_message_id: 5652)
+      create(:comment_to_councillor, writeit_message_id: 1234)
     end
 
     it "fetches answers from WriteIt, creates replies and returns them" do
@@ -265,8 +265,8 @@ describe Comment do
       end
 
       expect(comment.replies.count).to eql 1
-      expect(comment.replies.first.text).to eql "Test to Henare from Chris."
-      expect(comment.replies.first.writeit_id).to eql 629
+      expect(comment.replies.first.text).to eql "I agree, thanks for your comment"
+      expect(comment.replies.first.writeit_id).to eql 567
       expect(comment.replies.first.councillor).to eql comment.councillor
       expect(comment.replies.first.received_at).to eql Time.utc(2016, 4, 4, 6, 58, 38)
     end

--- a/spec/models/councillor_spec.rb
+++ b/spec/models/councillor_spec.rb
@@ -13,4 +13,11 @@ describe Councillor do
     it { expect(Councillor.new(authority: create(:authority), email: "foo@bar.com")).to be_valid }
     it { expect(Councillor.new(authority: create(:authority), email: "foo@bar.com", image_url: "https://foobar.com")).to be_valid }
   end
+
+  describe "#writeit_id" do
+    it "combines the popolo_id with the authority popolo_url" do
+      expect(create(:councillor, popolo_id: "authority/foo_bar").writeit_id)
+        .to eql "https://raw.githubusercontent.com/openaustralia/australian_local_councillors_popolo/master/nsw_local_councillor_popolo.json/person/authority/foo_bar"
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,4 +72,5 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
   config.include Devise::TestHelpers, type: :view
   config.include SessionHelpers, type: :feature
+  config.include EnvHelpers
 end

--- a/spec/support/env_helpers.rb
+++ b/spec/support/env_helpers.rb
@@ -1,0 +1,5 @@
+module EnvHelpers
+  def with_modified_env(options, &block)
+    ClimateControl.modify(options, &block)
+  end
+end

--- a/spec/support/env_helpers.rb
+++ b/spec/support/env_helpers.rb
@@ -1,4 +1,11 @@
 module EnvHelpers
+  def writeit_config_variables
+    { WRITEIT_BASE_URL: "http://writeit.ciudadanointeligente.org",
+      WRITEIT_URL: "/api/v1/instance/1927/",
+      WRITEIT_USERNAME: "henare",
+      WRITEIT_API_KEY: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" }
+  end
+
   def with_modified_env(options, &block)
     ClimateControl.modify(options, &block)
   end


### PR DESCRIPTION
This is a really hacky spike to get WriteIt integrated for Write To Councillors.

## TODO

- [x] Fetch a reply to a comment
    - [x] Store writeit message id on comment
    - [x] Get comment with “answers” from the writeit api
    - [x] Save answer as a reply
    - [x] Save the Writeit answer id on the reply so that we can check for dupes
    - [x] It shouldn't check for replies if we've already had a reply
- [x] Respond to an inbound webhook from WriteIt http://requestb.in/18yqlwu1?inspect
- [x] Deploy to test so we can fully test all the webhooks etc.
    - [x] When we deploy to test we'll need to let the webhooks through our http auth barrier (We need to use this URL http://nsw.test.planningalerts.org.au/comments/reply_webhook because we force SSL on the main test site and the certificate is broken)
- [x] Make reply loader accept multiple replies
- [x] Resolve TODOs in sending code
- [x] Massive tidy up of hacky code