### PR TITLE
Parse new alert signups

### DIFF
--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -12,21 +12,17 @@ class AlertsController < ApplicationController
   end
 
   def create
-    @alert = Alert.new(
-      email: params[:alert][:email],
-      address: params[:alert][:address],
-      radius_meters: zone_sizes['l'],
-      theme: @theme
-    )
-    @alert.geocode_from_address
+    @alert = NewAlertParser.new(
+      Alert.new(
+        email: params[:alert][:email],
+        address: params[:alert][:address],
+        radius_meters: zone_sizes['l'],
+        theme: @theme
+      )
+    ).parse
 
-    if Alert.find_by(email: @alert.email, address: @alert.address, confirmed: false)
-      @alert = Alert.find_by(email: @alert.email, address: @alert.address)
-      @alert.send_confirmation_email
-    else
-      if !@alert.save
-        render 'new'
-      end
+    if @alert.present? && !@alert.save
+      render 'new'
     end
   end
 

--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -12,10 +12,21 @@ class AlertsController < ApplicationController
   end
 
   def create
-    @address = params[:alert][:address]
-    @alert = Alert.new(address: @address, email: params[:alert][:email], radius_meters: zone_sizes['l'], theme: @theme)
-    if !@alert.save
-      render 'new'
+    @alert = Alert.new(
+      email: params[:alert][:email],
+      address: params[:alert][:address],
+      radius_meters: zone_sizes['l'],
+      theme: @theme
+    )
+    @alert.geocode_from_address
+
+    if Alert.find_by(email: @alert.email, address: @alert.address, confirmed: false)
+      @alert = Alert.find_by(email: @alert.email, address: @alert.address)
+      @alert.send_confirmation_email
+    else
+      if !@alert.save
+        render 'new'
+      end
     end
   end
 

--- a/app/mailers/alert_notifier.rb
+++ b/app/mailers/alert_notifier.rb
@@ -14,4 +14,15 @@ class AlertNotifier < ActionMailer::Base
         locals: {applications: applications, comments: comments, alert: alert, replies: replies}).strip,
       "List-Unsubscribe" => "<" + unsubscribe_alert_url(protocol: protocol(theme), host: host(theme), id: alert.confirm_id) + ">")
   end
+
+  def new_signup_attempt_notice(alert)
+    @alert = alert
+
+    themed_mail(
+      theme: alert.theme,
+      from: email_from(alert.theme),
+      to: alert.email,
+      subject: "Your subscription for #{alert.address}"
+    )
+  end
 end

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -5,7 +5,6 @@ class Alert < ActiveRecord::Base
   validate :validate_address
 
   before_validation :geocode
-  before_create :remove_other_alerts_for_this_address
   include EmailConfirmable
 
   attr_writer :address_for_placeholder
@@ -262,10 +261,6 @@ class Alert < ActiveRecord::Base
   end
 
   private
-
-  def remove_other_alerts_for_this_address
-    Alert.delete_all(email: email, address: address)
-  end
 
   def geocode
     # Only geocode if location hasn't been set

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -252,15 +252,11 @@ class Alert < ActiveRecord::Base
   def geocode_from_address
     # Only geocode if location hasn't been set
     if lat.nil? && lng.nil?
-      geocode_result = Location.geocode(address)
+      @geocode_result = Location.geocode(address)
 
-      if geocode_result.error
-        self.errors.add(:address, geocode_result.error)
-      elsif geocode_result.all.size > 1
-        self.errors.add(:address, "isn't complete. Please enter a full street address, including suburb and state, e.g. #{geocode_result.full_address}")
-      else
-        self.location = geocode_result
-        self.address = geocode_result.full_address
+      unless @geocode_result.error || @geocode_result.all.many?
+        self.location = @geocode_result
+        self.address = @geocode_result.full_address
       end
     end
   end

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -61,6 +61,10 @@ class Alert < ActiveRecord::Base
     end.count
   end
 
+  def geocoded?
+    location.present?
+  end
+
   def unsubscribe!
     update!(unsubscribed: true, unsubscribed_at: Time.now)
   end
@@ -249,8 +253,7 @@ class Alert < ActiveRecord::Base
   end
 
   def geocode_from_address
-    # Only geocode if location hasn't been set
-    if lat.nil? && lng.nil?
+    unless geocoded?
       @geocode_result = Location.geocode(address)
 
       unless @geocode_result.error || @geocode_result.all.many?

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -270,7 +270,7 @@ class Alert < ActiveRecord::Base
     if @geocode_result
       if @geocode_result.error
         errors.add(:address, @geocode_result.error)
-      elsif @geocode_result.all.size > 1
+      elsif @geocode_result.all.many?
         errors.add(:address, "isn't complete. Please enter a full street address, including suburb and state, e.g. #{@geocode_result.full_address}")
       end
     end

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -249,6 +249,22 @@ class Alert < ActiveRecord::Base
     [total_no_emails, total_no_applications, total_no_comments]
   end
 
+  def geocode_from_address
+    # Only geocode if location hasn't been set
+    if lat.nil? && lng.nil?
+      geocode_result = Location.geocode(address)
+
+      if geocode_result.error
+        self.errors.add(:address, geocode_result.error)
+      elsif geocode_result.all.size > 1
+        self.errors.add(:address, "isn't complete. Please enter a full street address, including suburb and state, e.g. #{geocode_result.full_address}")
+      else
+        self.location = geocode_result
+        self.address = geocode_result.full_address
+      end
+    end
+  end
+
   private
 
   def remove_other_alerts_for_this_address

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -4,7 +4,7 @@ class Alert < ActiveRecord::Base
   validates_numericality_of :radius_meters, greater_than: 0, message: "isn't selected"
   validate :validate_address
 
-  before_validation :geocode_from_address
+  before_validation :geocode_from_address, unless: :geocoded?
   include EmailConfirmable
 
   attr_writer :address_for_placeholder
@@ -253,13 +253,11 @@ class Alert < ActiveRecord::Base
   end
 
   def geocode_from_address
-    unless geocoded?
-      @geocode_result = Location.geocode(address)
+    @geocode_result = Location.geocode(address)
 
-      unless @geocode_result.error || @geocode_result.all.many?
-        self.location = @geocode_result
-        self.address = @geocode_result.full_address
-      end
+    unless @geocode_result.error || @geocode_result.all.many?
+      self.location = @geocode_result
+      self.address = @geocode_result.full_address
     end
   end
 

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -4,7 +4,7 @@ class Alert < ActiveRecord::Base
   validates_numericality_of :radius_meters, greater_than: 0, message: "isn't selected"
   validate :validate_address
 
-  before_validation :geocode
+  before_validation :geocode_from_address
   include EmailConfirmable
 
   attr_writer :address_for_placeholder
@@ -261,15 +261,6 @@ class Alert < ActiveRecord::Base
   end
 
   private
-
-  def geocode
-    # Only geocode if location hasn't been set
-    if self.lat.nil? && self.lng.nil?
-      @geocode_result = Location.geocode(address)
-      self.location = @geocode_result
-      self.address = @geocode_result.full_address
-    end
-  end
 
   def validate_address
     # Only validate the street address if we used the geocoder

--- a/app/models/new_alert_parser.rb
+++ b/app/models/new_alert_parser.rb
@@ -8,24 +8,24 @@ class NewAlertParser
   def parse
     alert.geocode_from_address
 
-    if preexisting_matching_alert
-      if preexisting_matching_alert.confirmed?
-        if preexisting_matching_alert.unsubscribed?
-          alert
-        else
-          nil
-        end
-      else
-        preexisting_matching_alert.send_confirmation_email
-
-        nil
-      end
-    else
-      alert
-    end
+    preexisting_matching_alert ? parse_for_preexisting_alert_states : alert
   end
 
   private
+
+  def parse_for_preexisting_alert_states
+    if preexisting_matching_alert.confirmed?
+      if preexisting_matching_alert.unsubscribed?
+        alert
+      else
+        nil
+      end
+    else
+      preexisting_matching_alert.send_confirmation_email
+
+      nil
+    end
+  end
 
   def preexisting_matching_alert
     Alert.find_by(email: alert.email, address: alert.address)

