### PR TITLE
Make councillors more approachable, clearer and councillor list more usable

### DIFF
--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -218,28 +218,6 @@ ol#comments {
   .councillor-image {
     width: 4em;
     height: 4.5em;
-    overflow: hidden;
-    border-radius: .25em;
-    background-color: $lightest-cool-highlight;
-  }
-
-  .councillor-initials {
-    font-size: 1.5em;
-    text-transform: uppercase;
-    display: block;
-    width: 100%;
-    height: 100%;
-    border: none;
-    text-decoration: none;
-    text-align: center;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  img {
-    width: 100%;
-    height: auto;
   }
 }
 

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -223,6 +223,20 @@ ol#comments {
     background-color: $lightest-cool-highlight;
   }
 
+  .councillor-initials {
+    font-size: 1.5em;
+    text-transform: uppercase;
+    display: block;
+    width: 100%;
+    height: 100%;
+    border: none;
+    text-decoration: none;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   img {
     width: 100%;
     height: auto;

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -216,7 +216,7 @@ ol#comments {
   }
 
   .councillor-image {
-    width: 4em;
+    width: 4.5em;
     height: 4.5em;
   }
 }

--- a/app/assets/stylesheets/partials/_comments.scss
+++ b/app/assets/stylesheets/partials/_comments.scss
@@ -220,6 +220,7 @@ ol#comments {
     height: 4.5em;
     overflow: hidden;
     border-radius: .25em;
