### PR TITLE
 Note in the database when an alert is unsubscribed

### DIFF
--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -36,7 +36,7 @@ class AlertsController < ApplicationController
 
   def unsubscribe
     @alert = Alert.find_by_confirm_id(params[:id])
-    @alert.update_attribute(:unsubscribed, true) if @alert
+    @alert.unsubscribe! if @alert
   end
 
   def area

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -66,7 +66,7 @@ class Alert < ActiveRecord::Base
   end
 
   def unsubscribe!
-    update_attribute(:unsubscribed, true)
+    update!(unsubscribed: true)
   end
 
   # Only enable subscriptions on the default theme

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -66,7 +66,7 @@ class Alert < ActiveRecord::Base
   end
 
   def unsubscribe!
-    update!(unsubscribed: true)
+    update!(unsubscribed: true, unsubscribed_at: Time.now)
   end
 
   # Only enable subscriptions on the default theme

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -56,9 +56,9 @@ class Alert < ActiveRecord::Base
   end
 
   def self.count_of_email_completely_unsubscribed_on_date(date)
-    emails = where("date(updated_at) = ?", date).where(unsubscribed: true).
-                                                 distinct.
-                                                 pluck(:email)
+    emails = where("date(unsubscribed_at) = ?", date).where(unsubscribed: true).
+                                                      distinct.
+                                                      pluck(:email)
 
     emails.reject do |email|
       active.where(email: email).where("date(created_at) <= ?", date).any?

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -65,6 +65,10 @@ class Alert < ActiveRecord::Base
     end.count
   end
 
+  def unsubscribe!
+    update_attribute(:unsubscribed, true)
+  end
+
   # Only enable subscriptions on the default theme
   def subscription
     super if theme == "default"

--- a/db/migrate/20161103015049_add_unsubscribed_at_to_alert.rb
+++ b/db/migrate/20161103015049_add_unsubscribed_at_to_alert.rb
@@ -1,0 +1,13 @@
+class AddUnsubscribedAtToAlert < ActiveRecord::Migration
+  def up
+    add_column :alerts, :unsubscribed_at, :datetime
+
+    Alert.where(unsubscribed: true).find_each do |alert|
+      alert.update!(unsubscribed_at: alert.updated_at)
+    end
+  end
+
+  def down
+    remove_column :alerts, :unsubscribed_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160824034142) do
+ActiveRecord::Schema.define(version: 20161103015049) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "resource_id",   limit: 255,   null: false
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 20160824034142) do
     t.boolean  "unsubscribed",               default: false,     null: false
     t.datetime "last_processed"
     t.string   "theme",          limit: 255, default: "default", null: false
+    t.datetime "unsubscribed_at"
   end
 
   add_index "alerts", ["email"], name: "index_alerts_on_email", using: :btree

--- a/spec/controllers/alerts_controller_spec.rb
+++ b/spec/controllers/alerts_controller_spec.rb
@@ -35,7 +35,7 @@ describe AlertsController do
 
       expect(alert.reload).to be_unsubscribed
     end
-    
+
     # In order to avoid confusion when clicking on unsubscribe link twice -
     it "should allow unsubscribing for non-existent alerts" do
       get :unsubscribe, id: "1111"

--- a/spec/controllers/alerts_controller_spec.rb
+++ b/spec/controllers/alerts_controller_spec.rb
@@ -28,11 +28,12 @@ describe AlertsController do
   end
 
   describe "unsubscribing" do
-    it "should delete the alert when unsubscribing" do
-      alert = mock_model(Alert)
-      expect(Alert).to receive(:find_by_confirm_id).with("1234").and_return(alert)
-      expect(alert).to receive(:update_attribute).with(:unsubscribed, true)
-      get :unsubscribe, id: "1234"
+    it "should mark the alert as unsubscribed" do
+      alert = create :confirmed_alert
+
+      get :unsubscribe, id: alert.confirm_id
+
+      expect(alert.reload).to be_unsubscribed
     end
     
     # In order to avoid confusion when clicking on unsubscribe link twice -

