### PR TITLE
Add a Alert sign up form to authority applications pages

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -13,6 +13,7 @@ class ApplicationsController < ApplicationController
       apps = @authority.applications
       @description << " from #{@authority.full_name_and_state}"
       @alert = Alert.new
+      @alert.address_for_placeholder = apps.last.address if apps.any?
     else
       @description << " within the last #{Application.nearby_and_recent_max_age_months} months"
       apps = Application.where("date_scraped > ?", Application.nearby_and_recent_max_age_months.months.ago)

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -12,6 +12,7 @@ class ApplicationsController < ApplicationController
       @authority = Authority.find_by_short_name_encoded!(params[:authority_id])
       apps = @authority.applications
       @description << " from #{@authority.full_name_and_state}"
+      @alert = Alert.new
     else
       @description << " within the last #{Application.nearby_and_recent_max_age_months} months"
       apps = Application.where("date_scraped > ?", Application.nearby_and_recent_max_age_months.months.ago)

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -12,14 +12,14 @@ class ApplicationsController < ApplicationController
       @authority = Authority.find_by_short_name_encoded!(params[:authority_id])
       apps = @authority.applications
       @description << " from #{@authority.full_name_and_state}"
-      @alert = Alert.new
-      @alert.address_for_placeholder = apps.last.address if apps.any?
     else
       @description << " within the last #{Application.nearby_and_recent_max_age_months} months"
       apps = Application.where("date_scraped > ?", Application.nearby_and_recent_max_age_months.months.ago)
     end
 
     @applications = apps.paginate(page: params[:page], per_page: 30)
+    @alert = Alert.new
+    @alert.address_for_placeholder = @applications.last.address if @applications.any?
   end
 
   # JSON api for returning the number of scraped applications per day

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -8,6 +8,8 @@ class Alert < ActiveRecord::Base
   before_create :remove_other_alerts_for_this_address
   acts_as_email_confirmable
 
+  attr_writer :address_for_placeholder
+
   scope :active, -> { where(confirmed: true, unsubscribed: false) }
   scope :in_past_week, -> { where("created_at > ?", 7.days.ago) }
   # People with 3 or more alerts that don't yet have a subscription
@@ -48,6 +50,10 @@ class Alert < ActiveRecord::Base
   # Only enable subscriptions on the default theme
   def subscription
     super if theme == "default"
+  end
+
+  def address_for_placeholder
+    @address_for_placeholder || "1 Sowerby St, Goulburn, NSW 2580"
   end
 
   # Name of the local government authority

--- a/app/views/alerts/_signup_form.html.haml
+++ b/app/views/alerts/_signup_form.html.haml
@@ -1,6 +1,14 @@
 = semantic_form_for alert do |f|
   = f.inputs do
-    = f.input :address, label: "Enter a street address", placeholder: "e.g. 1 Sowerby St, Goulburn, NSW 2580", input_html: { required: "required" }
-    = f.input :email, label: "Enter your email address", placeholder: "your@email.com", input_html: { required: "required" }
+    = f.input :address,
+              label: "Enter a street address",
+              placeholder: "e.g. 1 Sowerby St, Goulburn, NSW 2580",
+              input_html: { required: "required" }
+    = f.input :email,
+              label: "Enter your email address",
+              placeholder: "your@email.com",
+              input_html: { required: "required" }
   = f.actions do
-    = f.action :submit, label: "Create alert", button_html: { class: "button button-rounded button-large button-action" }
+    = f.action :submit,
+               label: "Create alert",
+               button_html: { class: "button button-rounded button-large button-action" }

--- a/app/views/alerts/_signup_form.html.haml
+++ b/app/views/alerts/_signup_form.html.haml
@@ -1,0 +1,6 @@
+= semantic_form_for alert, url: {action: 'create'} do |f|
+  = f.inputs do
+    = f.input :address, label: "Enter a street address", placeholder: "e.g. 1 Sowerby St, Goulburn, NSW 2580", input_html: { required: "required" }
+    = f.input :email, label: "Enter your email address", placeholder: "your@email.com", input_html: { required: "required" }
+  = f.actions do
+    = f.action :submit, label: "Create alert", button_html: { class: "button button-rounded button-large button-action" }

--- a/app/views/alerts/_signup_form.html.haml
+++ b/app/views/alerts/_signup_form.html.haml
@@ -6,7 +6,7 @@
     - else
       = f.input :address,
                 label: "Enter a street address",
-                placeholder: "e.g. 1 Sowerby St, Goulburn, NSW 2580",
+                placeholder: "e.g. #{alert.address_for_placeholder}",
                 input_html: { required: "required" }
     = f.input :email,
               label: "Enter your email address",

--- a/app/views/alerts/_signup_form.html.haml
+++ b/app/views/alerts/_signup_form.html.haml
@@ -1,4 +1,5 @@
 = semantic_form_for alert, html: {class: form_classes} do |f|
+  = render "alerts/signup_introduction" if with_intro
   = f.inputs do
     = f.input :address,
               label: "Enter a street address",

--- a/app/views/alerts/_signup_form.html.haml
+++ b/app/views/alerts/_signup_form.html.haml
@@ -1,10 +1,13 @@
 = semantic_form_for alert, html: {class: form_classes} do |f|
   = render "alerts/signup_introduction" if with_intro
   = f.inputs do