+    background-color: $lightest-cool-highlight;
   }
 
   img {

--- a/app/assets/stylesheets/partials/_councillors.scss
+++ b/app/assets/stylesheets/partials/_councillors.scss
@@ -1,7 +1,7 @@
   .councillor-image {
     overflow: hidden;
     border-radius: .25em;
-    background-color: $lightest-cool-highlight;
+    background-color: $councillor-message-yellow;
 
     img {
       width: 100%;

--- a/app/assets/stylesheets/partials/_councillors.scss
+++ b/app/assets/stylesheets/partials/_councillors.scss
@@ -1,0 +1,25 @@
+  .councillor-image {
+    overflow: hidden;
+    border-radius: .25em;
+    background-color: $lightest-cool-highlight;
+
+    img {
+      width: 100%;
+      height: auto;
+    }
+  }
+
+  .councillor-initials {
+    font-size: 1.5em;
+    text-transform: uppercase;
+    display: block;
+    width: 100%;
+    height: 100%;
+    border: none;
+    text-decoration: none;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+

--- a/app/assets/stylesheets/partials/_councillors.scss
+++ b/app/assets/stylesheets/partials/_councillors.scss
@@ -1,6 +1,6 @@
   .councillor-image {
     overflow: hidden;
-    border-radius: .25em;
+    border-radius: 50%;
     background-color: $councillor-message-yellow;
 
     img {

--- a/app/assets/stylesheets/partials/special_forms/_comment_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_comment_form.scss
@@ -148,6 +148,20 @@
     }
   }
 
+  .councillor-initials {
+    font-size: 1.5em;
+    text-transform: uppercase;
+    display: block;
+    width: 100%;
+    height: 100%;
+    border: none;
+    text-align: center;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   .p-name,
   .p-org {
     display: block;

--- a/app/assets/stylesheets/partials/special_forms/_comment_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_comment_form.scss
@@ -148,7 +148,8 @@
   }
 
   .p-name {
-    font-weight: bold;
+    font-weight: normal;
+    font-size: 1.25em;
   }
 
   .p-org {

--- a/app/assets/stylesheets/partials/special_forms/_comment_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_comment_form.scss
@@ -124,16 +124,23 @@
 
   .councillor-option {
     display: table;
+    display: flex;
+    justify-content: flex-start;
   }
 
   .councillor-image-wrapper,
   .councillor-details {
     vertical-align: top;
     display: table-cell;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-start;
   }
 
   .councillor-image-wrapper {
     padding: 0 1em 0 0;
+    flex: 0 0 auto;
   }
 
   .councillor-image {

--- a/app/assets/stylesheets/partials/special_forms/_comment_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_comment_form.scss
@@ -138,6 +138,7 @@
   .councillor-image {
     width: 5em;
     height: 5em;
+    border: .25em solid $content-background;
   }
 
   .p-name,
@@ -156,9 +157,17 @@
   :hover + &,
   :focus + &  {
     color: $link-hover-color;
+
+    .councillor-image {
+      border-color: $formal-comment-border-color;
+    }
   }
 
   :checked + & {
     color: $link-active-color;
+
+    .councillor-image {
+      border-color: $link-active-color;
+    }
   }
 }

--- a/app/assets/stylesheets/partials/special_forms/_comment_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_comment_form.scss
@@ -138,28 +138,6 @@
   .councillor-image {
     width: 5em;
     height: 5.5em;
-    overflow: hidden;
-    border-radius: .25em;
-    background-color: $lightest-cool-highlight;
-
-    img {
-      width: 100%;
-      height: auto;
-    }
-  }
-
-  .councillor-initials {
-    font-size: 1.5em;
-    text-transform: uppercase;
-    display: block;
-    width: 100%;
-    height: 100%;
-    border: none;
-    text-align: center;
-    text-decoration: none;
-    display: flex;
-    align-items: center;
-    justify-content: center;
   }
 
   .p-name,

--- a/app/assets/stylesheets/partials/special_forms/_comment_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_comment_form.scss
@@ -137,7 +137,7 @@
 
   .councillor-image {
     width: 5em;
-    height: 5.5em;
+    height: 5em;
   }
 
   .p-name,

--- a/app/assets/stylesheets/partials/special_forms/_comment_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_comment_form.scss
@@ -99,6 +99,13 @@
   list-style: none;
   clear: both;
 
+  &.open {
+    @include at-breakpoint(50em) {
+      display: flex !important;
+      flex-wrap: wrap;
+    }
+  }
+
   footer {
     clear: both;
   }
@@ -121,6 +128,10 @@
   padding: 0 0 .5em 0 !important;
   width: 80% !important;
   cursor: pointer;
+
+  @include at-breakpoint(50em) {
+    flex: 0 0 49%;
+  }
 
   .councillor-option {
     display: table;
@@ -157,6 +168,7 @@
   .p-name {
     font-weight: normal;
     font-size: 1.25em;
+    padding-right: .5em;
   }
 
   .p-org {

--- a/app/assets/stylesheets/partials/special_forms/_comment_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_comment_form.scss
@@ -84,8 +84,12 @@
 
 #councillors-list-toggler {
   ~ .councillor-select-list {
-    margin: 0 0 2em 2em;
+    margin: 0 0 2em 1em;
     display: none;
+
+    @include at-breakpoint(30em) {
+      margin: 0 0 2em 2em;
+    }
   }
 
   &:checked ~ .councillor-select-list {
@@ -155,9 +159,14 @@
   }
 
   .councillor-image {
-    width: 5em;
-    height: 5em;
+    width: 4em;
+    height: 4em;
     border: .25em solid $content-background;
+
+    @include at-breakpoint(30em) {
+      width: 5em;
+      height: 5em;
+    }
   }
 
   .p-name,

--- a/app/assets/stylesheets/partials/special_forms/_comment_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_comment_form.scss
@@ -110,14 +110,15 @@
 }
 
 .councillor-select-radio {
-  width: auto !important;
-  clear: both;
+  @include sr-only();
+  position: relative !important;
   float: left;
+  opacity: 0;
 }
 
 .councillor-select-label {
   margin: 0 0 .5em !important;
-  padding: 0 0 .5em .5em !important;
+  padding: 0 0 .5em 0 !important;
   width: 80% !important;
   cursor: pointer;
 
@@ -132,7 +133,7 @@
   }
 
   .councillor-image-wrapper {
-    padding: 0 1em 0 .5em;
+    padding: 0 1em 0 0;
   }
 
   .councillor-image {

--- a/app/assets/stylesheets/screen.scss
+++ b/app/assets/stylesheets/screen.scss
@@ -25,6 +25,7 @@ body {
 @import "partials/form";
 @import "partials/grid";
 @import "partials/comments";
+@import "partials/councillors";
 @import "partials/flash_messages";
 @import "partials/charts";
 

--- a/app/models/councillor.rb
+++ b/app/models/councillor.rb
@@ -6,6 +6,12 @@ class Councillor < ActiveRecord::Base
   validates :authority, :email, presence: true
   validates :image_url, format: { with: /\Ahttps/, message: "must be HTTPS" }, allow_blank: true
 
+  def initials
+    first_letters = name.split(/\s/).collect { |word| word.first.upcase }
+    first_letters = first_letters.values_at(0, -1) unless first_letters.one?
+    first_letters.join(" ")
+  end
+
   def prefixed_name
     "local councillor #{name}"
   end

--- a/app/views/comments/_comment_receiver_options.html.haml
+++ b/app/views/comments/_comment_receiver_options.html.haml
@@ -34,12 +34,7 @@
         = b.radio_button(class: "councillor-select-radio")
         = b.label(class: "councillor-select-label h-card") do
           .councillor-option
-            .councillor-image-wrapper
-              .councillor-image
-                - if b.object.image_url.present?
-                  = image_tag b.object.image_url,
-                              alt: "Photo of #{b.object.name}",
-                              class: "u-photo"
+            = render "councillors/councillor_image", councillor: b.object
             .councillor-details
               %span.p-name= b.object.name
               %span.p-org= b.object.party

--- a/app/views/comments/_comment_receiver_options.html.haml
+++ b/app/views/comments/_comment_receiver_options.html.haml
@@ -34,9 +34,9 @@
         = b.radio_button(class: "councillor-select-radio")
         = b.label(class: "councillor-select-label h-card") do
           .councillor-option
-            - if b.object.image_url.present?
-              .councillor-image-wrapper
-                .councillor-image
+            .councillor-image-wrapper
+              .councillor-image
+                - if b.object.image_url.present?
                   = image_tag b.object.image_url,
                               alt: "Photo of #{b.object.name}",
                               class: "u-photo"

--- a/app/views/councillors/_councillor_image.html.haml
+++ b/app/views/councillors/_councillor_image.html.haml
@@ -1,0 +1,6 @@
+.councillor-image-wrapper
+  .councillor-image
+    - if councillor.image_url.present?
+      = image_tag councillor.image_url,
+                  alt: "Photo of #{councillor.name}",
+                  class: "u-photo"

--- a/app/views/councillors/_councillor_image.html.haml
+++ b/app/views/councillors/_councillor_image.html.haml
@@ -4,3 +4,6 @@
       = image_tag councillor.image_url,
                   alt: "Photo of #{councillor.name}",
                   class: "u-photo"
+    - else
+      %abbr.councillor-initials{title: councillor.name}
+        = councillor.initials

--- a/app/views/replies/_reply.html.haml
+++ b/app/views/replies/_reply.html.haml
@@ -1,9 +1,9 @@
 %figure.reply-from-councillor.comment-item.panel{id: "reply#{reply.id}"}
   .panel-body
     .comment-heading.h-card
-      - if reply.councillor.image_url.present?
-        .councillor-image-wrapper
-          .councillor-image
+      .councillor-image-wrapper
+        .councillor-image
+          - if reply.councillor.image_url.present?
             = image_tag reply.councillor.image_url,
                         alt: "Photo of #{reply.councillor.name}",
                         class: "u-photo"

--- a/app/views/replies/_reply.html.haml
+++ b/app/views/replies/_reply.html.haml
@@ -1,12 +1,7 @@
 %figure.reply-from-councillor.comment-item.panel{id: "reply#{reply.id}"}
   .panel-body
     .comment-heading.h-card
-      .councillor-image-wrapper
-        .councillor-image
-          - if reply.councillor.image_url.present?
-            = image_tag reply.councillor.image_url,
-                        alt: "Photo of #{reply.councillor.name}",
-                        class: "u-photo"
+      = render "councillors/councillor_image", councillor: reply.councillor
       %figcaption.comment-meta
         .comment-author.councillor
           %span.p-name= reply.councillor.name

--- a/spec/models/councillor_spec.rb
+++ b/spec/models/councillor_spec.rb
@@ -5,6 +5,14 @@ describe Councillor do
     it { expect(create(:councillor, name: "Steve").prefixed_name).to eq "local councillor Steve" }
   end
 
+  describe "#initials" do
+    it { expect(create(:councillor, name: "Vandarna").initials).to eq "V" }
+    it { expect(create(:councillor, name: "Vandarna Adams").initials).to eq "V A" }
+    it { expect(create(:councillor, name: "vandarna adams").initials).to eq "V A" }
+    it { expect(create(:councillor, name: "Kate O'Neil").initials).to eq "K O" }
+    it { expect(create(:councillor, name: "Kate \"Smithy\" Smiles").initials).to eq "K S" }
+  end
+
   describe "validations" do
     it { expect(Councillor.new).to_not be_valid }
     it { expect(Councillor.new(authority: create(:authority))).to_not be_valid }


### PR DESCRIPTION
This is an iteration on the presentation of councillors to:

* Make the councillors list more friendly, human and approachable by making their images circles, giving them a friendly yellow if they have no image (consistent yellow colour to match councillor comments), and makes their names bigger and clearer ( first pass on #985 ),
* If councillors don’t have images, it gives them a friendly yellow avatar with their initials. This means the all the councillors have a consistent layout whether they have images or not both in their replies and in the councillor select list ( fixes #973 ).
* Wraps the list round into two columns if there's space making the list more compact on widescreens ( fixes #929 )
* Makes it clearer you can click the nice big faces by giving them a hover effect and hidding the radio button, so you don't think you need to fiddle with the radio button (fixes #986 )
* Makes the councillors names bigger and clearer
* Makes the list fit a bit better on small screens
* refactors some of the councillor styles

## Before

![screen shot 2016-06-09 at 11 16 32 am](https://cloud.githubusercontent.com/assets/1239550/15950298/df564e2e-2ef0-11e6-86c7-be57c6122550.png)

![screen shot 2016-06-09 at 11 16 24 am](https://cloud.githubusercontent.com/assets/1239550/15950334/1f0560f0-2ef1-11e6-8e12-6f86c40831f5.png)

## After

![screen shot 2016-06-10 at 9 41 04 am](https://cloud.githubusercontent.com/assets/1239550/15950291/d0db4cdc-2ef0-11e6-9b44-2d33bac863e7.png)

![screen shot 2016-06-09 at 11 13 27 am](https://cloud.githubusercontent.com/assets/1239550/15950333/19c57c24-2ef1-11e6-9050-0a2464e9f40b.png)