### PR TITLE
Refactor alert spec

### DIFF
--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -17,8 +17,8 @@ describe Alert do
   # In order to stop frustrating multiple alerts
   it "should only have one alert active for a particular street address / email address combination at one time" do
     email = "foo@foo.org"
-    u1 = Alert.create!(email: email, address: "A street address", radius_meters: 200, lat: 1.0, lng: 2.0)
-    u2 = Alert.create!(email: email, address: "A street address", radius_meters: 800, lat: 1.0, lng: 2.0)
+    u1 = create(:alert, email: email, address: "A street address", radius_meters: 200)
+    u2 = create(:alert, email: email, address: "A street address", radius_meters: 800)
     alerts = Alert.where(email: email)
     expect(alerts.count).to eq(1)
     expect(alerts.first.radius_meters).to eq(u2.radius_meters)

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -67,25 +67,6 @@ describe Alert do
     end
   end
 
-  # TODO: Is this actually testing EmailConfirmable?
-  describe "email address" do
-    it "is not blank" do
-      expect(build(:alert, email: nil)).to_not be_valid
-    end
-
-    it "should be valid" do
-      alert = build(:alert, email: "diddle@")
-      expect(alert).not_to be_valid
-      expect(alert.errors[:email]).to eq(["does not appear to be a valid e-mail address"])
-    end
-
-    it "should have an '@' in it" do
-      alert = build(:alert, email: "diddle")
-      expect(alert).not_to be_valid
-      expect(alert.errors[:email]).to eq(["does not appear to be a valid e-mail address"])
-    end
-  end
-
   it "should be able to store the attribute location" do
     alert = Alert.new
     alert.location = Location.new(1.0, 2.0)

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -8,13 +8,14 @@ describe Alert do
   # In order to stop frustrating multiple alerts
   it "should only have one alert active for a particular street address / email address combination at one time" do
     email = "foo@foo.org"
-    existing_alert = create(:alert, email: email, address: "A street address", radius_meters: 200)
-    new_alert = create(:alert, email: email, address: "A street address", radius_meters: 800)
+    existing_alert = create(:alert, email: email, address: "A street address")
+    new_alert = create(:alert, email: email, address: "A street address")
 
     alerts = Alert.where(email: email)
 
     expect(alerts.count).to eq(1)
-    expect(alerts.first.radius_meters).to eq(new_alert.radius_meters)
+    expect(alerts.first).to_not eql existing_alert
+    expect(alerts.first).to eql new_alert
   end
 
   it "should allow multiple alerts for different street addresses but the same email address" do

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -14,14 +14,6 @@ describe Alert do
     allow(Location).to receive(:geocode).and_return(@loc)
   end
 
-  it "should have no trouble creating a user with valid attributes" do
-    Alert.create!(
-      address: "24 Bruce Road, Glenbrook, NSW",
-      email: "matthew@openaustralia.org",
-      radius_meters: 200
-    )
-  end
-
   # In order to stop frustrating multiple alerts
   it "should only have one alert active for a particular street address / email address combination at one time" do
     email = "foo@foo.org"

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -617,7 +617,7 @@ describe Alert do
 
   describe "#process!" do
     context "an alert with no new comments" do
-      let(:alert) { Alert.create!(email: "matthew@openaustralia.org", address: address, radius_meters: 2000) }
+      let(:alert) { create(:alert, address: address) }
       before :each do
         allow(alert).to receive(:recent_comments).and_return([])
         # Don't know why this isn't cleared out automatically

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -98,23 +98,6 @@ describe Alert do
     end
   end
 
