### PR TITLE
Change Alert 'confirmed' column to two value Boolean

### DIFF
--- a/db/migrate/20170109002546_default_alerts_confirmed_to_false.rb
+++ b/db/migrate/20170109002546_default_alerts_confirmed_to_false.rb
@@ -1,0 +1,5 @@
+class DefaultAlertsConfirmedToFalse < ActiveRecord::Migration
+  def change
+    change_column_default :alerts, :confirmed, false
+  end
+end

--- a/db/migrate/20170109004333_change_alert_confirmed_nil_to_false.rb
+++ b/db/migrate/20170109004333_change_alert_confirmed_nil_to_false.rb
@@ -1,0 +1,7 @@
+class ChangeAlertConfirmedNilToFalse < ActiveRecord::Migration
+  def change
+    Alert.where(confirmed: nil).find_each do |alert|
+      alert.update(confirmed: false)
+    end
+  end
+end

--- a/db/migrate/20170109005050_set_alert_confirmed_to_null_false.rb
+++ b/db/migrate/20170109005050_set_alert_confirmed_to_null_false.rb
@@ -1,0 +1,5 @@
+class SetAlertConfirmedToNullFalse < ActiveRecord::Migration
+  def change
+    change_column_null :alerts, :confirmed, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161228065516) do
+ActiveRecord::Schema.define(version: 20170109002546) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "resource_id",   limit: 255,   null: false
@@ -29,20 +29,20 @@ ActiveRecord::Schema.define(version: 20161228065516) do
   add_index "active_admin_comments", ["resource_type", "resource_id"], name: "index_admin_notes_on_resource_type_and_resource_id", using: :btree
 
   create_table "alerts", force: :cascade do |t|
-    t.string   "email",          limit: 120,                     null: false
-    t.string   "address",        limit: 120,                     null: false
+    t.string   "email",           limit: 120,                     null: false
+    t.string   "address",         limit: 120,                     null: false
     t.datetime "last_sent"
-    t.float    "lat",            limit: 24,                      null: false
-    t.float    "lng",            limit: 24,                      null: false
-    t.string   "confirm_id",     limit: 20
-    t.boolean  "confirmed"
-    t.integer  "radius_meters",  limit: 4,                       null: false
-    t.string   "lga_name",       limit: 50
+    t.float    "lat",             limit: 24,                      null: false
+    t.float    "lng",             limit: 24,                      null: false
+    t.string   "confirm_id",      limit: 20
+    t.boolean  "confirmed",                   default: false
+    t.integer  "radius_meters",   limit: 4,                       null: false
+    t.string   "lga_name",        limit: 50
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "unsubscribed",               default: false,     null: false
+    t.boolean  "unsubscribed",                default: false,     null: false
     t.datetime "last_processed"
-    t.string   "theme",          limit: 255, default: "default", null: false
+    t.string   "theme",           limit: 255, default: "default", null: false
     t.datetime "unsubscribed_at"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170109002546) do
+ActiveRecord::Schema.define(version: 20170109005050) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "resource_id",   limit: 255,   null: false
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 20170109002546) do
     t.float    "lat",             limit: 24,                      null: false
     t.float    "lng",             limit: 24,                      null: false
     t.string   "confirm_id",      limit: 20
-    t.boolean  "confirmed",                   default: false
+    t.boolean  "confirmed",                   default: false,     null: false
     t.integer  "radius_meters",   limit: 4,                       null: false
     t.string   "lga_name",        limit: 50
     t.datetime "created_at"

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -100,7 +100,7 @@ describe Alert do
 
   describe "confirmed" do
     it "should be false when alert is created" do
-      expect(create(:alert).confirmed).to be_falsey
+      expect(create(:alert).confirmed).to be false
     end
 
     it "should be able to be set to false" do


### PR DESCRIPTION
Currently an Alert’s confirmed value, which should be a Boolean, can be `true`, `false` or `null`. You'd expect a Boolean to only have two possible values, `true` or `false`.

The current situation means we can't do queries like `Alert.where(email: "example@email.com", confirmed: false), because the value could also be null.

There are other ways to hack around this, but I think it's better to remove the complexity at the root.

This PR runs three migrations to change the `confirmed` column to behave as you'd expect of a Boolean, and to match our `unsubscribed` column:

1. Set the default value to `false` not `null`
2. Change all the existing Alerts with confirmed=nil, to confirmed=false
3. Make the column not accept null, only true or false.
