### PR TITLE
Enable distinguishing between past and current councillors, users can only write to cuurent councillors, but all councillors replies remain

### DIFF
--- a/app/admin/authorities.rb
+++ b/app/admin/authorities.rb
@@ -36,6 +36,7 @@ ActiveAdmin.register Authority do
     if a.councillors.present?
       table_for resource.councillors, class: "index_table" do
         column :name
+        column :current
         column :email
         column :party
         column(:image) { |c| link_to image_tag(c.image_url), c.image_url }

--- a/app/admin/authorities.rb
+++ b/app/admin/authorities.rb
@@ -34,7 +34,7 @@ ActiveAdmin.register Authority do
 
     h3 "Councillors"
     if a.councillors.present?
-      table_for resource.councillors, class: "index_table" do
+      table_for resource.councillors.order(current: :desc), class: "index_table" do
         column :name
         column :current
         column :email

--- a/app/admin/councillor.rb
+++ b/app/admin/councillor.rb
@@ -4,6 +4,7 @@ ActiveAdmin.register Councillor do
   index do
     column :authority
     column :name
+    column :current
     column :email
     column :party
     column(:number_of_comments) { |c| c.comments.count }

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -170,10 +170,6 @@ class Application < ActiveRecord::Base
     authority.councillors.where(current: true).shuffle if authority.councillors.any?
   end
 
-  def councillors_for_authority
-    authority.councillors.shuffle if authority.councillors.any?
-  end
-
   def councillors_available_for_contact
     current_councillors_for_authority if authority.write_to_councillors_enabled?
   end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -166,12 +166,16 @@ class Application < ActiveRecord::Base
     on_notice_to && Date.today > on_notice_to
   end
 
+  def current_councillors_for_authority
+    authority.councillors.where(current: true).shuffle if authority.councillors.any?
+  end
+
   def councillors_for_authority
     authority.councillors.shuffle if authority.councillors.any?
   end
 
   def councillors_available_for_contact
-    councillors_for_authority if authority.write_to_councillors_enabled?
+    current_councillors_for_authority if authority.write_to_councillors_enabled?
   end
 
   private

--- a/app/models/authority.rb
+++ b/app/models/authority.rb
@@ -262,6 +262,9 @@ class Authority < ActiveRecord::Base
     persons.map do |person|
       councillor = councillors.find_or_create_by(name: person.name)
 
+      no_longer_councillor = person.end_date.present? && Date.parse(person.end_date) <= Date.today
+
+      councillor.current = false if no_longer_councillor
       councillor.popolo_id = person.id
       councillor.image_url = councillor.cached_image_url if councillor.cached_image_available?
       councillor.update(email: person.email, party: person.party)

--- a/app/models/popolo_councillors.rb
+++ b/app/models/popolo_councillors.rb
@@ -14,17 +14,18 @@ class PopoloCouncillors
     )
 
     councillor_memberships.map do |membership|
-      person_with_party_for_membership(membership)
+      person_with_party_and_end_date_for_membership(membership)
     end
   end
 
-  def person_with_party_for_membership(membership)
+  def person_with_party_and_end_date_for_membership(membership)
     person = popolo.persons.find_by(id: membership.person_id)
+    end_date = membership.end_date
     party = popolo.organizations.find_by(id: membership.on_behalf_of_id, classification: "party")
     party_name = party.name unless party.name == "unknown"
 
     EveryPolitician::Popolo::Person.new(
-      person.document.merge(party: party_name)
+      person.document.merge(party: party_name, end_date: end_date)
     )
   end
 end

--- a/db/migrate/20161228065516_add_current_to_councillors.rb
+++ b/db/migrate/20161228065516_add_current_to_councillors.rb
@@ -1,0 +1,5 @@
+class AddCurrentToCouncillors < ActiveRecord::Migration
+  def change
+    add_column :councillors, :current, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161226071108) do
+ActiveRecord::Schema.define(version: 20161228065516) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "resource_id",   limit: 255,   null: false
@@ -140,6 +140,7 @@ ActiveRecord::Schema.define(version: 20161226071108) do
     t.string   "email",        limit: 255
     t.integer  "authority_id", limit: 4
     t.string   "popolo_id",    limit: 255