-  # TODO: Is this actually testing EmailConfirmable?
-  describe "confirm_id" do
-    it "should be a string" do
-      expect(create(:alert).confirm_id).to be_instance_of(String)
-    end
-
-    it "should not be the the same for two different users" do
-      u1 = create(:alert)
-      u2 = create(:alert)
-      expect(u1.confirm_id).not_to eq(u2.confirm_id)
-    end
-
-    it "should only have hex characters in it and be exactly twenty characters long" do
-      expect(create(:alert).confirm_id).to match(/^[0-9a-f]{20}$/)
-    end
-  end
-
   describe "confirmed" do
     it "should be false when alert is created" do
       expect(create(:alert).confirmed).to be_falsey

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -5,16 +5,6 @@ describe Alert do
 
   let(:address) { "24 Bruce Road, Glenbrook" }
 
-  before :each do
-    # Unless we override this elsewhere just stub the geocoder to return coordinates of address above
-    @loc = Location.new(-33.772609, 150.624263)
-    allow(@loc).to receive(:country_code).and_return("AU")
-    allow(@loc).to receive(:full_address).and_return("24 Bruce Rd, Glenbrook NSW 2773")
-    allow(@loc).to receive(:accuracy).and_return(8)
-    allow(@loc).to receive(:all).and_return([@loc])
-    allow(Location).to receive(:geocode).and_return(@loc)
-  end
-
   # In order to stop frustrating multiple alerts
   it "should only have one alert active for a particular street address / email address combination at one time" do
     email = "foo@foo.org"
@@ -45,11 +35,10 @@ describe Alert do
     it "should happen automatically on saving" do
       alert = build(:alert, address: address, lat: nil, lng: nil)
 
-      alert.save
+      VCR.use_cassette(:planningalerts) { alert.save! }
 
-      expect(alert.lat).to eq(@loc.lat)
-      expect(alert.lng).to eq(@loc.lng)
-      expect(alert).to be_valid
+      expect(alert.lat).to eq(-33.772607)
+      expect(alert.lng).to eq(150.624245)
     end
 
     it "should set an error on the address if there is an error on geocoding" do
@@ -68,8 +57,10 @@ describe Alert do
 
     it "should replace the address with the full resolved address obtained by geocoding" do
       u = build(:alert, address: "24 Bruce Road, Glenbrook", lat: nil, lng: nil)
-      u.save!
-      expect(u.address).to eq("24 Bruce Rd, Glenbrook NSW 2773")
+
+      VCR.use_cassette(:planningalerts) { u.save! }
+
+      expect(u.address).to eq("24 Bruce Road, Glenbrook NSW 2773")
     end
   end
 

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -12,7 +12,6 @@ describe Alert do
     allow(@loc).to receive(:accuracy).and_return(8)
     allow(@loc).to receive(:all).and_return([@loc])
     allow(Location).to receive(:geocode).and_return(@loc)
-    Alert.delete_all
   end
 
   it "should have no trouble creating a user with valid attributes" do

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -8,11 +8,13 @@ describe Alert do
   # In order to stop frustrating multiple alerts
   it "should only have one alert active for a particular street address / email address combination at one time" do
     email = "foo@foo.org"
-    u1 = create(:alert, email: email, address: "A street address", radius_meters: 200)
-    u2 = create(:alert, email: email, address: "A street address", radius_meters: 800)
+    existing_alert = create(:alert, email: email, address: "A street address", radius_meters: 200)
+    new_alert = create(:alert, email: email, address: "A street address", radius_meters: 800)
+
     alerts = Alert.where(email: email)
+
     expect(alerts.count).to eq(1)
-    expect(alerts.first.radius_meters).to eq(u2.radius_meters)
+    expect(alerts.first.radius_meters).to eq(new_alert.radius_meters)
   end
 
   it "should allow multiple alerts for different street addresses but the same email address" do
@@ -25,10 +27,10 @@ describe Alert do
   it "should be able to accept location information if it is already known and so not use the geocoder" do
     expect(Location).not_to receive(:geocode)
 
-    u = create(:alert, lat: 1.0, lng: 2.0)
+    alert = create(:alert, lat: 1.0, lng: 2.0)
 