-    = f.input :address,
-              label: "Enter a street address",
-              placeholder: "e.g. 1 Sowerby St, Goulburn, NSW 2580",
-              input_html: { required: "required" }
+    - if address_hidden
+      = f.input :address, as: :hidden
+    - else
+      = f.input :address,
+                label: "Enter a street address",
+                placeholder: "e.g. 1 Sowerby St, Goulburn, NSW 2580",
+                input_html: { required: "required" }
     = f.input :email,
               label: "Enter your email address",
               placeholder: "your@email.com",

--- a/app/views/alerts/_signup_form.html.haml
+++ b/app/views/alerts/_signup_form.html.haml
@@ -1,4 +1,4 @@
-= semantic_form_for alert do |f|
+= semantic_form_for alert, html: {class: form_classes} do |f|
   = f.inputs do
     = f.input :address,
               label: "Enter a street address",

--- a/app/views/alerts/_signup_form.html.haml
+++ b/app/views/alerts/_signup_form.html.haml
@@ -1,4 +1,4 @@
-= semantic_form_for alert, url: {action: 'create'} do |f|
+= semantic_form_for alert do |f|
   = f.inputs do
     = f.input :address, label: "Enter a street address", placeholder: "e.g. 1 Sowerby St, Goulburn, NSW 2580", input_html: { required: "required" }
     = f.input :email, label: "Enter your email address", placeholder: "your@email.com", input_html: { required: "required" }

--- a/app/views/alerts/_signup_form.html.haml
+++ b/app/views/alerts/_signup_form.html.haml
@@ -4,15 +4,12 @@
     - if address_hidden
       = f.input :address, as: :hidden
     - else
-      = f.input :address,
-                label: "Enter a street address",
-                placeholder: "e.g. #{alert.address_for_placeholder}",
-                input_html: { required: "required" }
-    = f.input :email,
-              label: "Enter your email address",
-              placeholder: "your@email.com",
-              input_html: { required: "required" }
+      = f.input :address, label: "Enter a street address",
+                          placeholder: "e.g. #{alert.address_for_placeholder}",
+                          input_html: { required: "required" }
+    = f.input :email, label: "Enter your email address",
+                      placeholder: "your@email.com",
+                      input_html: { required: "required" }
   = f.actions do
-    = f.action :submit,
-               label: "Create alert",
-               button_html: { class: "button button-rounded button-large button-action" }
+    = f.action :submit, label: "Create alert",
+                        button_html: { class: "button button-rounded button-large button-action" }

--- a/app/views/alerts/new.html.haml
+++ b/app/views/alerts/new.html.haml
@@ -2,7 +2,7 @@
 
 - content_for :meta_description, @themer.default_meta_description
 
-= render "signup_form", alert: @alert
+= render "signup_form", alert: @alert, form_classes: nil
 
 %p You will receive email only when there are new applications nearby and no more than once per day.
 

--- a/app/views/alerts/new.html.haml
+++ b/app/views/alerts/new.html.haml
@@ -2,7 +2,10 @@
 
 - content_for :meta_description, @themer.default_meta_description
 
-= render "signup_form", alert: @alert, with_intro: false, address_hidden: false, form_classes: nil
+= render "signup_form", alert: @alert,
+                        with_intro: false,
+                        address_hidden: false,
+                        form_classes: nil
 
 %p You will receive email only when there are new applications nearby and no more than once per day.
 

--- a/app/views/alerts/new.html.haml
+++ b/app/views/alerts/new.html.haml
@@ -2,7 +2,7 @@
 
 - content_for :meta_description, @themer.default_meta_description
 
-= render "signup_form", alert: @alert, form_classes: nil
+= render "signup_form", alert: @alert, with_intro: false, form_classes: nil
 
 %p You will receive email only when there are new applications nearby and no more than once per day.
 

--- a/app/views/alerts/new.html.haml
+++ b/app/views/alerts/new.html.haml
@@ -2,12 +2,7 @@
 
 - content_for :meta_description, @themer.default_meta_description
 
-= semantic_form_for @alert, url: {action: 'create'} do |f|
-  = f.inputs do
-    = f.input :address, label: "Enter a street address", placeholder: "e.g. 1 Sowerby St, Goulburn, NSW 2580", input_html: { required: "required" }
-    = f.input :email, label: "Enter your email address", placeholder: "your@email.com", input_html: { required: "required" }
-  = f.actions do
-    = f.action :submit, label: "Create alert", button_html: { class: "button button-rounded button-large button-action" }
+= render "signup_form", alert: @alert
 
 %p You will receive email only when there are new applications nearby and no more than once per day.
 

--- a/app/views/alerts/new.html.haml
+++ b/app/views/alerts/new.html.haml
@@ -2,7 +2,7 @@
 
 - content_for :meta_description, @themer.default_meta_description
 
-= render "signup_form", alert: @alert, with_intro: false, form_classes: nil
+= render "signup_form", alert: @alert, with_intro: false, address_hidden: false, form_classes: nil
 
 %p You will receive email only when there are new applications nearby and no more than once per day.
 

