### PR TITLE
Track unsubscribers

### DIFF
--- a/app/controllers/performance_controller.rb
+++ b/app/controllers/performance_controller.rb
@@ -21,7 +21,7 @@ class PerformanceController < ApplicationController
     (3.months.ago.to_date..1.day.ago.to_date).to_a.reverse.map do |day|
       {
         date: day,
-        new_alert_subscribers: Alert.with_new_unique_email_created_on_date(day).count,
+        new_alert_subscribers: Alert.count_of_new_unique_email_created_on_date(day),
         emails_completely_unsubscribed: Alert.count_of_email_completely_unsubscribed_on_date(day)
       }
     end

--- a/app/controllers/performance_controller.rb
+++ b/app/controllers/performance_controller.rb
@@ -21,7 +21,8 @@ class PerformanceController < ApplicationController
     (3.months.ago.to_date..1.day.ago.to_date).to_a.reverse.map do |day|
       {
         date: day,
-        new_alert_subscribers: Alert.with_new_unique_email_created_on_date(day).count
+        new_alert_subscribers: Alert.with_new_unique_email_created_on_date(day).count,
+        emails_completely_unsubscribed: Alert.count_of_email_completely_unsubscribed_on_date(day)
       }
     end
   end

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -57,7 +57,6 @@ class Alert < ActiveRecord::Base
 
   def self.count_of_email_completely_unsubscribed_on_date(date)
     emails = where("date(updated_at) = ?", date).where(unsubscribed: true).
-                                                 select(:email).
                                                  distinct.
                                                  pluck(:email)
 

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -50,11 +50,11 @@ class Alert < ActiveRecord::Base
   def self.count_of_new_unique_email_created_on_date(date)
     alerts = where(confirmed: true).where("date(created_at) = ?", date).group(:email)
 
-    alerts.select do |alert|
+    alerts.reject do |alert|
       where("id != ? and email = ? and created_at < ?",
             alert.id,
             alert.email,
-            alert.created_at).empty?
+            alert.created_at).any?
     end.count
   end
 

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -51,10 +51,9 @@ class Alert < ActiveRecord::Base
     alerts = where(confirmed: true).where("date(created_at) = ?", date).group(:email)
 
     alerts.reject do |alert|
-      where("id != ? and email = ? and created_at < ?",
-            alert.id,
-            alert.email,
-            alert.created_at).any?
+      where(email: alert.email).where("created_at < ?", alert.created_at).
+                                where.not(id: alert.id).
+                                any?
     end.count
   end
 

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -51,9 +51,7 @@ class Alert < ActiveRecord::Base
     alerts = where(confirmed: true).where("date(created_at) = ?", date).group(:email)
 
     alerts.reject do |alert|
-      where(email: alert.email).where("created_at < ?", alert.created_at).
-                                where.not(id: alert.id).
-                                any?
+      where(email: alert.email).where("created_at < ?", alert.created_at).any?
     end.count
   end
 

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -15,11 +15,6 @@ class Alert < ActiveRecord::Base
   # People with 3 or more alerts that don't yet have a subscription
   scope :potential_subscribers, -> { active.group("alerts.email").having("count(alerts.email) >= 3") }
   scope :without_subscription, -> { includes(:subscription).where(subscriptions: {email: nil}) }
-  scope :with_new_unique_email_created_on_date, ->(date) {
-    where(confirmed: true).where("date(created_at) = ?", date).group(:email).select do |alert|
-      where("id != ? and email = ? and created_at < ?", alert.id, alert.email, alert.created_at).empty?
-    end
-  }
 
   def location=(l)
     if l
@@ -50,6 +45,12 @@ class Alert < ActiveRecord::Base
         )
       |
     Alert.find_by_sql(command)
+  end
+
+  def self.with_new_unique_email_created_on_date(date)
+    where(confirmed: true).where("date(created_at) = ?", date).group(:email).select do |alert|
+      where("id != ? and email = ? and created_at < ?", alert.id, alert.email, alert.created_at).empty?
+    end
   end
 
   def self.count_of_email_completely_unsubscribed_on_date(date)

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -16,8 +16,8 @@ class Alert < ActiveRecord::Base
   scope :potential_subscribers, -> { active.group("alerts.email").having("count(alerts.email) >= 3") }
   scope :without_subscription, -> { includes(:subscription).where(subscriptions: {email: nil}) }
   scope :with_new_unique_email_created_on_date, ->(date) {
-    active.where("date(created_at) = ?", date).group(:email).select do |alert|
-      where("email = ? and created_at < ?", alert.email, alert.created_at.to_date).empty?
+    where(confirmed: true).where("date(created_at) = ?", date).group(:email).select do |alert|
+      where("id != ? and email = ? and created_at < ?", alert.id, alert.email, alert.created_at).empty?
     end
   }
 

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -47,10 +47,10 @@ class Alert < ActiveRecord::Base
     Alert.find_by_sql(command)
   end
 
-  def self.with_new_unique_email_created_on_date(date)
+  def self.count_of_new_unique_email_created_on_date(date)
     where(confirmed: true).where("date(created_at) = ?", date).group(:email).select do |alert|
       where("id != ? and email = ? and created_at < ?", alert.id, alert.email, alert.created_at).empty?
-    end
+    end.count
   end
 
   def self.count_of_email_completely_unsubscribed_on_date(date)

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -52,6 +52,17 @@ class Alert < ActiveRecord::Base
     Alert.find_by_sql(command)
   end
 
+  def self.count_of_email_completely_unsubscribed_on_date(date)
+    emails = where("date(updated_at) = ?", date).where(unsubscribed: true).
+                                                 select(:email).
+                                                 distinct.
+                                                 pluck(:email)
+
+    emails.reject do |email|
+      active.where(email: email).where("date(created_at) <= ?", date).any?
+    end.count
+  end
+
   # Only enable subscriptions on the default theme
   def subscription
     super if theme == "default"

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -48,7 +48,9 @@ class Alert < ActiveRecord::Base
   end
 
   def self.count_of_new_unique_email_created_on_date(date)