--- a/app/models/new_alert_parser.rb
+++ b/app/models/new_alert_parser.rb
@@ -9,11 +9,15 @@ class NewAlertParser
     alert.geocode_from_address
 
     if preexisting_matching_alert
-      preexisting_alert = preexisting_matching_alert
+      if preexisting_matching_alert.confirmed?
+        nil
+      else
+        preexisting_alert = preexisting_matching_unconfirmed_alert
 
-      preexisting_alert.send_confirmation_email
+        preexisting_alert.send_confirmation_email
 
-      nil
+        nil
+      end
     else
       alert
     end
@@ -22,6 +26,6 @@ class NewAlertParser
   private
 
   def preexisting_matching_alert
-    Alert.find_by(email: alert.email, address: alert.address, confirmed: false)
+    Alert.find_by(email: alert.email, address: alert.address)
   end
 end

--- a/app/models/new_alert_parser.rb
+++ b/app/models/new_alert_parser.rb
@@ -14,15 +14,26 @@ class NewAlertParser
   private
 
   def parse_for_preexisting_alert_states
-    if preexisting_matching_alert.confirmed?
-      if preexisting_matching_alert.unsubscribed?
-        alert
-      else
-        send_notice_to_existing_active_alert_owner_and_return
-      end
-    else
+    case
+    when preexisting_alert_is_confirmed_but_unsubscribed?
+      alert
+    when preexisting_alert_is_confirmed_and_subscribed?
+      send_notice_to_existing_active_alert_owner_and_return
+    when preexisting_alert_is_unconfirmed?
       resend_original_confirmation_email_and_return
     end
+  end
+
+  def preexisting_alert_is_confirmed_but_unsubscribed?
+    preexisting_matching_alert.confirmed? && preexisting_matching_alert.unsubscribed?
+  end
+
+  def preexisting_alert_is_confirmed_and_subscribed?
+    preexisting_matching_alert.confirmed? && !preexisting_matching_alert.unsubscribed?
+  end
+
+  def preexisting_alert_is_unconfirmed?
+    !preexisting_matching_alert.confirmed?
   end
 
   def preexisting_matching_alert

--- a/app/models/new_alert_parser.rb
+++ b/app/models/new_alert_parser.rb
@@ -1,0 +1,27 @@
+class NewAlertParser
+  attr_reader :alert
+
+  def initialize(alert)
+    @alert = alert
+  end
+
+  def parse
+    alert.geocode_from_address
+
+    if preexisting_matching_alert
+      preexisting_alert = preexisting_matching_alert
+
+      preexisting_alert.send_confirmation_email
+
+      nil
+    else
+      alert
+    end
+  end
+
+  private
+
+  def preexisting_matching_alert
+    Alert.find_by(email: alert.email, address: alert.address, confirmed: false)
+  end
+end

--- a/app/models/new_alert_parser.rb
+++ b/app/models/new_alert_parser.rb
@@ -12,9 +12,7 @@ class NewAlertParser
       if preexisting_matching_alert.confirmed?
         nil
       else
-        preexisting_alert = preexisting_matching_unconfirmed_alert
-
-        preexisting_alert.send_confirmation_email
+        preexisting_matching_alert.send_confirmation_email
 
         nil
       end

--- a/app/models/new_alert_parser.rb
+++ b/app/models/new_alert_parser.rb
@@ -18,20 +18,28 @@ class NewAlertParser
       if preexisting_matching_alert.unsubscribed?
         alert
       else
-        AlertNotifier.new_signup_attempt_notice(
-          preexisting_matching_alert
-        ).deliver_later
-
-        nil
+        send_notice_to_existing_active_alert_owner_and_return
       end
     else
-      preexisting_matching_alert.send_confirmation_email
-
-      nil
+      resend_original_confirmation_email_and_return
     end
   end
 
   def preexisting_matching_alert
     Alert.find_by(email: alert.email, address: alert.address)
+  end
+
+  def send_notice_to_existing_active_alert_owner_and_return
+    AlertNotifier.new_signup_attempt_notice(
+      preexisting_matching_alert
+    ).deliver_later
+
+    return
+  end
+
+  def resend_original_confirmation_email_and_return
+    preexisting_matching_alert.send_confirmation_email
+
+    return
   end
 end

--- a/app/models/new_alert_parser.rb
+++ b/app/models/new_alert_parser.rb
@@ -18,6 +18,10 @@ class NewAlertParser
       if preexisting_matching_alert.unsubscribed?
         alert
       else
+        AlertNotifier.new_signup_attempt_notice(
+          preexisting_matching_alert
+        ).deliver_later
+
         nil
       end
     else

--- a/app/models/new_alert_parser.rb
+++ b/app/models/new_alert_parser.rb
@@ -10,7 +10,11 @@ class NewAlertParser
 
     if preexisting_matching_alert
       if preexisting_matching_alert.confirmed?
-        nil
+        if preexisting_matching_alert.unsubscribed?
+          alert
+        else
+          nil
+        end
       else
         preexisting_matching_alert.send_confirmation_email
 

--- a/app/views/alert_notifier/new_signup_attempt_notice.html.haml
+++ b/app/views/alert_notifier/new_signup_attempt_notice.html.haml
@@ -15,7 +15,7 @@
 %p
   This could be because we haven't collected any applications for your area lately.
   You can see if there's a problem with the scraper for your area on
-  #{link_to "our coverage page", authorities_url}.
+  #{link_to "our coverage page", authorities_url(utm_source: "resignup_notice", utm_medium: "email", utm_campaign: 'view-authorities')}.
 %p Please just reply to this email if you have any questions. We're here to help.
 %p All the best,
 %p The PlanningAlerts Team

--- a/app/views/alert_notifier/new_signup_attempt_notice.html.haml
+++ b/app/views/alert_notifier/new_signup_attempt_notice.html.haml
@@ -1,0 +1,21 @@
+%p Hi there,
+%p
+  We just received a new request to send PlanningAlerts for #{@alert.address}
+  to your email address.
+%p
+  %strong
+    You already have an active subscription for this street address.
+    When we find new planning applications around this address, we'll send them through.
+%p
+  If it wasn't you who tried to sign up again, don't worry,
+  nothing has happened to your subscription.
+%p
+  %strong
+    Haven't been receiving our emails with planning applications as you were expecting?
+%p
+  This could be because we haven't collected any applications for your area lately.
+  You can see if there's a problem with the scraper for your area on
+  #{link_to "our coverage page", authorities_url}.
+%p Please just reply to this email if you have any questions. We're here to help.
+%p All the best,
+%p The PlanningAlerts Team

--- a/app/views/alert_notifier/new_signup_attempt_notice.text.erb
+++ b/app/views/alert_notifier/new_signup_attempt_notice.text.erb
@@ -9,7 +9,7 @@ If it wasn't you who tried to sign up again, don't worry, nothing has happened t
 
 Haven't been receiving our emails with planning applications as you were expecting?
 This could be because we haven't collected any applications for your area lately.
-You can see if there's a problem with the scraper for your area on <%= link_to "our coverage page", authorities_url %>.
+You can see if there's a problem with the scraper for your area on <%= link_to "our coverage page", authorities_url(utm_source: "resignup_notice", utm_medium: "email", utm_campaign: 'view-authorities') %>.
 
 Please just reply to this email if you have any questions. We're here to help.
 

--- a/app/views/alert_notifier/new_signup_attempt_notice.text.erb
+++ b/app/views/alert_notifier/new_signup_attempt_notice.text.erb
@@ -1,0 +1,17 @@
+Hi there,
+
+We just received a new request to send PlanningAlerts for <%= @alert.address %> to your email address.
+
+You already have an active subscription for this street address.
+When we find new planning applications around this address, we'll send them through.
+
+If it wasn't you who tried to sign up again, don't worry, nothing has happened to your subscription.
+
+Haven't been receiving our emails with planning applications as you were expecting?
+This could be because we haven't collected any applications for your area lately.
+You can see if there's a problem with the scraper for your area on <%= link_to "our coverage page", authorities_url %>.
+
+Please just reply to this email if you have any questions. We're here to help.
+
+All the best,
+The PlanningAlerts Team

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -135,6 +135,27 @@ feature "Sign up for alerts" do
     end
   end
 