+    t.boolean  "current",                  default: true, null: false
   end
 
   create_table "delayed_jobs", force: :cascade do |t|

--- a/spec/features/admin_loads_councillors_spec.rb
+++ b/spec/features/admin_loads_councillors_spec.rb
@@ -56,4 +56,25 @@ feature "Admin loads councillors for an authority" do
       expect(page).to have_content "Skipped loading 10 councillors"
     end
   end
+
+  context "when some councillors have been removed from office" do
+    around do |test|
+      Timecop.freeze(2016, 10, 11) { test.run }
+    end
+
+    given(:authority) { create(:authority,
+                              full_name: "Marrickville Council",
+                              state: "NSW") }
+
+    scenario "they loaded and marked as not current" do
+      sign_in_as_admin
+
+      visit admin_authority_path(authority)
+
+      click_button "Load Councillors"
+
+      expect(page).to have_content "Successfully loaded/updated 12 councillors"
+      expect(page).to have_content "Melissa Brooks No"
+    end
+  end
 end

--- a/spec/features/admin_loads_councillors_spec.rb
+++ b/spec/features/admin_loads_councillors_spec.rb
@@ -66,7 +66,7 @@ feature "Admin loads councillors for an authority" do
                               full_name: "Marrickville Council",
                               state: "NSW") }
 
-    scenario "they loaded and marked as not current" do
+    scenario "they are loaded and marked as not current" do
       sign_in_as_admin
 
       visit admin_authority_path(authority)

--- a/spec/features/view_message_to_councillor_spec.rb
+++ b/spec/features/view_message_to_councillor_spec.rb
@@ -16,4 +16,16 @@ feature "View a message sent to a councillor" do
 
     expect(page).to have_content("Richard Pope wrote to local councillor Louise Councillor")
   end
+
+  context "when they are not one of the authority's current councillors" do
+    before do
+      comment.councillor.update(current: false)
+    end
+
+    scenario "on the application page" do
+      visit application_path(comment.application)
+
+      expect(page).to have_content("Richard Pope wrote to local councillor Louise Councillor")
+    end
+  end
 end

--- a/spec/features/view_reply_from_councillor_spec.rb
+++ b/spec/features/view_reply_from_councillor_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+feature "View a reply from a councillor" do
+  given(:comment) do
+    VCR.use_cassette('planningalerts') do
+      authority = create(:authority, full_name: "City of Sydney")
+      create(
+        :comment_to_councillor,
+        :confirmed,
+        name: "Richard Pope",
+        councillor: create(:councillor, name: "Louise Councillor", authority: authority),
+        application: create(:application, authority: authority)
+      )
+    end
+  end
+
+  before do
+    create(:reply, comment: comment, councillor: comment.councillor)
+  end
+
+  scenario "on the application page" do
+    visit application_path(comment.application)
+
+    expect(page).to have_content("Richard Pope wrote to local councillor Louise Councillor")
+    expect(page).to have_content("Louise Councillor local councillor for City of Sydney replied to Richard Pope")
+  end
+
+  context "when they are not one of the authority's current councillors" do
+    before do
+      comment.councillor.update(current: false)
+    end
+
+    scenario "on the application page" do
+      visit application_path(comment.application)
+
+      expect(page).to have_content("Richard Pope wrote to local councillor Louise Councillor")
+      expect(page).to have_content("Louise Councillor local councillor for City of Sydney replied to Richard Pope")
+    end
+  end
+end

--- a/spec/features/write_to_councillors_spec.rb
+++ b/spec/features/write_to_councillors_spec.rb
@@ -68,6 +68,7 @@ feature "Send a message to a councillor" do
     context "and there are councillors on this authority" do
       background do
         create(:councillor, name: "Louise Councillor", authority: authority)
+        create(:councillor, name: "Fatima Councillor", current: false, authority: authority)
       end
 
       scenario "sending a message" do