-    where(confirmed: true).where("date(created_at) = ?", date).group(:email).select do |alert|
+    alerts = where(confirmed: true).where("date(created_at) = ?", date).group(:email)
+
+    alerts.select do |alert|
       where("id != ? and email = ? and created_at < ?", alert.id, alert.email, alert.created_at).empty?
     end.count
   end

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -51,7 +51,10 @@ class Alert < ActiveRecord::Base
     alerts = where(confirmed: true).where("date(created_at) = ?", date).group(:email)
 
     alerts.select do |alert|
-      where("id != ? and email = ? and created_at < ?", alert.id, alert.email, alert.created_at).empty?
+      where("id != ? and email = ? and created_at < ?",
+            alert.id,
+            alert.email,
+            alert.created_at).empty?
     end.count
   end
 

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -170,8 +170,8 @@ describe Alert do
     end
   end
 
-  describe ".with_new_unique_email_created_on_date" do
-    it { expect(Alert.with_new_unique_email_created_on_date("2016-08-24")).to eq [] }
+  describe ".count_of_new_unique_email_created_on_date" do
+    it { expect(Alert.count_of_new_unique_email_created_on_date("2016-08-24")).to eq 0 }
 
     context "when there are unconfirmed alerts" do
       before do
@@ -179,7 +179,7 @@ describe Alert do
       end
 
       it "it doesn't include them" do
-        expect(Alert.with_new_unique_email_created_on_date("2016-08-24")).to eq []
+        expect(Alert.count_of_new_unique_email_created_on_date("2016-08-24")).to eq 0
       end
     end
 
@@ -189,7 +189,7 @@ describe Alert do
       end
 
       it "doesn't include them" do
-        expect(Alert.with_new_unique_email_created_on_date("2016-08-24")).to eq []
+        expect(Alert.count_of_new_unique_email_created_on_date("2016-08-24")).to eq 0
       end
     end
 
@@ -200,7 +200,7 @@ describe Alert do
       end
 
       it "doesn't include them" do
-        expect(Alert.with_new_unique_email_created_on_date("2016-08-24")).to eq []
+        expect(Alert.count_of_new_unique_email_created_on_date("2016-08-24")).to eq 0
       end
     end
 
@@ -213,9 +213,9 @@ describe Alert do
       end
 
       it "includes them" do
-        expect(Alert.with_new_unique_email_created_on_date("2016-08-24")).to eq [@alert, @alert2]
-        expect(Alert.with_new_unique_email_created_on_date("2012-04-01")).to eq [@alert3]
-        expect(Alert.with_new_unique_email_created_on_date("1990-05-27")).to eq [@alert4]
+        expect(Alert.count_of_new_unique_email_created_on_date("2016-08-24")).to eq 2
+        expect(Alert.count_of_new_unique_email_created_on_date("2012-04-01")).to eq 1
+        expect(Alert.count_of_new_unique_email_created_on_date("1990-05-27")).to eq 1
       end
     end
 
@@ -225,8 +225,8 @@ describe Alert do
         @alert2 = create(:confirmed_alert, email: "clare@jones.org", created_at: "2016-08-24")
       end
 
-      it "includes the first alert they created" do
-        expect(Alert.with_new_unique_email_created_on_date("2016-08-24")).to eq [@alert1]
+      it "only counts one" do
+        expect(Alert.count_of_new_unique_email_created_on_date("2016-08-24")).to eq 1
       end
     end
 
@@ -244,7 +244,7 @@ describe Alert do
       end
 
       it "still includes it for the day it was created" do
-        expect(Alert.with_new_unique_email_created_on_date("2016-08-24")).to eq [alert]
+        expect(Alert.count_of_new_unique_email_created_on_date("2016-08-24")).to eq 1
       end
     end
   end

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -173,10 +173,9 @@ describe Alert do
   describe ".with_new_unique_email_created_on_date" do
     it { expect(Alert.with_new_unique_email_created_on_date("2016-08-24")).to eq [] }
 
-    context "when there are no active alerts" do
+    context "when there are unconfirmed alerts" do
       before do
         create(:unconfirmed_alert, created_at: "2016-08-24")
-        create(:confirmed_alert, unsubscribed: true)
       end
 
       it "it doesn't include them" do
@@ -228,6 +227,24 @@ describe Alert do
 
       it "includes the first alert they created" do
         expect(Alert.with_new_unique_email_created_on_date("2016-08-24")).to eq [@alert1]
+      end
+    end
+
+    context "when the alert has since been unsubscribed" do
+      let!(:alert) do
+        a = Timecop.freeze(Date.new(2016, 8, 24)) do
+          create :confirmed_alert
+        end
+
+        Timecop.freeze(Date.new(2016, 8, 24)) do
+          a.update_attribute(:unsubscribed, true)
+        end
+
+        a
+      end
+
+      it "still includes it for the day it was created" do
+        expect(Alert.with_new_unique_email_created_on_date("2016-08-24")).to eq [alert]
       end
     end
   end


### PR DESCRIPTION
Currently in our performance api we’re tracking data about new subscribers, but not unsubscribes.

We're interested in knowing about unsubscribes because:

1. we'll soon be working on “PlanningAlerts Subscribers” where we want people to keep using the project so they continue to support it.
2. we think we might see things in this data that will help us make the project more useful to people.

This adds the number of people who completely leave PlanningAlerts each day (unsubscribe their last remaining alert). It also fixes a bug in the subscribers data where it only counted people if they were still subscribed.