### PR TITLE
#442 Add home_page attribute for authorities

### DIFF
--- a/app/admin/authorities.rb
+++ b/app/admin/authorities.rb
@@ -23,6 +23,7 @@ ActiveAdmin.register Authority do
       row :full_name
       row :short_name
       row :state
+      row :home_page
       row :email
       row :write_to_councillors_enabled
       row :population_2011
@@ -58,6 +59,7 @@ ActiveAdmin.register Authority do
       input :short_name
     end
     inputs "Details" do
+      input :home_page
       input :state
       input :email
       input :population_2011
@@ -103,7 +105,8 @@ ActiveAdmin.register Authority do
     column :morph_name
     column(:number_of_applications) { |a| a.applications.count }
     column(:number_of_comments) { |a| a.comments.count }
+    column :home_page
   end
 
-  permit_params :full_name, :short_name, :state, :email, :write_to_councillors_enabled, :population_2011, :morph_name, :disabled
+  permit_params :full_name, :short_name, :state, :email, :write_to_councillors_enabled, :population_2011, :morph_name, :disabled, :home_page
 end

--- a/app/views/authorities/show.html.haml
+++ b/app/views/authorities/show.html.haml
@@ -1,5 +1,8 @@
 - content_for :page_title, @authority.full_name
 %h3= yield :page_title
+- if @authority.home_page
+  %p
+    <a href="#{@authority.home_page}" target="_blank">#{@authority.home_page}</a>
 
 - if @authority.population_2011
   %p

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -95,15 +95,16 @@ ActiveRecord::Schema.define(version: 20160330040409) do
   add_index "applications", ["suburb"], name: "index_applications_on_suburb", using: :btree
 
   create_table "authorities", force: true do |t|
-    t.string  "full_name",            limit: 200, null: false
-    t.string  "short_name",           limit: 100, null: false
+    t.string  "full_name",                    limit: 200,                 null: false
+    t.string  "short_name",                   limit: 100,                 null: false
     t.boolean "disabled"
-    t.string  "state",                limit: 20
+    t.string  "state",                        limit: 20
     t.string  "email"
     t.integer "population_2011"
     t.text    "last_scraper_run_log"
     t.string  "morph_name"
     t.boolean "write_to_councillors_enabled",             default: false, null: false
+    t.string  "home_page"
   end
 
   add_index "authorities", ["short_name"], name: "short_name_unique", unique: true, using: :btree


### PR DESCRIPTION
Cleaner version of #940.

Closes #442.
## TODO
- [x] Add a field in the database
- [ ] Fill in the values
- [x] Show the values on the authority detail page
- [ ] Deliver this in the api