--- a/spec/controllers/alerts_controller_spec.rb
+++ b/spec/controllers/alerts_controller_spec.rb
@@ -36,7 +36,6 @@ describe AlertsController do
       expect(alert.reload).to be_unsubscribed
     end
 
-    # In order to avoid confusion when clicking on unsubscribe link twice -
     it "should allow unsubscribing for non-existent alerts" do
       get :unsubscribe, id: "1111"
       expect(response).to be_success

--- a/spec/controllers/alerts_controller_spec.rb
+++ b/spec/controllers/alerts_controller_spec.rb
@@ -5,7 +5,7 @@ describe AlertsController do
     request.env['HTTPS'] = 'on'
   end
 
-  describe "confirming" do
+  describe "#confirmed" do
     it "should set the alert to be confirmed" do
       alert = create(:alert)
       expect(Alert).to receive(:find_by!).with(confirm_id: "1234").and_return(alert)
@@ -27,7 +27,7 @@ describe AlertsController do
     end
   end
 
-  describe "unsubscribing" do
+  describe "#unsubscribe" do
     it "should mark the alert as unsubscribed" do
       alert = create :confirmed_alert
 
@@ -43,7 +43,7 @@ describe AlertsController do
     end
   end
 
-  describe "area" do
+  describe "#area" do
     it "should 404 if the alert can't be found" do
       expect {
         get :area, id: 'non_existent_id'

--- a/spec/controllers/performance_controller_spec.rb
+++ b/spec/controllers/performance_controller_spec.rb
@@ -49,7 +49,7 @@ describe PerformanceController do
       before do
         alert = create :confirmed_alert, email: "mary@example.org", created_at: DateTime.new(2016,6,19)
 
-        Timecop.freeze(Time.utc(2016, 8, 23)) { alert.update_attribute(:unsubscribed, true) }
+        Timecop.freeze(Time.utc(2016, 8, 23)) { alert.unsubscribe! }
 
         get(:alerts, format: :json)
       end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -101,6 +101,11 @@ FactoryGirl.define do
     factory :confirmed_alert do
       confirmed true
       confirm_id "1234"
+
+      factory :unsubscribed_alert do
+        unsubscribed true
+        unsubscribed_at Time.now
+      end
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -100,6 +100,7 @@ FactoryGirl.define do
 
     factory :confirmed_alert do
       confirmed true
+      confirm_id "1234"
     end
   end
 

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -237,7 +237,7 @@ describe Alert do
         end
 
         Timecop.freeze(Date.new(2016, 8, 24)) do
-          a.update_attribute(:unsubscribed, true)
+          a.unsubscribe!
         end
 
         a
@@ -255,16 +255,16 @@ describe Alert do
     end
 
     it "is 0 when there is no complete unsubscribes" do
-      create(:confirmed_alert, email: "foo@email.com", unsubscribed: true)
-      create(:confirmed_alert, email: "foo@email.com", unsubscribed: true)
-      create(:confirmed_alert, email: "foo@email.com", unsubscribed: false)
+      create(:unsubscribed_alert, email: "foo@email.com")
+      create(:unsubscribed_alert, email: "foo@email.com")
+      create(:confirmed_alert, email: "foo@email.com")
 
       expect(Alert.count_of_email_completely_unsubscribed_on_date(Date.today)).to eql 0
     end
 
     it "only counts unique emails" do
-      create(:confirmed_alert, email: "foo@email.com", unsubscribed: true)
-      create(:confirmed_alert, email: "foo@email.com", unsubscribed: true)
+      create(:unsubscribed_alert, email: "foo@email.com")
+      create(:unsubscribed_alert, email: "foo@email.com")
 
       expect(Alert.count_of_email_completely_unsubscribed_on_date(Date.today)).to eql 1
     end
@@ -273,8 +273,8 @@ describe Alert do
       alert1 = create(:confirmed_alert, email: "foo@email.com")
       alert2 = create(:confirmed_alert, email: "bar@email.com")
 
-      Timecop.freeze(Time.utc(2016, 8, 23)) { alert1.update_attribute(:unsubscribed, true) }
-      Timecop.freeze(Time.utc(2016, 8, 24)) { alert2.update_attribute(:unsubscribed, true) }
+      Timecop.freeze(Time.utc(2016, 8, 23)) { alert1.unsubscribe! }
+      Timecop.freeze(Time.utc(2016, 8, 24)) { alert2.unsubscribe! }
 
       expect(Alert.count_of_email_completely_unsubscribed_on_date(Date.new(2016, 8, 23))).to eql 1
     end
@@ -285,7 +285,7 @@ describe Alert do
           create(:confirmed_alert, email: "foo@email.com")
         end
 
-        Timecop.freeze(Time.utc(2016, 8, 23)) { alert.update_attribute(:unsubscribed, true) }
+        Timecop.freeze(Time.utc(2016, 8, 23)) { alert.unsubscribe! }
 
         Timecop.freeze(Time.utc(2016, 8, 28)) do
           create(:confirmed_alert, email: "foo@email.com")
@@ -302,7 +302,7 @@ describe Alert do
             create(:confirmed_alert, email: "foo@email.com")
           end
 
-          Timecop.freeze(Time.utc(2016, 9, 1)) { alert.update_attribute(:unsubscribed, true) }
+          Timecop.freeze(Time.utc(2016, 9, 1)) { alert.unsubscribe! }
         end
 
         it "doesn't count their unsubscribe" do

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -313,16 +313,15 @@ describe Alert do
   end
 
   describe "#unsubscribe!" do
-    it "unsubscribes the alert" do
-      alert = create :alert
+    let(:alert) { create :alert }
 
+    it "unsubscribes the alert" do
       alert.unsubscribe!
 
       expect(alert).to be_unsubscribed
     end
 
     it "sets the unsubscribed_at time" do
-      alert = create :alert
       action_time = Time.new(2016, 11, 3, 15, 29)
 
       Timecop.freeze(action_time) { alert.unsubscribe! }

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -262,12 +262,6 @@ describe Alert do
       expect(Alert.count_of_email_completely_unsubscribed_on_date(Date.today)).to eql 0
     end
 
-    it "returns number of emails completely unsubscribed on a date" do
-      create(:confirmed_alert, unsubscribed: true)
-
-      expect(Alert.count_of_email_completely_unsubscribed_on_date(Date.today)).to eql 1
-    end
-
     it "only counts unique emails" do
       create(:confirmed_alert, email: "foo@email.com", unsubscribed: true)
       create(:confirmed_alert, email: "foo@email.com", unsubscribed: true)

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -318,7 +318,7 @@ describe Alert do
 
       alert.unsubscribe!
 
-      expect(alert.unsubscribed).to be true
+      expect(alert).to be_unsubscribed
     end
 
     it "sets the unsubscribed_at time" do

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -318,6 +318,16 @@ describe Alert do
     end
   end
 
+  describe "#unsubscribe!" do
+    it "unsubscribes the alert" do
+      alert = create :alert
+
+      alert.unsubscribe!
+
+      expect(alert.unsubscribed).to be true
+    end
+  end
+
   describe "#address_for_placeholder" do
     it "has a default address" do
       expect(Alert.new.address_for_placeholder).to eql "1 Sowerby St, Goulburn, NSW 2580"

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -326,6 +326,15 @@ describe Alert do
 
       expect(alert.unsubscribed).to be true
     end
+
+    it "sets the unsubscribed_at time" do
+      alert = create :alert
+      action_time = Time.new(2016, 11, 3, 15, 29)
+
+      Timecop.freeze(action_time) { alert.unsubscribe! }
+
+      expect(alert.unsubscribed_at).to eql action_time
+    end
   end
 
   describe "#address_for_placeholder" do


### PR DESCRIPTION
Rather than assuming the `updated_at` time of an unsubscribed alert is the time it was actually unsubscribed, this pull requests creates a new attribute to track that time.

As part of the migration it populates this value with our previously assumed value from `updated_at`.

Fixes #1040.