-    expect(u.lat).to eq(1.0)
-    expect(u.lng).to eq(2.0)
+    expect(alert.lat).to eq(1.0)
+    expect(alert.lng).to eq(2.0)
   end
 
   describe "geocoding" do
@@ -43,24 +45,24 @@ describe Alert do
 
     it "should set an error on the address if there is an error on geocoding" do
       allow(Location).to receive(:geocode).and_return(double(error: "some error message", lat: nil, lng: nil, full_address: nil))
-      u = build(:alert, lat: nil, lng: nil)
-      expect(u).not_to be_valid
-      expect(u.errors[:address]).to eq(["some error message"])
+      alert = build(:alert, lat: nil, lng: nil)
+      expect(alert).not_to be_valid
+      expect(alert.errors[:address]).to eq(["some error message"])
     end
 
     it "should error if there are multiple matches from the geocoder" do
       allow(Location).to receive(:geocode).and_return(double(lat: 1, lng: 2, full_address: "Bruce Rd, VIC 3885", error: nil, all: [nil, nil]))
-      u = build(:alert, address: "Bruce Road", lat: nil, lng: nil)
-      expect(u).not_to be_valid
-      expect(u.errors[:address]).to eq(["isn't complete. Please enter a full street address, including suburb and state, e.g. Bruce Rd, VIC 3885"])
+      alert = build(:alert, address: "Bruce Road", lat: nil, lng: nil)
+      expect(alert).not_to be_valid
+      expect(alert.errors[:address]).to eq(["isn't complete. Please enter a full street address, including suburb and state, e.g. Bruce Rd, VIC 3885"])
     end
 
     it "should replace the address with the full resolved address obtained by geocoding" do
-      u = build(:alert, address: "24 Bruce Road, Glenbrook", lat: nil, lng: nil)
+      alert = build(:alert, address: "24 Bruce Road, Glenbrook", lat: nil, lng: nil)
 
-      VCR.use_cassette(:planningalerts) { u.save! }
+      VCR.use_cassette(:planningalerts) { alert.save! }
 
-      expect(u.address).to eq("24 Bruce Road, Glenbrook NSW 2773")
+      expect(alert.address).to eq("24 Bruce Road, Glenbrook NSW 2773")
     end
   end
 
@@ -71,46 +73,46 @@ describe Alert do
     end
 
     it "should be valid" do
-      u = build(:alert, email: "diddle@")
-      expect(u).not_to be_valid
-      expect(u.errors[:email]).to eq(["does not appear to be a valid e-mail address"])
+      alert = build(:alert, email: "diddle@")
+      expect(alert).not_to be_valid
+      expect(alert.errors[:email]).to eq(["does not appear to be a valid e-mail address"])
     end
 
     it "should have an '@' in it" do
-      u = build(:alert, email: "diddle")
-      expect(u).not_to be_valid
-      expect(u.errors[:email]).to eq(["does not appear to be a valid e-mail address"])
+      alert = build(:alert, email: "diddle")
+      expect(alert).not_to be_valid
+      expect(alert.errors[:email]).to eq(["does not appear to be a valid e-mail address"])
     end
   end
 
   it "should be able to store the attribute location" do
-    u = Alert.new
-    u.location = Location.new(1.0, 2.0)
-    expect(u.lat).to eq(1.0)
-    expect(u.lng).to eq(2.0)
-    expect(u.location.lat).to eq(1.0)
-    expect(u.location.lng).to eq(2.0)
+    alert = Alert.new
+    alert.location = Location.new(1.0, 2.0)
+    expect(alert.lat).to eq(1.0)
+    expect(alert.lng).to eq(2.0)
+    expect(alert.location.lat).to eq(1.0)
+    expect(alert.location.lng).to eq(2.0)
   end
 
   it "should handle location being nil" do
