### PR TITLE
allow for 2 ticks when max value is less than 3

### DIFF
--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -39,9 +39,9 @@ function barGraph(selector, url, metric) {
     var bisectDate = d3.bisector(function(d) { return d.key; }).left
 
     var yTickCount;
-    if (maxYValue < 2) {
-      yTickCount = 1;
-    } else  {
+    if (maxYValue < 3) {
+      yTickCount = Math.floor(maxYValue)
+    } else {
       yTickCount = 3;
     }
 

--- a/app/assets/javascripts/bar_graph.js
+++ b/app/assets/javascripts/bar_graph.js
@@ -40,7 +40,7 @@ function barGraph(selector, url, metric) {
 
     var yTickCount;
     if (maxYValue < 3) {
-      yTickCount = Math.floor(maxYValue)
+      yTickCount = Math.floor(maxYValue);
     } else {
       yTickCount = 3;
     }


### PR DESCRIPTION
@henare @equivalentideas
This fixes the issue here:
https://github.com/openaustralia/planningalerts/issues/887

Basically when the max Y axis value was 2 - the 'yTickCount' was being set to 3. This was causing the yAxis to show weird numbers to try to fill 3 ticks when there were only going to be 2. Would have thought d3 would have just shown this more gracefully.. maybe in version 4. :)

Anyway I did a quick jsbin so could play around with the real data and see that the change works:
http://jsbin.com/zuqimuhocu/edit?html,js,console,output

Take a look when you have time.