--- a/app/views/applications/address_results.html.haml
+++ b/app/views/applications/address_results.html.haml
@@ -27,14 +27,10 @@
     The more people that sign up for your area, the sooner we'll add your area to PlanningAlerts. So, get your friends and neighbours to sign up too!
 
 - else
-
-  = semantic_form_for @alert, html: {class: "attention"} do |f|
-    = render "alerts/signup_introduction"
-    = f.inputs do
-      = f.input :address, as: :hidden
-      = f.input :email, label: "Enter your email address", placeholder: "your@email.com", input_html: { required: "required" }
-    = f.actions do
-      = f.action :submit, label: "Create alert", button_html: { class: "button button-rounded button-action button-large" }
+  = render "alerts/signup_form", alert: @alert,
+                                 with_intro: true,
+                                 address_hidden: true,
+                                 form_classes: "attention"
 
   %ul.list-options
     %li

--- a/app/views/applications/index.html.haml
+++ b/app/views/applications/index.html.haml
@@ -3,9 +3,9 @@
 %h3= @description
 
 = render "alerts/signup_form", alert: @alert,
-                                with_intro: true,
-                                address_hidden: false,
-                                form_classes: "attention"
+                               with_intro: true,
+                               address_hidden: false,
+                               form_classes: "attention"
 
 - if @authority && @authority.broken?
   - if @authority.latest_application_date.nil?

--- a/app/views/applications/index.html.haml
+++ b/app/views/applications/index.html.haml
@@ -2,6 +2,10 @@
 
 %h3= @description
 
+- if @authority
+  = render "alerts/signup_introduction"
+  = render "alerts/signup_form", alert: @alert
+
 - if @authority && @authority.broken?
   - if @authority.latest_application_date.nil?
     %span.highlight There are no applications yet for this authority

--- a/app/views/applications/index.html.haml
+++ b/app/views/applications/index.html.haml
@@ -3,7 +3,10 @@
 %h3= @description
 
 - if @authority
-  = render "alerts/signup_form", alert: @alert, with_intro: true, form_classes: "attention"
+  = render "alerts/signup_form", alert: @alert,
+                                 with_intro: true,
+                                 address_hidden: false,
+                                 form_classes: "attention"
 
 - if @authority && @authority.broken?
   - if @authority.latest_application_date.nil?

--- a/app/views/applications/index.html.haml
+++ b/app/views/applications/index.html.haml
@@ -2,11 +2,10 @@
 
 %h3= @description
 
-- if @authority
-  = render "alerts/signup_form", alert: @alert,
-                                 with_intro: true,
-                                 address_hidden: false,
-                                 form_classes: "attention"
+= render "alerts/signup_form", alert: @alert,
+                                with_intro: true,
+                                address_hidden: false,
+                                form_classes: "attention"
 
 - if @authority && @authority.broken?
   - if @authority.latest_application_date.nil?

--- a/app/views/applications/index.html.haml
+++ b/app/views/applications/index.html.haml
@@ -3,8 +3,7 @@
 %h3= @description
 
 - if @authority
-  = render "alerts/signup_introduction"
-  = render "alerts/signup_form", alert: @alert, form_classes: "attention"
+  = render "alerts/signup_form", alert: @alert, with_intro: true, form_classes: "attention"
 
 - if @authority && @authority.broken?
   - if @authority.latest_application_date.nil?

--- a/app/views/applications/index.html.haml
+++ b/app/views/applications/index.html.haml
@@ -4,7 +4,7 @@
 
 - if @authority
   = render "alerts/signup_introduction"
-  = render "alerts/signup_form", alert: @alert
+  = render "alerts/signup_form", alert: @alert, form_classes: "attention"
 
 - if @authority && @authority.broken?
   - if @authority.latest_application_date.nil?

--- a/spec/features/manage_alerts_spec.rb
+++ b/spec/features/manage_alerts_spec.rb
@@ -1,32 +1,6 @@
 require 'spec_helper'
 
 feature "Manage alerts" do