-    u = Alert.new
-    u.location = nil
-    expect(u.lat).to be_nil
-    expect(u.lng).to be_nil
-    expect(u.location).to be_nil
+    alert = Alert.new
+    alert.location = nil
+    expect(alert.lat).to be_nil
+    expect(alert.lng).to be_nil
+    expect(alert.location).to be_nil
   end
 
   describe "radius_meters" do
     it "should have a number" do
-      u = build(:alert, radius_meters: "a")
-      expect(u).not_to be_valid
-      expect(u.errors[:radius_meters]).to eq(["isn't selected"])
+      alert = build(:alert, radius_meters: "a")
+      expect(alert).not_to be_valid
+      expect(alert.errors[:radius_meters]).to eq(["isn't selected"])
     end
 
     it "should be greater than zero" do
-      u = build(:alert, radius_meters: "0")
-      expect(u).not_to be_valid
-      expect(u.errors[:radius_meters]).to eq(["isn't selected"])
+      alert = build(:alert, radius_meters: "0")
+      expect(alert).not_to be_valid
+      expect(alert.errors[:radius_meters]).to eq(["isn't selected"])
     end
   end
 
@@ -137,17 +139,17 @@ describe Alert do
     end
 
     it "should be able to be set to false" do
-      u = build(:alert)
-      u.confirmed = false
-      u.save!
-      expect(u.confirmed).to eq(false)
+      alert = build(:alert)
+      alert.confirmed = false
+      alert.save!
+      expect(alert.confirmed).to eq(false)
     end
 
     it "should be able to set to true" do
-      u = build(:alert)
-      u.confirmed = true
-      u.save!
-      expect(u.confirmed).to eq(true)
+      alert = build(:alert)
+      alert.confirmed = true
+      alert.save!
+      expect(alert.confirmed).to eq(true)
     end
   end
 
@@ -213,15 +215,15 @@ describe Alert do
 
     context "when the alert has since been unsubscribed" do
       let!(:alert) do
-        a = Timecop.freeze(Date.new(2016, 8, 24)) do
+        alert = Timecop.freeze(Date.new(2016, 8, 24)) do
           create :confirmed_alert
         end
 
         Timecop.freeze(Date.new(2016, 8, 24)) do
-          a.unsubscribe!
+          alert.unsubscribe!
         end
 
-        a
+        alert
       end
 
       it "still includes it for the day it was created" do
@@ -384,17 +386,17 @@ describe Alert do
     it "should return the local government authority name" do
       expect(Geo2gov).to receive(:new).with(1.0, 2.0).and_return(double(lga_name: "Blue Mountains"))
 
-      a = create(:alert, lat: 1.0, lng: 2.0, email: "foo@bar.com", radius_meters: 200, address: "")
-      expect(a.lga_name).to eq("Blue Mountains")
+      alert = create(:alert, lat: 1.0, lng: 2.0, email: "foo@bar.com", radius_meters: 200, address: "")
+      expect(alert.lga_name).to eq("Blue Mountains")
     end
 
     it "should cache the value in the database" do
       expect(Geo2gov).to receive(:new).once.with(1.0, 2.0).and_return(double(lga_name: "Blue Mountains"))
 
-      a = create(:alert, id: 1, lat: 1.0, lng: 2.0, email: "foo@bar.com", radius_meters: 200, address: "")
-      expect(a.lga_name).to eq("Blue Mountains")
-      b = Alert.first
-      expect(b.lga_name).to eq("Blue Mountains")
+      alert = create(:alert, id: 1, lat: 1.0, lng: 2.0, email: "foo@bar.com", radius_meters: 200, address: "")
+      expect(alert.lga_name).to eq("Blue Mountains")
+
+      expect(Alert.first.lga_name).to eq("Blue Mountains")
     end
   end
 

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -3,8 +3,9 @@ require 'spec_helper'
 describe Alert do
   it_behaves_like "email_confirmable"
 
+  let(:address) { "24 Bruce Road, Glenbrook, NSW" }
+
   before :each do