+  context "when there is already an confirmed alert for the address" do
+    given!(:preexisting_alert) do
+      create(:confirmed_alert, address: "24 Bruce Rd, Glenbrook NSW 2773",
+                               email: "jenny@email.org",
+                               created_at: 3.days.ago,
+                               updated_at: 3.days.ago)
+    end
+
+    scenario "see the confiration page, so we don't leak information, but nothing happens" do
+      visit '/alerts/signup'
+
+      fill_in("Enter a street address", with: "24 Bruce Rd, Glenbrook")
+      fill_in("Enter your email address", with: "jenny@email.org")
+      click_button("Create alert")
+
+      expect(page).to have_content("Now check your email")
+
+      mailbox_for("jenny@email.org").empty?
+    end
+  end
+
   def confirm_alert_in_email
     open_email("example@example.com")
     expect(current_email).to have_subject("Please confirm your planning alert")

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -30,6 +30,17 @@ feature "Sign up for alerts" do
     ).to_not be_nil
   end
 
+  scenario "unsuccessfully with an invalid address" do
+    visit '/alerts/signup'
+
+    fill_in("Enter a street address", with: "Bruce Rd")
+    fill_in("Enter your email address", with: "example@example.com")
+
+    click_button("Create alert")
+
+    expect(page).to have_content("Please enter a full street address, including suburb and state, e.g. Bruce Rd, Millmerran QLD 4357")
+  end
+
   context "via an application page" do
     given(:application) do
       create(:application, address: "24 Bruce Rd, Glenbrook NSW 2773")

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -143,7 +143,7 @@ feature "Sign up for alerts" do
                                updated_at: 3.days.ago)
     end
 
-    scenario "see the confirmation page, so we don't leak information, but send a notice about the signup attempt" do
+    scenario "see the confirmation page, so we don't leak information, but also get a notice about the signup attempt" do
       visit '/alerts/signup'
 
       fill_in("Enter a street address", with: "24 Bruce Rd, Glenbrook")

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -154,6 +154,29 @@ feature "Sign up for alerts" do
 
       mailbox_for("jenny@email.org").empty?
     end
+
+    context "but it is unsubscribed" do
+      before do
+        preexisting_alert.unsubscribe!
+      end
+
+      scenario "successfully" do
+        visit '/alerts/signup'
+
+        fill_in("Enter a street address", with: "24 Bruce Rd, Glenbrook")
+        fill_in("Enter your email address", with: "jenny@email.org")
+        click_button("Create alert")
+
+        expect(page).to have_content("Now check your email")
+
+        open_email("jenny@email.org")
+
+        click_first_link_in_email
+
+        expect(page).to have_content("your alert has been activated")
+        expect(page).to have_content("24 Bruce Rd, Glenbrook NSW 2773")
+      end
+    end
   end
 
   def confirm_alert_in_email

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -143,7 +143,7 @@ feature "Sign up for alerts" do
                                updated_at: 3.days.ago)
     end
 
-    scenario "see the confiration page, so we don't leak information, but nothing happens" do
+    scenario "see the confiration page, so we don't leak information, but send a notice about the signup attempt" do
       visit '/alerts/signup'
 
       fill_in("Enter a street address", with: "24 Bruce Rd, Glenbrook")
@@ -152,7 +152,11 @@ feature "Sign up for alerts" do
 
       expect(page).to have_content("Now check your email")
 
-      mailbox_for("jenny@email.org").empty?
+      open_last_email_for("jenny@email.org")
+
+      expect(current_email.default_part_body.to_s).to have_content(
+        "We just received a new request to send PlanningAlerts for 24 Bruce Rd, Glenbrook NSW 2773 to your email address."
+      )
     end
 
     context "but it is unsubscribed" do

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -143,7 +143,7 @@ feature "Sign up for alerts" do
                                updated_at: 3.days.ago)
     end
 
-    scenario "see the confiration page, so we don't leak information, but send a notice about the signup attempt" do
+    scenario "see the confirmation page, so we don't leak information, but send a notice about the signup attempt" do
       visit '/alerts/signup'
 
       fill_in("Enter a street address", with: "24 Bruce Rd, Glenbrook")

--- a/spec/fixtures/vcr_cassettes/planningalerts.yml
+++ b/spec/fixtures/vcr_cassettes/planningalerts.yml
@@ -26905,4 +26905,1340 @@ http_interactions:
         }
     http_version: 
   recorded_at: Thu, 12 May 2016 05:09:36 GMT