-  # In order to see new development applications in my suburb
-  # I want to sign up for an email alert
-  
-  scenario "Sign up for email alert" do
-    VCR.use_cassette('planningalerts') do
-      visit '/alerts/signup'
-
-      fill_in("alert_email", with: "example@example.com")
-      fill_in("alert_address", with: "24 Bruce Road, Glenbrook")
-      click_button("Create alert")
-    end
-
-    page.should have_content("Now check your email")
-
-    unread_emails_for("example@example.com").size.should == 1
-    open_email("example@example.com")
-    current_email.should have_subject("Please confirm your planning alert")
-    current_email.default_part_body.to_s.should include("24 Bruce Road, Glenbrook NSW 2773")
-    click_first_link_in_email
-
-    page.should have_content("your alert has been activated")
-    page.should have_content("24 Bruce Road, Glenbrook NSW 2773")
-    page.should_not have_content("You now have several email alerts")
-    Alert.active.find_by(address: "24 Bruce Road, Glenbrook NSW 2773", radius_meters: "2000", email: current_email_address).should_not be_nil
-  end
-
   scenario "Unsubscribe from an email alert" do
     # Adding arbitrary coordinates so that geocoding is not carried out
     alert = create(:alert, address: "24 Bruce Rd, Glenbrook", email: "example@example.com",

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -18,7 +18,6 @@ feature "Sign up for alerts" do
 
     page.should have_content("Now check your email")
 
-    unread_emails_for("example@example.com").size.should == 1
     open_email("example@example.com")
     current_email.should have_subject("Please confirm your planning alert")
     current_email.default_part_body.to_s.should include("24 Bruce Road, Glenbrook NSW 2773")

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -12,8 +12,8 @@ feature "Sign up for alerts" do
   scenario "successfully" do
     visit '/alerts/signup'
 
-    fill_in("alert_email", with: "example@example.com")
-    fill_in("alert_address", with: "24 Bruce Rd, Glenbrook")
+    fill_in("Enter your email address", with: "example@example.com")
+    fill_in("Enter a street address", with: "24 Bruce Rd, Glenbrook")
     click_button("Create alert")
 
     expect(page).to have_content("Now check your email")
@@ -84,8 +84,8 @@ feature "Sign up for alerts" do
     scenario "successfully" do
       visit applications_path(authority: authority)
 
-      fill_in("alert_email", with: "example@example.com")
-      fill_in("alert_address", with: "24 Bruce Rd, Glenbrook")
+      fill_in("Enter your email address", with: "example@example.com")
+      fill_in("Enter a street address", with: "24 Bruce Rd, Glenbrook")
       click_button("Create alert")
 
       expect(page).to have_content("Now check your email")

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+feature "Sign up for alerts" do
+  # In order to see new development applications in my suburb
+  # I want to sign up for an email alert
+  scenario "successfully" do
+    VCR.use_cassette('planningalerts') do
+      visit '/alerts/signup'
+
+      fill_in("alert_email", with: "example@example.com")
+      fill_in("alert_address", with: "24 Bruce Road, Glenbrook")
+      click_button("Create alert")
+    end
+
+    page.should have_content("Now check your email")
+
+    unread_emails_for("example@example.com").size.should == 1
+    open_email("example@example.com")
+    current_email.should have_subject("Please confirm your planning alert")
+    current_email.default_part_body.to_s.should include("24 Bruce Road, Glenbrook NSW 2773")
+    click_first_link_in_email
+
+    page.should have_content("your alert has been activated")
+    page.should have_content("24 Bruce Road, Glenbrook NSW 2773")
+    page.should_not have_content("You now have several email alerts")
+    Alert.active.find_by(address: "24 Bruce Road, Glenbrook NSW 2773", radius_meters: "2000", email: current_email_address).should_not be_nil
+  end
+end

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -78,7 +78,6 @@ feature "Sign up for alerts" do
       create(:application, address: "26 Bruce Rd, Glenbrook NSW 2773", authority: authority)
     end
 
-
     scenario "successfully" do
       visit applications_path(authority_id: "glenbrook")
 

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -13,20 +13,17 @@ feature "Sign up for alerts" do
     visit '/alerts/signup'
 
     fill_in("alert_email", with: "example@example.com")
-    fill_in("alert_address", with: "24 Bruce Road, Glenbrook")
+    fill_in("alert_address", with: "24 Bruce Rd, Glenbrook")
     click_button("Create alert")
 
     page.should have_content("Now check your email")
 
-    open_email("example@example.com")
-    current_email.should have_subject("Please confirm your planning alert")
-    current_email.default_part_body.to_s.should include("24 Bruce Road, Glenbrook NSW 2773")
-    click_first_link_in_email
+    confirm_alert_in_email
 
     page.should have_content("your alert has been activated")
-    page.should have_content("24 Bruce Road, Glenbrook NSW 2773")
+    page.should have_content("24 Bruce Rd, Glenbrook NSW 2773")
     page.should_not have_content("You now have several email alerts")
-    Alert.active.find_by(address: "24 Bruce Road, Glenbrook NSW 2773", radius_meters: "2000", email: current_email_address).should_not be_nil
+    Alert.active.find_by(address: "24 Bruce Rd, Glenbrook NSW 2773", radius_meters: "2000", email: current_email_address).should_not be_nil
   end
 
   context "via an application page" do
@@ -44,9 +41,7 @@ feature "Sign up for alerts" do
 
       page.should have_content("Now check your email")
 
-      open_email("example@example.com")
-      current_email.should have_subject("Please confirm your planning alert")
-      click_first_link_in_email
+      confirm_alert_in_email
 
       page.should have_content("your alert has been activated")
     end
@@ -59,7 +54,7 @@ feature "Sign up for alerts" do
 
     scenario "successfully" do
       visit root_path
-      fill_in("Enter a street address", with: "24 Bruce Road, Glenbrook")
+      fill_in("Enter a street address", with: "24 Bruce Rd, Glenbrook")
       click_button("Search")
 
       fill_in("Enter your email address", with: "example@example.com")
@@ -67,11 +62,16 @@ feature "Sign up for alerts" do
 
       page.should have_content("Now check your email")
 
-      open_email("example@example.com")
-      current_email.should have_subject("Please confirm your planning alert")
-      click_first_link_in_email
+      confirm_alert_in_email
 
       page.should have_content("your alert has been activated")
     end
+  end
+
+  def confirm_alert_in_email
+    open_email("example@example.com")
+    current_email.should have_subject("Please confirm your planning alert")
+    current_email.default_part_body.to_s.should include("24 Bruce Rd, Glenbrook NSW 2773")
+    click_first_link_in_email
   end
 end

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -12,8 +12,8 @@ feature "Sign up for alerts" do
   scenario "successfully" do
     visit '/alerts/signup'
 
-    fill_in("Enter your email address", with: "example@example.com")
     fill_in("Enter a street address", with: "24 Bruce Rd, Glenbrook")
+    fill_in("Enter your email address", with: "example@example.com")
     click_button("Create alert")
 
     expect(page).to have_content("Now check your email")
@@ -84,8 +84,8 @@ feature "Sign up for alerts" do
     scenario "successfully" do
       visit applications_path(authority: authority)
 
-      fill_in("Enter your email address", with: "example@example.com")
       fill_in("Enter a street address", with: "24 Bruce Rd, Glenbrook")
+      fill_in("Enter your email address", with: "example@example.com")
       click_button("Create alert")
 
       expect(page).to have_content("Now check your email")

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -26,6 +26,35 @@ feature "Sign up for alerts" do
     Alert.active.find_by(address: "24 Bruce Road, Glenbrook NSW 2773", radius_meters: "2000", email: current_email_address).should_not be_nil
   end
 
+  context "via an application page" do
+    around do |example|
+      VCR.use_cassette('planningalerts') do
+        example.run
+      end
+    end
+
+    given(:application) do
+      create(:application, address: "24 Bruce Rd, Glenbrook NSW 2773")
+    end
+
+    scenario "successfully" do
+      visit application_path(application)
+
+      within "#new_alert" do
+        fill_in("Enter your email address", with: "example@example.com")
+        click_button("Create Alert")
+      end
+
+      page.should have_content("Now check your email")
+
+      open_email("example@example.com")
+      current_email.should have_subject("Please confirm your planning alert")
+      click_first_link_in_email
+
+      page.should have_content("your alert has been activated")
+    end
+  end
+
   context "via the homepage" do
     around do |example|
       VCR.use_cassette('planningalerts') do

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -3,14 +3,18 @@ require 'spec_helper'
 feature "Sign up for alerts" do
   # In order to see new development applications in my suburb
   # I want to sign up for an email alert
-  scenario "successfully" do
+  around do |example|
     VCR.use_cassette('planningalerts') do
-      visit '/alerts/signup'
-
-      fill_in("alert_email", with: "example@example.com")
-      fill_in("alert_address", with: "24 Bruce Road, Glenbrook")
-      click_button("Create alert")
+      example.run
     end
+  end
+
+  scenario "successfully" do
+    visit '/alerts/signup'
+
+    fill_in("alert_email", with: "example@example.com")
+    fill_in("alert_address", with: "24 Bruce Road, Glenbrook")
+    click_button("Create alert")
 
     page.should have_content("Now check your email")
 
@@ -27,12 +31,6 @@ feature "Sign up for alerts" do
   end
 
   context "via an application page" do
-    around do |example|
-      VCR.use_cassette('planningalerts') do
-        example.run
-      end
-    end
-
     given(:application) do
       create(:application, address: "24 Bruce Rd, Glenbrook NSW 2773")
     end
@@ -56,12 +54,6 @@ feature "Sign up for alerts" do
   end
 
   context "via the homepage" do
-    around do |example|
-      VCR.use_cassette('planningalerts') do
-        example.run
-      end
-    end
-
     background do
       create(:application, address: "26 Bruce Rd, Glenbrook NSW 2773")
     end

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -23,7 +23,11 @@ feature "Sign up for alerts" do
     expect(page).to have_content("your alert has been activated")
     expect(page).to have_content("24 Bruce Rd, Glenbrook NSW 2773")
     expect(page).to_not have_content("You now have several email alerts")
-    expect(Alert.active.find_by(address: "24 Bruce Rd, Glenbrook NSW 2773", radius_meters: "2000", email: current_email_address)).to_not be_nil
+    expect(
+      Alert.active.find_by(address: "24 Bruce Rd, Glenbrook NSW 2773",
+                           radius_meters: "2000",
+                           email: current_email_address)
+    ).to_not be_nil
   end
 
   context "via an application page" do

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -73,16 +73,14 @@ feature "Sign up for alerts" do
   end
 
   context "via an authority’s applications page" do
-    given(:authority) { create(:authority, full_name: "Glenbrook City Council") }
-
     background do
-      create(:application, address: "26 Bruce Rd, Glenbrook NSW 2773",
-                           authority: authority)
+      authority = create(:authority, short_name: "Glenbrook")
+      create(:application, address: "26 Bruce Rd, Glenbrook NSW 2773", authority: authority)
     end
 
 
     scenario "successfully" do
-      visit applications_path(authority: authority)
+      visit applications_path(authority_id: "glenbrook")
 
       fill_in("Enter a street address", with: "24 Bruce Rd, Glenbrook")
       fill_in("Enter your email address", with: "example@example.com")

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -25,4 +25,33 @@ feature "Sign up for alerts" do
     page.should_not have_content("You now have several email alerts")
     Alert.active.find_by(address: "24 Bruce Road, Glenbrook NSW 2773", radius_meters: "2000", email: current_email_address).should_not be_nil
   end
+
+  context "via the homepage" do
+    around do |example|
+      VCR.use_cassette('planningalerts') do
+        example.run
+      end
+    end
+
+    background do
+      create(:application, address: "26 Bruce Rd, Glenbrook NSW 2773")
+    end
+
+    scenario "successfully" do
+      visit root_path
+      fill_in("Enter a street address", with: "24 Bruce Road, Glenbrook")
+      click_button("Search")
+
+      fill_in("Enter your email address", with: "example@example.com")
+      click_button("Create alert")
+
+      page.should have_content("Now check your email")
+
+      open_email("example@example.com")
+      current_email.should have_subject("Please confirm your planning alert")
+      click_first_link_in_email
+
+      page.should have_content("your alert has been activated")
+    end
+  end
 end

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -16,14 +16,14 @@ feature "Sign up for alerts" do
     fill_in("alert_address", with: "24 Bruce Rd, Glenbrook")
     click_button("Create alert")
 
-    page.should have_content("Now check your email")
+    expect(page).to have_content("Now check your email")
 
     confirm_alert_in_email
 
-    page.should have_content("your alert has been activated")
-    page.should have_content("24 Bruce Rd, Glenbrook NSW 2773")
-    page.should_not have_content("You now have several email alerts")
-    Alert.active.find_by(address: "24 Bruce Rd, Glenbrook NSW 2773", radius_meters: "2000", email: current_email_address).should_not be_nil
+    expect(page).to have_content("your alert has been activated")
+    expect(page).to have_content("24 Bruce Rd, Glenbrook NSW 2773")
+    expect(page).to_not have_content("You now have several email alerts")
+    expect(Alert.active.find_by(address: "24 Bruce Rd, Glenbrook NSW 2773", radius_meters: "2000", email: current_email_address)).to_not be_nil
   end
 
   context "via an application page" do
@@ -39,11 +39,11 @@ feature "Sign up for alerts" do
         click_button("Create Alert")
       end
 
-      page.should have_content("Now check your email")
+      expect(page).to have_content("Now check your email")
 
       confirm_alert_in_email
 
-      page.should have_content("your alert has been activated")
+      expect(page).to have_content("your alert has been activated")
     end
   end
 
@@ -60,18 +60,18 @@ feature "Sign up for alerts" do
       fill_in("Enter your email address", with: "example@example.com")
       click_button("Create alert")
 
-      page.should have_content("Now check your email")
+      expect(page).to have_content("Now check your email")
 
       confirm_alert_in_email
 
-      page.should have_content("your alert has been activated")
+      expect(page).to have_content("your alert has been activated")
     end
   end
 
   def confirm_alert_in_email
     open_email("example@example.com")
-    current_email.should have_subject("Please confirm your planning alert")
-    current_email.default_part_body.to_s.should include("24 Bruce Rd, Glenbrook NSW 2773")
+    expect(current_email).to have_subject("Please confirm your planning alert")
+    expect(current_email.default_part_body.to_s).to include("24 Bruce Rd, Glenbrook NSW 2773")
     click_first_link_in_email
   end
 end

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -72,6 +72,30 @@ feature "Sign up for alerts" do
     end
   end
 
+  context "via an authority’s applications page" do
+    given(:authority) { create(:authority, full_name: "Glenbrook City Council") }
+
+    background do
+      create(:application, address: "26 Bruce Rd, Glenbrook NSW 2773",
+                           authority: authority)
+    end
+
+
+    scenario "successfully" do
+      visit applications_path(authority: authority)
+
+      fill_in("alert_email", with: "example@example.com")
+      fill_in("alert_address", with: "24 Bruce Rd, Glenbrook")
+      click_button("Create alert")
+
+      expect(page).to have_content("Now check your email")
+
+      confirm_alert_in_email
+
+      expect(page).to have_content("your alert has been activated")
+    end
+  end
+
   def confirm_alert_in_email
     open_email("example@example.com")
     expect(current_email).to have_subject("Please confirm your planning alert")

--- a/spec/fixtures/vcr_cassettes/planningalerts.yml
+++ b/spec/fixtures/vcr_cassettes/planningalerts.yml
@@ -26496,4 +26496,310 @@ http_interactions:
       string: ''
     http_version: 
   recorded_at: Fri, 06 May 2016 02:03:07 GMT
+- request:
+    method: get
+    uri: http://maps.google.com/maps/api/geocode/json?address=24%20Bruce%20Rd,%20Glenbrook%20NSW%202773&region=au&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 May 2016 04:41:36 GMT
+      Expires:
+      - Fri, 13 May 2016 04:41:36 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Vary:
+      - Accept-Language
+      Access-Control-Allow-Origin:
+      - '*'
+      Server:
+      - mafe
+      Content-Length:
+      - '497'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: UTF-8
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "24",
+                       "short_name" : "24",
+                       "types" : [ "street_number" ]
+                    },
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Glenbrook",
+                       "short_name" : "Glenbrook",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "New South Wales",
+                       "short_name" : "NSW",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "2773",
+                       "short_name" : "2773",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "24 Bruce Rd, Glenbrook NSW 2773, Australia",
+                 "geometry" : {
+                    "location" : {
+                       "lat" : -33.772607,
+                       "lng" : 150.624245
+                    },
+                    "location_type" : "ROOFTOP",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -33.7712580197085,
+                          "lng" : 150.6255939802915
+                       },
+                       "southwest" : {
+                          "lat" : -33.7739559802915,
+                          "lng" : 150.6228960197085
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJoSwL6FaIEmsRGfTm6gH-VJQ",
+                 "types" : [ "street_address" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Thu, 12 May 2016 04:41:36 GMT
+- request:
+    method: get
+    uri: http://maps.google.com/maps/api/geocode/json?address=24%20Bruce%20Road,%20Glenbrook%20NSW%202773&region=au&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 May 2016 04:41:37 GMT
+      Expires:
+      - Fri, 13 May 2016 04:41:37 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Vary:
+      - Accept-Language
+      Access-Control-Allow-Origin:
+      - '*'
+      Server:
+      - mafe
+      Content-Length:
+      - '497'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: UTF-8
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "24",
+                       "short_name" : "24",
+                       "types" : [ "street_number" ]
+                    },
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Glenbrook",
+                       "short_name" : "Glenbrook",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "New South Wales",
+                       "short_name" : "NSW",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "2773",
+                       "short_name" : "2773",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "24 Bruce Rd, Glenbrook NSW 2773, Australia",
+                 "geometry" : {
+                    "location" : {
+                       "lat" : -33.772607,
+                       "lng" : 150.624245
+                    },
+                    "location_type" : "ROOFTOP",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -33.7712580197085,
+                          "lng" : 150.6255939802915
+                       },
+                       "southwest" : {
+                          "lat" : -33.7739559802915,
+                          "lng" : 150.6228960197085
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJoSwL6FaIEmsRGfTm6gH-VJQ",
+                 "types" : [ "street_address" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Thu, 12 May 2016 04:41:37 GMT
+- request:
+    method: get
+    uri: http://maps.google.com/maps/api/geocode/json?address=26%20Bruce%20Rd,%20Glenbrook%20NSW%202773&region=au&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 May 2016 04:41:41 GMT
+      Expires:
+      - Fri, 13 May 2016 04:41:41 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Vary:
+      - Accept-Language
+      Access-Control-Allow-Origin:
+      - '*'
+      Server:
+      - mafe
+      Content-Length:
+      - '497'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: UTF-8
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "26",
+                       "short_name" : "26",
+                       "types" : [ "street_number" ]
+                    },
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Glenbrook",
+                       "short_name" : "Glenbrook",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "New South Wales",
+                       "short_name" : "NSW",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "2773",
+                       "short_name" : "2773",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "26 Bruce Rd, Glenbrook NSW 2773, Australia",
+                 "geometry" : {
+                    "location" : {
+                       "lat" : -33.77262,
+                       "lng" : 150.624566
+                    },
+                    "location_type" : "ROOFTOP",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -33.7712710197085,
+                          "lng" : 150.6259149802915
+                       },
+                       "southwest" : {
+                          "lat" : -33.77396898029149,
+                          "lng" : 150.6232170197085
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJc03v5VaIEmsRB_gEvj-6HXk",
+                 "types" : [ "street_address" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Thu, 12 May 2016 04:41:42 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/vcr_cassettes/planningalerts.yml
+++ b/spec/fixtures/vcr_cassettes/planningalerts.yml
@@ -26600,108 +26600,6 @@ http_interactions:
   recorded_at: Thu, 12 May 2016 04:41:36 GMT
 - request:
     method: get
-    uri: http://maps.google.com/maps/api/geocode/json?address=24%20Bruce%20Road,%20Glenbrook%20NSW%202773&region=au&sensor=false
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Thu, 12 May 2016 04:41:37 GMT
-      Expires:
-      - Fri, 13 May 2016 04:41:37 GMT
-      Cache-Control:
-      - public, max-age=86400
-      Vary:
-      - Accept-Language
-      Access-Control-Allow-Origin:
-      - '*'
-      Server:
-      - mafe
-      Content-Length:
-      - '497'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - SAMEORIGIN
-    body:
-      encoding: UTF-8
-      string: |
-        {
-           "results" : [
-              {
-                 "address_components" : [
-                    {
-                       "long_name" : "24",
-                       "short_name" : "24",
-                       "types" : [ "street_number" ]
-                    },
-                    {
-                       "long_name" : "Bruce Road",
-                       "short_name" : "Bruce Rd",
-                       "types" : [ "route" ]
-                    },
-                    {
-                       "long_name" : "Glenbrook",
-                       "short_name" : "Glenbrook",
-                       "types" : [ "locality", "political" ]
-                    },
-                    {
-                       "long_name" : "New South Wales",
-                       "short_name" : "NSW",
-                       "types" : [ "administrative_area_level_1", "political" ]
-                    },
-                    {
-                       "long_name" : "Australia",
-                       "short_name" : "AU",
-                       "types" : [ "country", "political" ]
-                    },
-                    {
-                       "long_name" : "2773",
-                       "short_name" : "2773",
-                       "types" : [ "postal_code" ]
-                    }
-                 ],
-                 "formatted_address" : "24 Bruce Rd, Glenbrook NSW 2773, Australia",
-                 "geometry" : {
-                    "location" : {
-                       "lat" : -33.772607,
-                       "lng" : 150.624245
-                    },
-                    "location_type" : "ROOFTOP",
-                    "viewport" : {
-                       "northeast" : {
-                          "lat" : -33.7712580197085,
-                          "lng" : 150.6255939802915
-                       },
-                       "southwest" : {
-                          "lat" : -33.7739559802915,
-                          "lng" : 150.6228960197085
-                       }
-                    }
-                 },
-                 "place_id" : "ChIJoSwL6FaIEmsRGfTm6gH-VJQ",
-                 "types" : [ "street_address" ]
-              }
-           ],
-           "status" : "OK"
-        }
-    http_version: 
-  recorded_at: Thu, 12 May 2016 04:41:37 GMT
-- request:
-    method: get
     uri: http://maps.google.com/maps/api/geocode/json?address=26%20Bruce%20Rd,%20Glenbrook%20NSW%202773&region=au&sensor=false
     body:
       encoding: US-ASCII
@@ -26904,4 +26802,106 @@ http_interactions:
         }
     http_version: 
   recorded_at: Thu, 12 May 2016 04:57:25 GMT
+- request:
+    method: get
+    uri: http://maps.google.com/maps/api/geocode/json?address=24%20Bruce%20Rd,%20Glenbrook&region=au&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 May 2016 05:09:36 GMT
+      Expires:
+      - Fri, 13 May 2016 05:09:36 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Vary:
+      - Accept-Language
+      Access-Control-Allow-Origin:
+      - '*'
+      Server:
+      - mafe
+      Content-Length:
+      - '497'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: UTF-8
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "24",
+                       "short_name" : "24",
+                       "types" : [ "street_number" ]
+                    },
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Glenbrook",
+                       "short_name" : "Glenbrook",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "New South Wales",
+                       "short_name" : "NSW",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "2773",
+                       "short_name" : "2773",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "24 Bruce Rd, Glenbrook NSW 2773, Australia",
+                 "geometry" : {
+                    "location" : {
+                       "lat" : -33.772607,
+                       "lng" : 150.624245
+                    },
+                    "location_type" : "ROOFTOP",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -33.7712580197085,
+                          "lng" : 150.6255939802915
+                       },
+                       "southwest" : {
+                          "lat" : -33.7739559802915,
+                          "lng" : 150.6228960197085
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJoSwL6FaIEmsRGfTm6gH-VJQ",
+                 "types" : [ "street_address" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Thu, 12 May 2016 05:09:36 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/vcr_cassettes/planningalerts.yml
+++ b/spec/fixtures/vcr_cassettes/planningalerts.yml
@@ -26802,4 +26802,106 @@ http_interactions:
         }
     http_version: 
   recorded_at: Thu, 12 May 2016 04:41:42 GMT
+- request:
+    method: get
+    uri: http://maps.google.com/maps/api/geocode/json?address=24%20Bruce%20Rd,%20Glenbrook%20NSW%202773&region=au&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 May 2016 04:57:25 GMT
+      Expires:
+      - Fri, 13 May 2016 04:57:25 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Vary:
+      - Accept-Language
+      Access-Control-Allow-Origin:
+      - '*'
+      Server:
+      - mafe
+      Content-Length:
+      - '497'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: UTF-8
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "24",
+                       "short_name" : "24",
+                       "types" : [ "street_number" ]
+                    },
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Glenbrook",
+                       "short_name" : "Glenbrook",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "New South Wales",
+                       "short_name" : "NSW",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "2773",
+                       "short_name" : "2773",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "24 Bruce Rd, Glenbrook NSW 2773, Australia",
+                 "geometry" : {
+                    "location" : {
+                       "lat" : -33.772607,
+                       "lng" : 150.624245
+                    },
+                    "location_type" : "ROOFTOP",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -33.7712580197085,
+                          "lng" : 150.6255939802915
+                       },
+                       "southwest" : {
+                          "lat" : -33.7739559802915,
+                          "lng" : 150.6228960197085
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJoSwL6FaIEmsRGfTm6gH-VJQ",
+                 "types" : [ "street_address" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Thu, 12 May 2016 04:57:25 GMT
 recorded_with: VCR 2.5.0

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -168,6 +168,20 @@ describe Alert do
     end
   end
 
+  describe "#address_for_placeholder" do
+    it "has a default address" do
+      expect(Alert.new.address_for_placeholder).to eql "1 Sowerby St, Goulburn, NSW 2580"
+    end
+
+    it "can be set to something else" do
+      expect(
+        Alert.new(
+          address_for_placeholder: "5 Boaty St, Boat Face"
+        ).address_for_placeholder
+     ).to eql "5 Boaty St, Boat Face"
+    end
+  end
+
   describe "recent applications for this user" do
     before :each do
       @alert = Alert.create!(email: "matthew@openaustralia.org", address: @address, radius_meters: 2000)


### PR DESCRIPTION
Closes #977 to help people sign up for alerts from the Authority recent applications pages. Over a thousand people a week hit this page and many of them might like to sign up for alerts.

It also adds:

* integration tests for the main alert sign up scenarios
* DRY’s up the views that included the Alert signup form

![screen shot 2016-05-12 at 5 37 01 pm](https://cloud.githubusercontent.com/assets/1239550/15207264/4bf63ed0-1868-11e6-8c8d-0325e0ac7ac1.png)