-    @address = "24 Bruce Road, Glenbrook, NSW"
     # Unless we override this elsewhere just stub the geocoder to return coordinates of address above
     @loc = Location.new(-33.772609, 150.624263)
     allow(@loc).to receive(:country_code).and_return("AU")
@@ -42,7 +43,7 @@ describe Alert do
 
   describe "geocoding" do
     it "should happen automatically on saving" do
-      alert = build(:alert, address: @address, lat: nil, lng: nil)
+      alert = build(:alert, address: address, lat: nil, lng: nil)
 
       alert.save
 
@@ -337,7 +338,7 @@ describe Alert do
 
   describe "recent applications for this user" do
     before :each do
-      @alert = create(:alert, email: "matthew@openaustralia.org", address: @address, radius_meters: 2000)
+      @alert = create(:alert, email: "matthew@openaustralia.org", address: address, radius_meters: 2000)
       # Position test application around the point of the alert
       p1 = @alert.location.endpoint(0, 501) # 501 m north of alert
       p2 = @alert.location.endpoint(0, 499) # 499 m north of alert
@@ -407,7 +408,7 @@ describe Alert do
   end
 
   describe "#new_comments" do
-    let(:alert) { create(:alert, address: @address, radius_meters: 2000) }
+    let(:alert) { create(:alert, address: address, radius_meters: 2000) }
     let(:p1) { alert.location.endpoint(0, 501) } # 501 m north of alert
     let(:application) { create(:application, lat: p1.lat, lng: p1.lng, suburb: "", state: "", postcode: "") }
 
@@ -448,7 +449,7 @@ describe Alert do
   describe "#new_replies" do
     let (:alert) do
       create(:alert,
-             address: @address,
+             address: address,
              radius_meters: 2000,
              lat: 1.0,
              lng: 2.0)