-recorded_with: VCR 2.5.0
+- request:
+    method: get
+    uri: http://maps.google.com/maps/api/geocode/json?address=Bruce%20Rd&region=au&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 09 Jan 2017 03:36:53 GMT
+      Expires:
+      - Tue, 10 Jan 2017 03:36:53 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Vary:
+      - Accept-Language
+      Access-Control-Allow-Origin:
+      - '*'
+      Server:
+      - mafe
+      Content-Length:
+      - '1818'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: UTF-8
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Mount Martha",
+                       "short_name" : "Mount Martha",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Mornington Peninsula Shire",
+                       "short_name" : "Mornington Peninsula",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "Victoria",
+                       "short_name" : "VIC",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "3934",
+                       "short_name" : "3934",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "Bruce Rd, Mount Martha VIC 3934, Australia",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : -38.296238,
+                          "lng" : 145.0312444
+                       },
+                       "southwest" : {
+                          "lat" : -38.304894,
+                          "lng" : 144.9940619
+                       }
+                    },
+                    "location" : {
+                       "lat" : -38.3025233,
+                       "lng" : 145.0123317
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -38.296238,
+                          "lng" : 145.0312444
+                       },
+                       "southwest" : {
+                          "lat" : -38.304894,
+                          "lng" : 144.9940619
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJ5cHH8SbF1WoRAx23sdZonhM",
+                 "types" : [ "route" ]
+              },
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Riverton",
+                       "short_name" : "Riverton",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Clare and Gilbert Valleys Council",
+                       "short_name" : "Clare and Gilbert Valleys",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "South Australia",
+                       "short_name" : "SA",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "5412",
+                       "short_name" : "5412",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "Bruce Rd, Riverton SA 5412, Australia",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : -34.1303714,
+                          "lng" : 138.8358855
+                       },
+                       "southwest" : {
+                          "lat" : -34.16475399999999,
+                          "lng" : 138.7509152
+                       }
+                    },
+                    "location" : {
+                       "lat" : -34.1547389,
+                       "lng" : 138.8118674
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -34.1303714,
+                          "lng" : 138.8358855
+                       },
+                       "southwest" : {
+                          "lat" : -34.16475399999999,
+                          "lng" : 138.7509152
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJhR1MB4eGuWoRn1XBfYMYFVs",
+                 "types" : [ "route" ]
+              },
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Taldra",
+                       "short_name" : "Taldra",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "District Council of Loxton Waikerie",
+                       "short_name" : "DC of Loxton Waikerie",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "South Australia",
+                       "short_name" : "SA",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "5311",
+                       "short_name" : "5311",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "Bruce Rd, Taldra SA 5311, Australia",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : -34.3232233,
+                          "lng" : 140.8630602
+                       },
+                       "southwest" : {
+                          "lat" : -34.4444632,
+                          "lng" : 140.8363832
+                       }
+                    },
+                    "location" : {
+                       "lat" : -34.3821106,
+                       "lng" : 140.8376694
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -34.3232233,
+                          "lng" : 140.8630602
+                       },
+                       "southwest" : {
+                          "lat" : -34.4444632,
+                          "lng" : 140.8363832
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJzwWx0TfFxmoR5EvcTF8SjDk",
+                 "types" : [ "route" ]
+              },
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "The Regional Council of Goyder",
+                       "short_name" : "Goyder",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "South Australia",
+                       "short_name" : "SA",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "5417",
+                       "short_name" : "5417",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "Bruce Rd, South Australia 5417, Australia",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : -33.6827756,
+                          "lng" : 139.0941389
+                       },
+                       "southwest" : {
+                          "lat" : -33.6928132,
+                          "lng" : 138.9896481
+                       }
+                    },
+                    "location" : {
+                       "lat" : -33.690277,
+                       "lng" : 139.0441222
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -33.6827756,
+                          "lng" : 139.0941389
+                       },
+                       "southwest" : {
+                          "lat" : -33.6928132,
+                          "lng" : 138.9896481
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJg4Gy8v03uWoRq_FTivJB9ZE",
+                 "types" : [ "route" ]
+              },
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Mount Charles",
+                       "short_name" : "Mount Charles",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "District Council of Tatiara",
+                       "short_name" : "DC of Tatiara",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "South Australia",
+                       "short_name" : "SA",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "5267",
+                       "short_name" : "5267",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "Bruce Rd, Mount Charles SA 5267, Australia",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : -36.0505877,
+                          "lng" : 140.2531167
+                       },
+                       "southwest" : {
+                          "lat" : -36.1089447,
+                          "lng" : 140.2529291
+                       }
+                    },
+                    "location" : {
+                       "lat" : -36.0727219,
+                       "lng" : 140.2530571
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -36.0505877,
+                          "lng" : 140.2543718802915
+                       },
+                       "southwest" : {
+                          "lat" : -36.1089447,
+                          "lng" : 140.2516739197085
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJAeeMAT3CyWoR9jTA4om_4A4",
+                 "types" : [ "route" ]
+              },
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Bruce",
+                       "short_name" : "Bruce",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "South Australia",
+                       "short_name" : "SA",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "5433",
+                       "short_name" : "5433",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "Bruce Rd, Bruce SA 5433, Australia",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : -32.44738299999999,
+                          "lng" : 138.1886968
+                       },
+                       "southwest" : {
+                          "lat" : -32.4759258,
+                          "lng" : 138.13094
+                       }
+                    },
+                    "location" : {
+                       "lat" : -32.4640303,
+                       "lng" : 138.1578209
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -32.44738299999999,
+                          "lng" : 138.1886968
+                       },
+                       "southwest" : {
+                          "lat" : -32.4759258,
+                          "lng" : 138.13094
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJr3tJhUqvvWoRnZK7u8oZXy8",
+                 "types" : [ "route" ]
+              },
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Manmanning",
+                       "short_name" : "Manmanning",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Shire of Dowerin",
+                       "short_name" : "Dowerin",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "Western Australia",
+                       "short_name" : "WA",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "6465",
+                       "short_name" : "6465",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "Bruce Rd, Manmanning WA 6465, Australia",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : -30.8645424,
+                          "lng" : 117.1714087
+                       },
+                       "southwest" : {
+                          "lat" : -30.9125385,
+                          "lng" : 117.1703647
+                       }
+                    },
+                    "location" : {
+                       "lat" : -30.89533669999999,
+                       "lng" : 117.1713687
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -30.8645424,
+                          "lng" : 117.1722356802915
+                       },
+                       "southwest" : {
+                          "lat" : -30.9125385,
+                          "lng" : 117.1695377197085
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJ-QVsoXeCzCsRz3FWmW85xVU",
+                 "types" : [ "route" ]
+              },
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Mudgee",
+                       "short_name" : "Mudgee",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Mid-Western Regional Council",
+                       "short_name" : "Mid-Western Regional",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "New South Wales",
+                       "short_name" : "NSW",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "2850",
+                       "short_name" : "2850",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "Bruce Rd, Mudgee NSW 2850, Australia",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : -32.6195019,
+                          "lng" : 149.6064302
+                       },
+                       "southwest" : {
+                          "lat" : -32.6249336,
+                          "lng" : 149.5794324
+                       }
+                    },
+                    "location" : {
+                       "lat" : -32.6212426,
+                       "lng" : 149.5931025
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -32.6195019,
+                          "lng" : 149.6064302
+                       },
+                       "southwest" : {
+                          "lat" : -32.6249336,
+                          "lng" : 149.5794324
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJ01rGd7yJDmsRvzLsvVaCk3s",
+                 "types" : [ "route" ]
+              },
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "East Gippsland Shire",
+                       "short_name" : "East Gippsland",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "Victoria",
+                       "short_name" : "VIC",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Bruce Rd, Victoria, Australia",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : -37.7301987,
+                          "lng" : 147.9191394
+                       },
+                       "southwest" : {
+                          "lat" : -37.8358437,
+                          "lng" : 147.8941966
+                       }
+                    },
+                    "location" : {
+                       "lat" : -37.7794129,
+                       "lng" : 147.8993326
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -37.7301987,
+                          "lng" : 147.9191394
+                       },
+                       "southwest" : {
+                          "lat" : -37.8358437,
+                          "lng" : 147.8941966
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJr7aEXBpkJWsRbCAjoDaQlAY",
+                 "types" : [ "route" ]
+              },
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Millmerran",
+                       "short_name" : "Millmerran",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Toowoomba Regional",
+                       "short_name" : "Toowoomba",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "Queensland",
+                       "short_name" : "QLD",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "4357",
+                       "short_name" : "4357",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "Bruce Rd, Millmerran QLD 4357, Australia",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : -27.866874,
+                          "lng" : 151.2732381
+                       },
+                       "southwest" : {
+                          "lat" : -27.8747515,
+                          "lng" : 151.2612269
+                       }
+                    },
+                    "location" : {
+                       "lat" : -27.87081,
+                       "lng" : 151.267257
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -27.866874,
+                          "lng" : 151.2732381
+                       },
+                       "southwest" : {
+                          "lat" : -27.8747515,
+                          "lng" : 151.2612269
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJ2wdF3DpjvWsRH3r7vKsLTHs",
+                 "types" : [ "route" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Mon, 09 Jan 2017 03:36:53 GMT
+- request:
+    method: get
+    uri: http://maps.google.com/maps/api/geocode/json?address=Bruce%20Rd&region=au&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 09 Jan 2017 03:36:53 GMT
+      Expires:
+      - Tue, 10 Jan 2017 03:36:53 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Vary:
+      - Accept-Language
+      Access-Control-Allow-Origin:
+      - '*'
+      Server:
+      - mafe
+      Content-Length:
+      - '1818'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: UTF-8
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Mount Martha",
+                       "short_name" : "Mount Martha",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Mornington Peninsula Shire",
+                       "short_name" : "Mornington Peninsula",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "Victoria",
+                       "short_name" : "VIC",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "3934",
+                       "short_name" : "3934",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "Bruce Rd, Mount Martha VIC 3934, Australia",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : -38.296238,
+                          "lng" : 145.0312444
+                       },
+                       "southwest" : {
+                          "lat" : -38.304894,
+                          "lng" : 144.9940619
+                       }
+                    },
+                    "location" : {
+                       "lat" : -38.3025233,
+                       "lng" : 145.0123317
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -38.296238,
+                          "lng" : 145.0312444
+                       },
+                       "southwest" : {
+                          "lat" : -38.304894,
+                          "lng" : 144.9940619
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJ5cHH8SbF1WoRAx23sdZonhM",
+                 "types" : [ "route" ]
+              },
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Riverton",
+                       "short_name" : "Riverton",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Clare and Gilbert Valleys Council",
+                       "short_name" : "Clare and Gilbert Valleys",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "South Australia",
+                       "short_name" : "SA",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "5412",
+                       "short_name" : "5412",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "Bruce Rd, Riverton SA 5412, Australia",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : -34.1303714,
+                          "lng" : 138.8358855
+                       },
+                       "southwest" : {
+                          "lat" : -34.16475399999999,
+                          "lng" : 138.7509152
+                       }
+                    },
+                    "location" : {
+                       "lat" : -34.1547389,
+                       "lng" : 138.8118674
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -34.1303714,
+                          "lng" : 138.8358855
+                       },
+                       "southwest" : {
+                          "lat" : -34.16475399999999,
+                          "lng" : 138.7509152
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJhR1MB4eGuWoRn1XBfYMYFVs",
+                 "types" : [ "route" ]
+              },
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Taldra",
+                       "short_name" : "Taldra",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "District Council of Loxton Waikerie",
+                       "short_name" : "DC of Loxton Waikerie",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "South Australia",
+                       "short_name" : "SA",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "5311",
+                       "short_name" : "5311",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "Bruce Rd, Taldra SA 5311, Australia",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : -34.3232233,
+                          "lng" : 140.8630602
+                       },
+                       "southwest" : {
+                          "lat" : -34.4444632,
+                          "lng" : 140.8363832
+                       }
+                    },
+                    "location" : {
+                       "lat" : -34.3821106,
+                       "lng" : 140.8376694
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -34.3232233,
+                          "lng" : 140.8630602
+                       },
+                       "southwest" : {
+                          "lat" : -34.4444632,
+                          "lng" : 140.8363832
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJzwWx0TfFxmoR5EvcTF8SjDk",
+                 "types" : [ "route" ]
+              },
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "The Regional Council of Goyder",
+                       "short_name" : "Goyder",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "South Australia",
+                       "short_name" : "SA",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "5417",
+                       "short_name" : "5417",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "Bruce Rd, South Australia 5417, Australia",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : -33.6827756,
+                          "lng" : 139.0941389
+                       },
+                       "southwest" : {
+                          "lat" : -33.6928132,
+                          "lng" : 138.9896481
+                       }
+                    },
+                    "location" : {
+                       "lat" : -33.690277,
+                       "lng" : 139.0441222
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -33.6827756,
+                          "lng" : 139.0941389
+                       },
+                       "southwest" : {
+                          "lat" : -33.6928132,
+                          "lng" : 138.9896481
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJg4Gy8v03uWoRq_FTivJB9ZE",
+                 "types" : [ "route" ]
+              },
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Mount Charles",
+                       "short_name" : "Mount Charles",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "District Council of Tatiara",
+                       "short_name" : "DC of Tatiara",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "South Australia",
+                       "short_name" : "SA",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "5267",
+                       "short_name" : "5267",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "Bruce Rd, Mount Charles SA 5267, Australia",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : -36.0505877,
+                          "lng" : 140.2531167
+                       },
+                       "southwest" : {
+                          "lat" : -36.1089447,
+                          "lng" : 140.2529291
+                       }
+                    },
+                    "location" : {
+                       "lat" : -36.0727219,
+                       "lng" : 140.2530571
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -36.0505877,
+                          "lng" : 140.2543718802915
+                       },
+                       "southwest" : {
+                          "lat" : -36.1089447,
+                          "lng" : 140.2516739197085
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJAeeMAT3CyWoR9jTA4om_4A4",
+                 "types" : [ "route" ]
+              },
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Bruce",
+                       "short_name" : "Bruce",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "South Australia",
+                       "short_name" : "SA",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "5433",
+                       "short_name" : "5433",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "Bruce Rd, Bruce SA 5433, Australia",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : -32.44738299999999,
+                          "lng" : 138.1886968
+                       },
+                       "southwest" : {
+                          "lat" : -32.4759258,
+                          "lng" : 138.13094
+                       }
+                    },
+                    "location" : {
+                       "lat" : -32.4640303,
+                       "lng" : 138.1578209
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -32.44738299999999,
+                          "lng" : 138.1886968
+                       },
+                       "southwest" : {
+                          "lat" : -32.4759258,
+                          "lng" : 138.13094
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJr3tJhUqvvWoRnZK7u8oZXy8",
+                 "types" : [ "route" ]
+              },
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Manmanning",
+                       "short_name" : "Manmanning",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Shire of Dowerin",
+                       "short_name" : "Dowerin",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "Western Australia",
+                       "short_name" : "WA",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "6465",
+                       "short_name" : "6465",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "Bruce Rd, Manmanning WA 6465, Australia",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : -30.8645424,
+                          "lng" : 117.1714087
+                       },
+                       "southwest" : {
+                          "lat" : -30.9125385,
+                          "lng" : 117.1703647
+                       }
+                    },
+                    "location" : {
+                       "lat" : -30.89533669999999,
+                       "lng" : 117.1713687
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -30.8645424,
+                          "lng" : 117.1722356802915
+                       },
+                       "southwest" : {
+                          "lat" : -30.9125385,
+                          "lng" : 117.1695377197085
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJ-QVsoXeCzCsRz3FWmW85xVU",
+                 "types" : [ "route" ]
+              },
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Mudgee",
+                       "short_name" : "Mudgee",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Mid-Western Regional Council",
+                       "short_name" : "Mid-Western Regional",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "New South Wales",
+                       "short_name" : "NSW",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "2850",
+                       "short_name" : "2850",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "Bruce Rd, Mudgee NSW 2850, Australia",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : -32.6195019,
+                          "lng" : 149.6064302
+                       },
+                       "southwest" : {
+                          "lat" : -32.6249336,
+                          "lng" : 149.5794324
+                       }
+                    },
+                    "location" : {
+                       "lat" : -32.6212426,
+                       "lng" : 149.5931025
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -32.6195019,
+                          "lng" : 149.6064302
+                       },
+                       "southwest" : {
+                          "lat" : -32.6249336,
+                          "lng" : 149.5794324
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJ01rGd7yJDmsRvzLsvVaCk3s",
+                 "types" : [ "route" ]
+              },
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "East Gippsland Shire",
+                       "short_name" : "East Gippsland",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "Victoria",
+                       "short_name" : "VIC",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Bruce Rd, Victoria, Australia",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : -37.7301987,
+                          "lng" : 147.9191394
+                       },
+                       "southwest" : {
+                          "lat" : -37.8358437,
+                          "lng" : 147.8941966
+                       }
+                    },
+                    "location" : {
+                       "lat" : -37.7794129,
+                       "lng" : 147.8993326
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -37.7301987,
+                          "lng" : 147.9191394
+                       },
+                       "southwest" : {
+                          "lat" : -37.8358437,
+                          "lng" : 147.8941966
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJr7aEXBpkJWsRbCAjoDaQlAY",
+                 "types" : [ "route" ]
+              },
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Bruce Road",
+                       "short_name" : "Bruce Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Millmerran",
+                       "short_name" : "Millmerran",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Toowoomba Regional",
+                       "short_name" : "Toowoomba",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "Queensland",
+                       "short_name" : "QLD",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Australia",
+                       "short_name" : "AU",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "4357",
+                       "short_name" : "4357",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "Bruce Rd, Millmerran QLD 4357, Australia",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : -27.866874,
+                          "lng" : 151.2732381
+                       },
+                       "southwest" : {
+                          "lat" : -27.8747515,
+                          "lng" : 151.2612269
+                       }
+                    },
+                    "location" : {
+                       "lat" : -27.87081,
+                       "lng" : 151.267257
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : -27.866874,
+                          "lng" : 151.2732381
+                       },
+                       "southwest" : {
+                          "lat" : -27.8747515,
+                          "lng" : 151.2612269
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJ2wdF3DpjvWsRH3r7vKsLTHs",
+                 "types" : [ "route" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Mon, 09 Jan 2017 03:36:54 GMT
+recorded_with: VCR 2.9.3

--- a/spec/mailers/alert_notifier_spec.rb
+++ b/spec/mailers/alert_notifier_spec.rb
@@ -159,4 +159,21 @@ Cillum ethnic single-origin coffee labore, sriracha fixie jean shorts freegan. O
       end
     end
   end
+
+  describe ".new_signup_attempt_notice" do
+    it "puts the address in the subject" do
+      alert = build(:alert, address: "123 Lovely St, La La")
+      email = AlertNotifier.new_signup_attempt_notice(alert)
+
+      expect(email).to have_subject "Your subscription for 123 Lovely St, La La"
+    end
+
+    it "tells the user that we’ve recieved a new signup attempt" do
+      alert = build(:alert, address: "123 Lovely St, La La")
+      email = AlertNotifier.new_signup_attempt_notice(alert)
+
+      expect(email.html_part.body.to_s).to have_content "We just received a new request to send PlanningAlerts for 123 Lovely St, La La to your email address."
+      expect(email.text_part.body.to_s).to have_content "We just received a new request to send PlanningAlerts for 123 Lovely St, La La to your email address."
+    end
+  end
 end

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -18,6 +18,20 @@ describe Alert do
       build(:alert, address: "Bruce Rd", lat: nil, lng: nil)
     end
 
+    it "is valid when the geocoder returns no errors" do
+      allow(Location).to receive(:geocode).and_return(
+        double(
+          lat: -33.772607,
+          lng: 150.624245,
+          full_address: "24 Bruce Rd, Glenbrook, VIC 3885",
+          error: nil,
+          all: []
+        )
+      )
+
+      expect(alert).to be_valid
+    end
+
     it "is invalid if there was an error geocoding the address" do
       allow(Location).to receive(:geocode).and_return(
         double(

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -19,28 +19,13 @@ describe Alert do
     end
 
     it "is valid when the geocoder returns no errors" do
-      allow(Location).to receive(:geocode).and_return(
-        double(
-          lat: -33.772607,
-          lng: 150.624245,
-          full_address: "24 Bruce Rd, Glenbrook, VIC 3885",
-          error: nil,
-          all: []
-        )
-      )
+      mock_geocoder_valid_address_response
 
       expect(alert).to be_valid
     end
 
     it "is invalid if there was an error geocoding the address" do
-      allow(Location).to receive(:geocode).and_return(
-        double(
-          error: "some error message",
-          lat: nil,
-          lng: nil,
-          full_address: nil
-        )
-      )
+      mock_geocoder_error_response
 
       alert.save
 
@@ -49,16 +34,7 @@ describe Alert do
     end
 
     it "is invalid if the geocoder found multiple locations for the address" do
-      allow(Location).to receive(:geocode).and_return(
-        double(
-          lat: 1,
-          lng: 2,
-          full_address: "Bruce Rd, VIC 3885",
-          error: nil,
-          all: [double(full_address: "Bruce Rd, VIC 3885"),
-                double(full_address: "Bruce Rd, NSW 2042")]
-        )
-      )
+      mock_geocoder_multiple_locations_response
 
       alert.save
 
@@ -294,32 +270,16 @@ describe Alert do
     let(:original_address) { "24 Bruce Road, Glenbrook" }
 
     it "sets the address to the full address returned from the geocoder" do
-      allow(Location).to receive(:geocode).and_return(
-        double(
-          lat: 3,
-          lng: 4,
-          full_address: "24 Bruce Road, Glenbrook NSW 2773",
-          error: nil,
-          all: []
-        )
-      )
+      mock_geocoder_valid_address_response
       alert = build(:alert, address: original_address, lat: nil, lng: nil)
 
       alert.geocode_from_address
 
-      expect(alert.address).to eq "24 Bruce Road, Glenbrook NSW 2773"
+      expect(alert.address).to eq "24 Bruce Rd, Glenbrook, VIC 3885"
     end
 
     it "sets the lat and lng" do
-      allow(Location).to receive(:geocode).and_return(
-        double(
-          lat: -33.772607,
-          lng: 150.624245,
-          full_address: "24 Bruce Rd, Glenbrook, VIC 3885",
-          error: nil,
-          all: []
-        )
-      )
+      mock_geocoder_valid_address_response
       alert = build(:alert, address: original_address, lat: nil, lng: nil)
 
       alert.geocode_from_address
@@ -330,14 +290,7 @@ describe Alert do
 
     context "when there is an error geocoding" do
       it "doesn't update any values" do
-        allow(Location).to receive(:geocode).and_return(
-          double(
-            error: "some error message",
-            lat: nil,
-            lng: nil,
-            full_address: nil
-          )
-        )
+        mock_geocoder_error_response
 
         alert = build(:alert, address: original_address, lat: nil, lng: nil)
 
@@ -350,16 +303,7 @@ describe Alert do
 
     context "when the geocoder finds multiple locations" do
       it "doesn't update any values" do
-        allow(Location).to receive(:geocode).and_return(
-          double(
-            lat: 1,
-            lng: 2,
-            full_address: "Bruce Rd, VIC 3885",
-            error: nil,
-            all: [double(full_address: "Bruce Rd, VIC 3885"),
-                  double(full_address: "Bruce Rd, NSW 2042")]
-          )
-        )
+        mock_geocoder_multiple_locations_response
         alert = build(:alert, address: original_address, lat: nil, lng: nil)
 
         alert.geocode_from_address

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -311,6 +311,11 @@ describe Alert do
     end
   end
 
+  describe "#geocoded?" do
+    it { expect(build(:alert, address: "foo", lat: nil, lng: nil).geocoded?).to be false }
+    it { expect(build(:alert, address: "foo", lat: 1, lng: 2).geocoded?).to be true }
+  end
+
   describe "#unsubscribe!" do
     let(:alert) { create :alert }
 

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -53,26 +53,6 @@ describe Alert do
     end
   end
 
-  # In order to stop frustrating multiple alerts
-  it "should only have one alert active for a particular street address / email address combination at one time" do
-    email = "foo@foo.org"
-    existing_alert = create(:alert, email: email, address: "A street address")
-    new_alert = create(:alert, email: email, address: "A street address")
-
-    alerts = Alert.where(email: email)
-
-    expect(alerts.count).to eq(1)
-    expect(alerts.first).to_not eql existing_alert
-    expect(alerts.first).to eql new_alert
-  end
-
-  it "should allow multiple alerts for different street addresses but the same email address" do
-    email = "foo@foo.org"
-    create(:alert, email: email, address: "A street address", radius_meters: 200, lat: 1.0, lng: 2.0)
-    create(:alert, email: email, address: "Another street address", radius_meters: 800, lat: 1.0, lng: 2.0)
-    expect(Alert.where(email: email).count).to eq(2)
-  end
-
   it "should be able to accept location information if it is already known and so not use the geocoder" do
     expect(Location).not_to receive(:geocode)
 

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -284,10 +284,22 @@ describe Alert do
         build(:alert, address: original_address, lat: 1, lng: 2)
       end
 
-      it "does not update the address" do
+      it "it regeolocates the location" do
+        allow(Location).to receive(:geocode).and_return(
+          double(
+            lat: 3,
+            lng: 4,
+            full_address: "24 Bruce Rd, Glenbrook, VIC 3885",
+            error: nil,
+            all: []
+          )
+        )
+
         alert.geocode_from_address
 
-        expect(alert.address).to eq original_address
+        expect(alert.address).to eq "24 Bruce Rd, Glenbrook, VIC 3885"
+        expect(alert.lat).to eql 3.0
+        expect(alert.lng).to eql 4.0
       end
     end
 

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -305,17 +305,37 @@ describe Alert do
 
     context "when the lat and lng are nil" do
       it "sets the address to the full address returned from the geocoder" do
+        allow(Location).to receive(:geocode).and_return(
+          double(
+            lat: 3,
+            lng: 4,
+            full_address: "24 Bruce Road, Glenbrook NSW 2773",
+            error: nil,
+            all: []
+          )
+        )
+
         alert = build(:alert, address: original_address, lat: nil, lng: nil)
 
-        VCR.use_cassette(:planningalerts) { alert.geocode_from_address }
+        alert.geocode_from_address
 
         expect(alert.address).to eq "24 Bruce Road, Glenbrook NSW 2773"
       end
 
       it "sets the lat and lng" do
+        allow(Location).to receive(:geocode).and_return(
+          double(
+            lat: -33.772607,
+            lng: 150.624245,
+            full_address: "24 Bruce Rd, Glenbrook, VIC 3885",
+            error: nil,
+            all: []
+          )
+        )
+
         alert = build(:alert, address: original_address, lat: nil, lng: nil)
 
-        VCR.use_cassette(:planningalerts) { alert.geocode_from_address }
+        alert.geocode_from_address
 
         expect(alert.lat).to eq(-33.772607)
         expect(alert.lng).to eq(150.624245)

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -279,67 +279,39 @@ describe Alert do
   describe "#geocode_from_address" do
     let(:original_address) { "24 Bruce Road, Glenbrook" }
 
-    context "when the lat and lng are set" do
-      let(:alert) do
-        build(:alert, address: original_address, lat: 1, lng: 2)
-      end
-
-      it "it regeolocates the location" do
-        allow(Location).to receive(:geocode).and_return(
-          double(
-            lat: 3,
-            lng: 4,
-            full_address: "24 Bruce Rd, Glenbrook, VIC 3885",
-            error: nil,
-            all: []
-          )
+    it "sets the address to the full address returned from the geocoder" do
+      allow(Location).to receive(:geocode).and_return(
+        double(
+          lat: 3,
+          lng: 4,
+          full_address: "24 Bruce Road, Glenbrook NSW 2773",
+          error: nil,
+          all: []
         )
+      )
+      alert = build(:alert, address: original_address, lat: nil, lng: nil)
 
-        alert.geocode_from_address
+      alert.geocode_from_address
 
-        expect(alert.address).to eq "24 Bruce Rd, Glenbrook, VIC 3885"
-        expect(alert.lat).to eql 3.0
-        expect(alert.lng).to eql 4.0
-      end
+      expect(alert.address).to eq "24 Bruce Road, Glenbrook NSW 2773"
     end
 
-    context "when the lat and lng are nil" do
-      it "sets the address to the full address returned from the geocoder" do
-        allow(Location).to receive(:geocode).and_return(
-          double(
-            lat: 3,
-            lng: 4,
-            full_address: "24 Bruce Road, Glenbrook NSW 2773",
-            error: nil,
-            all: []
-          )
+    it "sets the lat and lng" do
+      allow(Location).to receive(:geocode).and_return(
+        double(
+          lat: -33.772607,
+          lng: 150.624245,
+          full_address: "24 Bruce Rd, Glenbrook, VIC 3885",
+          error: nil,
+          all: []
         )
+      )
+      alert = build(:alert, address: original_address, lat: nil, lng: nil)
 
-        alert = build(:alert, address: original_address, lat: nil, lng: nil)
+      alert.geocode_from_address
 
-        alert.geocode_from_address
-
-        expect(alert.address).to eq "24 Bruce Road, Glenbrook NSW 2773"
-      end
-
-      it "sets the lat and lng" do
-        allow(Location).to receive(:geocode).and_return(
-          double(
-            lat: -33.772607,
-            lng: 150.624245,
-            full_address: "24 Bruce Rd, Glenbrook, VIC 3885",
-            error: nil,
-            all: []
-          )
-        )
-
-        alert = build(:alert, address: original_address, lat: nil, lng: nil)
-
-        alert.geocode_from_address
-
-        expect(alert.lat).to eq(-33.772607)
-        expect(alert.lng).to eq(150.624245)
-      end
+      expect(alert.lat).to eq(-33.772607)
+      expect(alert.lng).to eq(150.624245)
     end
   end
 

--- a/spec/models/new_alert_parser_spec.rb
+++ b/spec/models/new_alert_parser_spec.rb
@@ -14,7 +14,7 @@ describe NewAlertParser do
 
         parser_result = NewAlertParser.new(alert).parse
 
-        expect(parser_result.id).to eq 7
+        expect(parser_result).to eql alert
       end
 
       it "geocodes the alert" do

--- a/spec/models/new_alert_parser_spec.rb
+++ b/spec/models/new_alert_parser_spec.rb
@@ -46,11 +46,11 @@ describe NewAlertParser do
           email: "jenny@example.com",
           address: "24 Bruce Rd, Glenbrook",
           lat: nil,
-          lng: nil
+          lng: nil,
+          theme: "default"
         )
 
-        # FIXME: This isn't testing that the specific instance has received this message
-        expect_any_instance_of(Alert).to receive(:send_confirmation_email)
+        expect(ConfirmationMailer).to receive(:confirm).with("default", preexisting_alert).and_call_original
 
         NewAlertParser.new(new_alert).parse
       end

--- a/spec/models/new_alert_parser_spec.rb
+++ b/spec/models/new_alert_parser_spec.rb
@@ -10,7 +10,7 @@ describe NewAlertParser do
 
     context "when there is no matching pre-existing Alert" do
       it "returns the original alert" do
-        alert = build(:alert)
+        alert = build(:alert, address: "24 Bruce Rd, Glenbrook")
 
         parser_result = NewAlertParser.new(alert).parse
 

--- a/spec/models/new_alert_parser_spec.rb
+++ b/spec/models/new_alert_parser_spec.rb
@@ -10,7 +10,7 @@ describe NewAlertParser do
 
     context "when there is no matching pre-existing Alert" do
       it "returns the original alert" do
-        alert = build(:alert, id: 7, address: "24 Bruce Rd, Glenbrook", lat: nil, lng: nil)
+        alert = build(:alert)
 
         parser_result = NewAlertParser.new(alert).parse
 

--- a/spec/models/new_alert_parser_spec.rb
+++ b/spec/models/new_alert_parser_spec.rb
@@ -9,7 +9,7 @@ describe NewAlertParser do
     end
 
     context "when there is no matching pre-existing Alert" do
-      it "returns the original alert geocoded" do
+      it "returns the original alert" do
         alert = build(:alert, id: 7, address: "24 Bruce Rd, Glenbrook", lat: nil, lng: nil)
 
         parser_result = NewAlertParser.new(alert).parse

--- a/spec/models/new_alert_parser_spec.rb
+++ b/spec/models/new_alert_parser_spec.rb
@@ -26,6 +26,7 @@ describe NewAlertParser do
         parser_result = NewAlertParser.new(alert).parse
 
         expect(parser_result.address).to eq "24 Bruce Rd, Glenbrook NSW 2773"
+        expect(parser_result.geocoded?).to be true
       end
     end
 

--- a/spec/models/new_alert_parser_spec.rb
+++ b/spec/models/new_alert_parser_spec.rb
@@ -2,10 +2,8 @@ require 'spec_helper'
 
 describe NewAlertParser do
   describe "#parse" do
-    around do |example|
-      VCR.use_cassette('planningalerts') do
-        example.run
-      end
+    before :each do
+      mock_geocoder_valid_address_response
     end
 
     context "when there is no matching pre-existing Alert" do
@@ -18,14 +16,11 @@ describe NewAlertParser do
       end
 
       it "geocodes the alert" do
-        allow(Location).to receive(:geocode).and_return(
-          double(full_address: "24 Bruce Rd, Glenbrook NSW 2773", lat: 1, lng: 2, error: nil, all: [])
-        )
         alert = build(:alert, id: 7, address: "24 Bruce Rd, Glenbrook", lat: nil, lng: nil)
 
         parser_result = NewAlertParser.new(alert).parse
 
-        expect(parser_result.address).to eq "24 Bruce Rd, Glenbrook NSW 2773"
+        expect(parser_result.address).to eq "24 Bruce Rd, Glenbrook, VIC 3885"
         expect(parser_result.geocoded?).to be true
       end
     end
@@ -34,7 +29,7 @@ describe NewAlertParser do
       let!(:preexisting_alert) do
         create(
           :unconfirmed_alert,
-          address: "24 Bruce Rd, Glenbrook NSW 2773",
+          address: "24 Bruce Rd, Glenbrook, VIC 3885",
           email: "jenny@example.com",
           created_at: 3.days.ago,
           updated_at: 3.days.ago
@@ -76,7 +71,7 @@ describe NewAlertParser do
       let!(:preexisting_alert) do
         create(
           :confirmed_alert,
-          address: "24 Bruce Rd, Glenbrook NSW 2773",
+          address: "24 Bruce Rd, Glenbrook, VIC 3885",
           email: "jenny@example.com",
           created_at: 3.days.ago,
           updated_at: 3.days.ago,

--- a/spec/models/new_alert_parser_spec.rb
+++ b/spec/models/new_alert_parser_spec.rb
@@ -77,7 +77,8 @@ describe NewAlertParser do
           address: "24 Bruce Rd, Glenbrook NSW 2773",
           email: "jenny@example.com",
           created_at: 3.days.ago,
-          updated_at: 3.days.ago
+          updated_at: 3.days.ago,
+          theme: "default"
         )
       end
 
@@ -95,10 +96,19 @@ describe NewAlertParser do
         expect(parser_result).to be nil
       end
 
-      # it "sends a helpful email to the alert’s email address" do
-      #   pending "add this behaviour"
-      #   fail
-      # end
+      it "sends a helpful email to the alert’s email address" do
+        new_alert = build(
+          :alert,
+          email: "jenny@example.com",
+          address: "24 Bruce Rd, Glenbrook",
+          lat: nil,
+          lng: nil
+        )
+
+        expect(AlertNotifier).to receive(:new_signup_attempt_notice).with(preexisting_alert).and_call_original
+
+        NewAlertParser.new(new_alert).parse
+      end
 
       context "but it is unsubscribed" do
         before do

--- a/spec/models/new_alert_parser_spec.rb
+++ b/spec/models/new_alert_parser_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe NewAlertParser do
+  describe "#parse" do
+    around do |example|
+      VCR.use_cassette('planningalerts') do
+        example.run
+      end
+    end
+
+    context "when there is no matching pre-existing Alert" do
+      it "returns the original alert geocoded" do
+        alert = build(:alert, id: 7, address: "24 Bruce Rd, Glenbrook", lat: nil, lng: nil)
+
+        parser_result = NewAlertParser.new(alert).parse
+
+        expect(parser_result.id).to eq 7
+      end
+
+      it "geocodes the alert" do
+        allow(Location).to receive(:geocode).and_return(
+          double(full_address: "24 Bruce Rd, Glenbrook NSW 2773", lat: 1, lng: 2, error: nil, all: [])
+        )
+        alert = build(:alert, id: 7, address: "24 Bruce Rd, Glenbrook", lat: nil, lng: nil)
+
+        parser_result = NewAlertParser.new(alert).parse
+
+        expect(parser_result.address).to eq "24 Bruce Rd, Glenbrook NSW 2773"
+      end
+    end
+
+    context "when there is a matching pre-existing unconfirmed Alert" do
+      let!(:preexisting_alert) do
+        create(
+          :unconfirmed_alert,
+          address: "24 Bruce Rd, Glenbrook NSW 2773",
+          email: "jenny@example.com",
+          created_at: 3.days.ago,
+          updated_at: 3.days.ago
+        )
+      end
+
+      it "resends the confirmation email for the pre-existing alert" do
+        new_alert = build(
+          :alert,
+          email: "jenny@example.com",
+          address: "24 Bruce Rd, Glenbrook",
+          lat: nil,
+          lng: nil
+        )
+
+        # FIXME: This isn't testing that the specific instance has received this message
+        expect_any_instance_of(Alert).to receive(:send_confirmation_email)
+
+        NewAlertParser.new(new_alert).parse
+      end
+
+      it "returns nil" do
+        new_alert = build(
+          :alert,
+          email: "jenny@example.com",
+          address: "24 Bruce Rd, Glenbrook",
+          lat: nil,
+          lng: nil
+        )
+
+        parser_result = NewAlertParser.new(new_alert).parse
+
+        expect(parser_result).to be nil
+      end
+    end
+  end
+end

--- a/spec/models/new_alert_parser_spec.rb
+++ b/spec/models/new_alert_parser_spec.rb
@@ -99,6 +99,27 @@ describe NewAlertParser do
       #   pending "add this behaviour"
       #   fail
       # end
+
+      context "but it is unsubscribed" do
+        before do
+          preexisting_alert.unsubscribe!
+        end
+
+        it "returns the new alert" do
+          new_alert = build(
+            :alert,
+            id: 9,
+            email: "jenny@example.com",
+            address: "24 Bruce Rd, Glenbrook",
+            lat: nil,
+            lng: nil
+          )
+
+          parser_result = NewAlertParser.new(new_alert).parse
+
+          expect(parser_result.id).to eq 9
+        end
+      end
     end
   end
 end

--- a/spec/models/new_alert_parser_spec.rb
+++ b/spec/models/new_alert_parser_spec.rb
@@ -69,5 +69,36 @@ describe NewAlertParser do
         expect(parser_result).to be nil
       end
     end
+
+    context "when there is a matching confirmed alert" do
+      let!(:preexisting_alert) do
+        create(
+          :confirmed_alert,
+          address: "24 Bruce Rd, Glenbrook NSW 2773",
+          email: "jenny@example.com",
+          created_at: 3.days.ago,
+          updated_at: 3.days.ago
+        )
+      end
+
+      it "returns nil" do
+        new_alert = build(
+          :alert,
+          email: "jenny@example.com",
+          address: "24 Bruce Rd, Glenbrook",
+          lat: nil,
+          lng: nil
+        )
+
+        parser_result = NewAlertParser.new(new_alert).parse
+
+        expect(parser_result).to be nil
+      end
+
+      # it "sends a helpful email to the alert’s email address" do
+      #   pending "add this behaviour"
+      #   fail
+      # end
+    end
   end
 end

--- a/spec/models/new_alert_parser_spec.rb
+++ b/spec/models/new_alert_parser_spec.rb
@@ -41,6 +41,7 @@ describe NewAlertParser do
       end
 
       it "resends the confirmation email for the pre-existing alert" do
+        allow(ConfirmationMailer).to receive(:confirm).with("default", preexisting_alert).and_call_original
         new_alert = build(
           :alert,
           email: "jenny@example.com",
@@ -50,9 +51,9 @@ describe NewAlertParser do
           theme: "default"
         )
 
-        expect(ConfirmationMailer).to receive(:confirm).with("default", preexisting_alert).and_call_original
-
         NewAlertParser.new(new_alert).parse
+
+        expect(ConfirmationMailer).to have_received(:confirm).with("default", preexisting_alert)
       end
 
       it "returns nil" do
@@ -97,6 +98,7 @@ describe NewAlertParser do
       end
 
       it "sends a helpful email to the alert’s email address" do
+        allow(AlertNotifier).to receive(:new_signup_attempt_notice).with(preexisting_alert).and_call_original
         new_alert = build(
           :alert,
           email: "jenny@example.com",
@@ -105,9 +107,9 @@ describe NewAlertParser do
           lng: nil
         )
 
-        expect(AlertNotifier).to receive(:new_signup_attempt_notice).with(preexisting_alert).and_call_original
-
         NewAlertParser.new(new_alert).parse
+
+        expect(AlertNotifier).to have_received(:new_signup_attempt_notice).with(preexisting_alert)
       end
 
       context "but it is unsubscribed" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -105,4 +105,5 @@ RSpec.configure do |config|
   config.include Devise::TestHelpers, type: :view
   config.include SessionHelpers, type: :feature
   config.include EnvHelpers
+  config.include MockLocationHelpers
 end

--- a/spec/support/mock_location_helpers.rb
+++ b/spec/support/mock_location_helpers.rb
@@ -1,0 +1,37 @@
+module MockLocationHelpers
+  def mock_geocoder_valid_address_response
+    allow(Location).to receive(:geocode).and_return(
+      double(
+        lat: -33.772607,
+        lng: 150.624245,
+        full_address: "24 Bruce Rd, Glenbrook, VIC 3885",
+        error: nil,
+        all: []
+      )
+    )
+  end
+
+  def mock_geocoder_error_response
+    allow(Location).to receive(:geocode).and_return(
+      double(
+        error: "some error message",
+        lat: nil,
+        lng: nil,
+        full_address: nil
+      )
+    )
+  end
+
+  def mock_geocoder_multiple_locations_response
+    allow(Location).to receive(:geocode).and_return(
+      double(
+        lat: 1,
+        lng: 2,
+        full_address: "Bruce Rd, VIC 3885",
+        error: nil,
+        all: [double(full_address: "Bruce Rd, VIC 3885"),
+              double(full_address: "Bruce Rd, NSW 2042")]
+      )
+    )
+  end
+end


### PR DESCRIPTION
This adds new behavior to improve the experience of people when they sign up for an alert, but they already have an alert for that address. You can read the detail of the new behavior here https://github.com/openaustralia/planningalerts/issues/117#issuecomment-258047772

Currently if you miss the confirm message and re-sign up, it's easy to end up at a very confusing 404 ( see #117 ). This fixes that situation and also smooths out other interactions.

The main thing is that you'll get an email telling you that there's been an attempt to sign up for the alert you already have. The email has some advice on why you might not be getting alert emails, the common reason we believe people might do this.

There are also some refactors to the Alert model and controller, making it's behavior a bit more predicable I believe. There's also a slight increase in test coverage overall ⭐️ .

Fixes #117

## TODO

* [x] refactor parse_for_preexisting_alert_states with case statement?
* [x] remove duplicate geocode method
* [x] move the test for whether it should geolocate to the validation if option
* [x] add test to geocode_from_address for expected behavior when there are errors
* [x] use test double for geocode_from_address so the actual workings so you can more clearly see the expected behavior.