@@ -104,6 +105,12 @@ feature "Send a message to a councillor" do
 
         expect(page).to have_content "Your comment has been sent to local councillor Louise Councillor and posted below."
         expect(page).to have_content "I think this is a really good idea"
+      end
+
+      scenario "only current councillors are available to write to" do
+        visit application_path(application)
+
+        expect(page).to_not have_content "Fatima Councillor"
       end
 
       scenario "getting an error after not selecting who your comment goes to" do

--- a/spec/fixtures/local_councillor_popolo.json
+++ b/spec/fixtures/local_councillor_popolo.json
@@ -81,7 +81,8 @@
       "person_id": "armidale_dumaresq_council/daryl_betteridge",
       "organization_id": "legislature/armidale_dumaresq_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/labor"
+      "on_behalf_of_id": "party/labor",
+      "end_date": "2016-09-10"
     },
     {
       "person_id": "armidale_dumaresq_council/darren_cameron",

--- a/spec/fixtures/vcr_cassettes/planningalerts.yml
+++ b/spec/fixtures/vcr_cassettes/planningalerts.yml
@@ -13067,7 +13067,8 @@ http_interactions:
               "person_id": "marrickville_council/melissa_brooks",
               "organization_id": "legislature/marrickville_council",
               "role": "councillor",
-              "on_behalf_of_id": "party/the_greens"
+              "on_behalf_of_id": "party/the_greens",
+              "end_date": "2016-10-11"
             },
             {
               "person_id": "marrickville_council/sylvie_ellsmore",

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -330,6 +330,44 @@ describe Application do
     end
   end
 
+  describe "#current_councillors_for_authority" do
+    let(:authority) { create(:authority) }
+    let(:application) { create(:application, authority: authority) }
+
+    context "when there are no councillors" do
+      it { expect(application.current_councillors_for_authority).to eq nil }
+    end
+
+    context "when there are councillors" do
+      before do
+        @councillor1 = create(:councillor, authority: authority)
+        @councillor2 = create(:councillor, authority: authority)
+        @councillor3 = create(:councillor, authority: authority)
+      end
+
+      it { expect(application.current_councillors_for_authority).to match_array [@councillor1, @councillor2, @councillor3] }
+    end
+
+    context "when there are councillors but not for the application’s authority" do
+      before do
+        @councillor1 = create(:councillor, authority: create(:authority))
+      end
+
+      it { expect(application.current_councillors_for_authority).to eq nil }
+    end
+
+    context "when there are councillors but not all are current" do
+      before do
+        @current_councillor = create(:councillor, current: true, authority: authority)
+        @former_councillor = create(:councillor, current: false, authority: authority)
+      end
+
+      it "only includes the current ones" do
+        expect(application.current_councillors_for_authority).to eq [@current_councillor]
+      end
+    end
+  end
+
   describe "#councillors_for_authority" do
     let(:authority) { create(:authority) }
     let(:application) { create(:application, authority: authority) }

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -368,33 +368,6 @@ describe Application do
     end
   end
 
-  describe "#councillors_for_authority" do
-    let(:authority) { create(:authority) }
-    let(:application) { create(:application, authority: authority) }
-
-    context "when there are no councillors" do
-      it { expect(application.councillors_for_authority).to eq nil }
-    end
-
-    context "when there are councillors" do
-      before do
-        @councillor1 = create(:councillor, authority: authority)
-        @councillor2 = create(:councillor, authority: authority)
-        @councillor3 = create(:councillor, authority: authority)
-      end
-
-      it { expect(application.councillors_for_authority).to match_array [@councillor1, @councillor2, @councillor3] }
-    end
-
-    context "when there are councillors but not for the application’s authority" do
-      before do
-        @councillor1 = create(:councillor, authority: create(:authority))
-      end
-
-      it { expect(application.councillors_for_authority).to eq nil }
-    end
-  end
-
   describe "#councillors_available_for_contact" do
     let(:authority) { create(:authority) }
     let(:application) { create(:application, authority: authority) }

--- a/spec/models/authority_spec.rb
+++ b/spec/models/authority_spec.rb
@@ -264,13 +264,26 @@ describe Authority do
           Timecop.freeze(2016, 12, 10) { test.run }
         end
 
-        it "sets them as not current" do
+        it "loads them and sets them as not current" do
           armidale = create(:authority, full_name: "Armidale Dumaresq Council")
 
           armidale.load_councillors(popolo)
 
           councillor = Councillor.find_by(name: "Daryl Betteridge")
           expect(councillor.current?).to be false
+        end
+
+        it "updates them as not current" do
+          armidale = create(:authority, full_name: "Armidale Dumaresq Council")
+          existing_councillor = create(
+            :councillor, authority: armidale,
+            name: "Daryl Betteridge",
+            current: true
+          )
+
+          armidale.load_councillors(popolo)
+
+          expect(existing_councillor.reload.current?).to be false
         end
       end
     end

--- a/spec/models/authority_spec.rb
+++ b/spec/models/authority_spec.rb
@@ -205,6 +205,7 @@ describe Authority do
         expect(kevin.email).to eql "kevin@albury.nsw.gov.au"
         expect(kevin.image_url).to eql "https://australian-local-councillors-images.s3.amazonaws.com/albury_city_council/kevin_mack-80x88.jpg"
         expect(kevin.party).to be_nil
+        expect(kevin.current).to be true
         expect(Councillor.find_by(name: "Ross Jackson").party).to eql "Liberal"
       end
 
@@ -241,6 +242,36 @@ describe Authority do
 
         councillor = Councillor.find_by(name: "Daryl Betteridge")
         expect(councillor.image_url).to be_nil
+      end
+
+      context "when a person is still a councillor" do
+        around do |test|
+          Timecop.freeze(2016, 9, 2) { test.run }
+        end
+
+        it "sets them as current" do
+          armidale = create(:authority, full_name: "Armidale Dumaresq Council")
+
+          armidale.load_councillors(popolo)
+
+          councillor = Councillor.find_by(name: "Daryl Betteridge")
+          expect(councillor.current?).to be true
+        end
+      end
+
+      context "when a person is no longer a councillor" do
+        around do |test|
+          Timecop.freeze(2016, 12, 10) { test.run }
+        end
+
+        it "sets them as not current" do
+          armidale = create(:authority, full_name: "Armidale Dumaresq Council")
+
+          armidale.load_councillors(popolo)
+
+          councillor = Councillor.find_by(name: "Daryl Betteridge")
+          expect(councillor.current?).to be false
+        end
       end
     end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -304,6 +304,23 @@ describe Comment do
     it "returns an empty Array if there are no replies on WriteIt" do
       skip
     end
+
+    context "when the councillor is not current" do
+      before do
+        VCR.use_cassette('planningalerts') do
+          comment.councillor.update(current: false)
+        end
+      end
+
+      it "still loads the reply" do
+        VCR.use_cassette('planningalerts') do
+          comment.create_replies_from_writeit!
+        end
+
+        expect(comment.replies.first.text).to eql "I agree, thanks for your comment"
+        expect(comment.replies.first.councillor).to eql comment.councillor
+      end
+    end
   end
 
   describe "#to_councillor?" do

--- a/spec/models/popolo_councillors_spec.rb
+++ b/spec/models/popolo_councillors_spec.rb
@@ -26,44 +26,10 @@ describe PopoloCouncillors do
   end
 
   describe "#person_with_party_and_end_date_for_membership" do
-    it "returns a person with their party" do
+    let(:popolo) do
       # TODO: Why is this the only test not using the fixture file?
       # We should choose one or the other for consistency
-      popolo = Everypolitician::Popolo::JSON.new(
-        persons: [{ name: "Kevin Mack", id: "kevin_mack" }],
-        organizations: [
-          {
-            name: "Sunripe Tomato Party",
-            id: "sunripe_tomato_party",
-            classification: "party"
-          },
-          {
-            name: "Marrickville Council",
-            id: "marrickville_council",
-            classification: "legislature"
-          }
-        ],
-        memberships: [
-          {
-            person_id: "kevin_mack",
-            organization_id: "marrickville_council",
-            on_behalf_of_id: "sunripe_tomato_party"
-          }
-        ]
-      )
-      popolo_councillors = PopoloCouncillors.new(popolo)
-      membership = popolo.memberships.first
-
-      expect(popolo_councillors.person_with_party_and_end_date_for_membership(membership).party)
-        .to eq "Sunripe Tomato Party"
-      expect(popolo_councillors.person_with_party_and_end_date_for_membership(membership).name)
-        .to eq "Kevin Mack"
-    end
-
-    it "returns a person with their membership end_date" do
-      # TODO: Why is this the only test not using the fixture file?
-      # We should choose one or the other for consistency
-      popolo = Everypolitician::Popolo::JSON.new(
+      Everypolitician::Popolo::JSON.new(
         persons: [{ name: "Kevin Mack", id: "kevin_mack" }],
         organizations: [
           {
@@ -86,6 +52,19 @@ describe PopoloCouncillors do
           }
         ]
       )
+    end
+
+    it "returns a person with their party" do
+      popolo_councillors = PopoloCouncillors.new(popolo)
+      membership = popolo.memberships.first
+
+      expect(popolo_councillors.person_with_party_and_end_date_for_membership(membership).party)
+        .to eq "Sunripe Tomato Party"
+      expect(popolo_councillors.person_with_party_and_end_date_for_membership(membership).name)
+        .to eq "Kevin Mack"
+    end
+
+    it "returns a person with their membership end_date" do
       popolo_councillors = PopoloCouncillors.new(popolo)
       membership = popolo.memberships.first
 

--- a/spec/models/popolo_councillors_spec.rb
+++ b/spec/models/popolo_councillors_spec.rb
@@ -25,7 +25,7 @@ describe PopoloCouncillors do
     end
   end
 
-  describe "#person_with_party_for_membership" do
+  describe "#person_with_party_and_end_date_for_membership" do
     it "returns a person with their party" do
       # TODO: Why is this the only test not using the fixture file?
       # We should choose one or the other for consistency
@@ -54,9 +54,44 @@ describe PopoloCouncillors do
       popolo_councillors = PopoloCouncillors.new(popolo)
       membership = popolo.memberships.first
 
-      expect(popolo_councillors.person_with_party_for_membership(membership).party)
+      expect(popolo_councillors.person_with_party_and_end_date_for_membership(membership).party)
         .to eq "Sunripe Tomato Party"
-      expect(popolo_councillors.person_with_party_for_membership(membership).name)
+      expect(popolo_councillors.person_with_party_and_end_date_for_membership(membership).name)
+        .to eq "Kevin Mack"
+    end
+
+    it "returns a person with their membership end_date" do
+      # TODO: Why is this the only test not using the fixture file?
+      # We should choose one or the other for consistency
+      popolo = Everypolitician::Popolo::JSON.new(
+        persons: [{ name: "Kevin Mack", id: "kevin_mack" }],
+        organizations: [
+          {
+            name: "Sunripe Tomato Party",
+            id: "sunripe_tomato_party",
+            classification: "party"
+          },
+          {
+            name: "Marrickville Council",
+            id: "marrickville_council",
+            classification: "legislature"
+          }
+        ],
+        memberships: [
+          {
+            person_id: "kevin_mack",
+            organization_id: "marrickville_council",
+            on_behalf_of_id: "sunripe_tomato_party",
+            end_date: "2016-12-29"
+          }
+        ]
+      )
+      popolo_councillors = PopoloCouncillors.new(popolo)
+      membership = popolo.memberships.first
+
+      expect(popolo_councillors.person_with_party_and_end_date_for_membership(membership).end_date)
+        .to eq "2016-12-29"
+      expect(popolo_councillors.person_with_party_and_end_date_for_membership(membership).name)
         .to eq "Kevin Mack"
     end
   end


### PR DESCRIPTION
See story here on #1073

Closes #1073 