@@ -462,7 +463,7 @@ describe Alert do
       application = create(:application,
                             lat: 1.0,
                             lng: 2.0,
-                            address: @address,
+                            address: address,
                             suburb: "Glenbrook",
                             state: "NSW",
                             postcode: "2773",
@@ -478,7 +479,7 @@ describe Alert do
       application = create(:application,
                             lat: 1.0,
                             lng: 2.0,
-                            address: @address,
+                            address: address,
                             suburb: "Glenbrook",
                             state: "NSW",
                             postcode: "2773",
@@ -495,12 +496,12 @@ describe Alert do
   end
 
   describe "#applications_with_new_comments" do
-    let (:alert) { create(:alert, address: @address, radius_meters: 2000, lat: 1.0, lng: 2.0) }
+    let (:alert) { create(:alert, address: address, radius_meters: 2000, lat: 1.0, lng: 2.0) }
     let (:near_application) do
       create(:application,
              lat: 1.0,
              lng: 2.0,
-             address: @address,
+             address: address,
              suburb: "Glenbrook",
              state: "NSW",
              postcode: "2773")
@@ -510,7 +511,7 @@ describe Alert do
       create(:application,
              lat: alert.location.endpoint(0, 5001).lat,
              lng: alert.location.endpoint(0, 5001).lng,
-             address: @address,
+             address: address,
              suburb: "Glenbrook",
              state: "NSW",
              postcode: "2773")
@@ -566,7 +567,7 @@ describe Alert do
   describe "#applications_with_new_replies" do
     let (:alert) do
       create(:alert,
-             address: @address,
+             address: address,
              radius_meters: 2000,
              lat: 1.0,
              lng: 2.0)
@@ -581,7 +582,7 @@ describe Alert do
         application = create(:application,
                              lat: 1.0,
                              lng: 2.0,
-                             address: @address,
+                             address: address,
                              suburb: "Glenbrook",
                              state: "NSW",
                              postcode: "2773",
@@ -600,7 +601,7 @@ describe Alert do
         application = create(:application,
                              lat: far_away.lat,
                              lng: far_away.lng,
-                             address: @address,
+                             address: address,
                              suburb: "Glenbrook",
                              state: "NSW",
                              postcode: "2773",
@@ -616,7 +617,7 @@ describe Alert do
 
   describe "#process!" do
     context "an alert with no new comments" do
-      let(:alert) { Alert.create!(email: "matthew@openaustralia.org", address: @address, radius_meters: 2000) }
+      let(:alert) { Alert.create!(email: "matthew@openaustralia.org", address: address, radius_meters: 2000) }
       before :each do
         allow(alert).to receive(:recent_comments).and_return([])
         # Don't know why this isn't cleared out automatically

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Alert do
   it_behaves_like "email_confirmable"
 
-  let(:address) { "24 Bruce Road, Glenbrook, NSW" }
+  let(:address) { "24 Bruce Road, Glenbrook" }
 
   before :each do
     # Unless we override this elsewhere just stub the geocoder to return coordinates of address above

--- a/spec/support/email_confirmable_concern.rb
+++ b/spec/support/email_confirmable_concern.rb
@@ -31,6 +31,28 @@ shared_examples_for "email_confirmable" do
     expect(object.errors[:email]).to eq(["does not appear to be a valid e-mail address"])
   end
 
+  describe "confirm_id" do
+    let(:object) do
+      VCR.use_cassette('planningalerts') { create(model_name_for_factory_girl) }
+    end
+
+    it "is a string" do
+      expect(object.confirm_id).to be_instance_of(String)
+    end
+
+    it "is not the same for two different objects" do
+      another_object = VCR.use_cassette('planningalerts') do
+        create(model_name_for_factory_girl)
+      end
+
+      expect(object.confirm_id).to_not eq another_object.confirm_id
+    end
+
+    it "only includes hex characters and is exactly twenty characters long" do
+      expect(object.confirm_id).to match(/^[0-9a-f]{20}$/)
+    end
+  end
+
   describe "#after_create" do
     let(:object) do
       VCR.use_cassette('planningalerts') { build(model_name_for_factory_girl) }

--- a/spec/support/email_confirmable_concern.rb
+++ b/spec/support/email_confirmable_concern.rb
@@ -4,6 +4,33 @@ shared_examples_for "email_confirmable" do
   let(:model) { described_class }
   let(:model_name_for_factory_girl) { model.to_s.underscore.to_sym }
 
+  it "must have an email" do
+    object = VCR.use_cassette('planningalerts') do
+      build(model_name_for_factory_girl, email: nil)
+    end
+
+    expect(object).to_not be_valid
+  end
+
+  it "must have a valid email address" do
+    object = VCR.use_cassette('planningalerts') do
+      build(model_name_for_factory_girl, email: "diddle@")
+    end
+
+    expect(object).not_to be_valid
+    expect(object.errors[:email]).to eq(["does not appear to be a valid e-mail address"])
+  end
+
+  # TODO: Is this just retesting the validates_email_format_of gem?
+  it "must have an email address which includes a '@'" do
+    object = VCR.use_cassette('planningalerts') do
+      build(model_name_for_factory_girl, email: "diddle")
+    end
+
+    expect(object).not_to be_valid
+    expect(object.errors[:email]).to eq(["does not appear to be a valid e-mail address"])
+  end
+
   describe "#after_create" do
     let(:object) do
       VCR.use_cassette('planningalerts') { build(model_name_for_factory_girl) }


### PR DESCRIPTION
This changes the spec:

* to use [factories](https://github.com/thoughtbot/factory_girl_rails) like our other specs
* use clearer naming
* use VRC to mock requests to the geocoder, rather than mocking the individual methods. Feels more consistent with our other tests and easier to read inline
* extract tests that are testing the behavior of EmailConfirmable into it's spec file.

This is ahead of changing the behavior of Alerts to not rely on callbacks so much.