### PR TITLE
Fix autocomplete, which isn't working at /alerts/signup or /authorities/marrickville/applications

### DIFF
--- a/app/assets/javascripts/address_autocomplete.js
+++ b/app/assets/javascripts/address_autocomplete.js
@@ -1,5 +1,5 @@
 function initAutoComplete() {
-  var input = document.getElementById('q');
+  var input = document.querySelector(".address-autocomplete-input");
   var options = {
     componentRestrictions: {country: "au"},
     types: ["address"]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,7 +40,7 @@ class ApplicationController < ActionController::Base
   def ssl_required?
     # This method is called before set_view_path so we need to calculate the theme from the
     # request rather than using @theme which isn't yet set
-    ::ThemeChooser.themer_from_request(request).theme != "nsw" && !Rails.env.development?
+    ::ThemeChooser.themer_from_request(request).theme != "nsw" && Rails.env.production?
   end
 
   def configure_permitted_parameters

--- a/app/views/alerts/_signup_form.html.haml
+++ b/app/views/alerts/_signup_form.html.haml
@@ -6,7 +6,7 @@
     - else
       = f.input :address, label: "Enter a street address",
                           placeholder: "e.g. #{alert.address_for_placeholder}",
-                          input_html: { required: "required" }
+                          input_html: { required: "required", class: "address-autocomplete-input" }
     = f.input :email, label: "Enter your email address",
                       placeholder: "your@email.com",
                       input_html: { required: "required" }

--- a/app/views/applications/address.html.haml
+++ b/app/views/applications/address.html.haml
@@ -7,7 +7,7 @@
     %ol
       %li#q_input.string{class: ("error" if @error)}
         = label_tag(:q, "Enter a street address")
-        = text_field_tag(:q, @q, placeholder: "e.g. 1 Sowerby St, Goulburn, NSW 2580", required: "required")
+        = text_field_tag(:q, @q, placeholder: "e.g. 1 Sowerby St, Goulburn, NSW 2580", required: "required", class: "address-autocomplete-input")
         - if @error
           %p.inline-errors= @error
         = link_to "#", class: "inline-hints", id: "geolocate" do

--- a/spec/features/search_for_applications_spec.rb
+++ b/spec/features/search_for_applications_spec.rb
@@ -40,7 +40,7 @@ feature "Searching for development application near an address" do
       fill_in "Enter a street address", with: "24 Bruce R"
 
       # this simulates focusing on the input field, which triggers the autocomplete search
-      page.execute_script("el = document.querySelector('#q');
+      page.execute_script("el = document.querySelector('.address-autocomplete-input');
                            event = document.createEvent('HTMLEvents');
                            event.initEvent('focus', false, true);
                            el.dispatchEvent(event);")

--- a/spec/features/search_for_applications_spec.rb
+++ b/spec/features/search_for_applications_spec.rb
@@ -37,7 +37,7 @@ feature "Searching for development application near an address" do
     scenario "autocomplete results are displayed", js: true do
       visit root_path
 
-      fill_in "Enter a street address", with: "24 Bruce R"
+      fill_in "Enter a street address", with: "24 Bruce Road Glenb"
 
       # this simulates focusing on the input field, which triggers the autocomplete search
       page.execute_script("el = document.querySelector('.address-autocomplete-input');

--- a/spec/features/search_for_applications_spec.rb
+++ b/spec/features/search_for_applications_spec.rb
@@ -28,12 +28,6 @@ feature "Searching for development application near an address" do
   end
 
   context "with javascript" do
-    before do
-      # This is a hack to get around the ssl_required? method in
-      # the application controller which redirects poltergeist to https.
-      allow(Rails.env).to receive(:development?).and_return true
-    end
-
     scenario "autocomplete results are displayed", js: true do
       visit root_path
 

--- a/spec/features/search_for_applications_spec.rb
+++ b/spec/features/search_for_applications_spec.rb
@@ -39,19 +39,7 @@ feature "Searching for development application near an address" do
 
       fill_in "Enter a street address", with: "24 Bruce Road Glenb"
 
-      # this simulates focusing on the input field, which triggers the autocomplete search
-      page.execute_script("el = document.querySelector('.address-autocomplete-input');
-                           event = document.createEvent('HTMLEvents');
-                           event.initEvent('focus', false, true);
-                           el.dispatchEvent(event);")
-
-      # Confirm that the suggested addresses appear.
-      # Is this a too brittle? It'll fail if the address format changes.
-      within ".pac-container" do
-        expect(page).to have_content "Bruce Road, Glenbrook, New South Wales"
-      end
-
-      # TODO: Actually test clicking the suggestion and seeing results
+      expect_autocomplete_suggestions_to_include "Bruce Road, Glenbrook, New South Wales"
     end
   end
 end

--- a/spec/features/search_for_applications_spec.rb
+++ b/spec/features/search_for_applications_spec.rb
@@ -26,4 +26,32 @@ feature "Searching for development application near an address" do
       expect(page).to have_content "A lovely house"
     end
   end
+
+  context "with javascript" do
+    before do
+      # This is a hack to get around the ssl_required? method in
+      # the application controller which redirects poltergeist to https.
+      allow(Rails.env).to receive(:development?).and_return true
+    end
+
+    scenario "autocomplete results are displayed", js: true do
+      visit root_path
+
+      fill_in "Enter a street address", with: "24 Bruce R"
+
+      # this simulates focusing on the input field, which triggers the autocomplete search
+      page.execute_script("el = document.querySelector('#q');
+                           event = document.createEvent('HTMLEvents');
+                           event.initEvent('focus', false, true);
+                           el.dispatchEvent(event);")
+
+      # Confirm that the suggested addresses appear.
+      # Is this a too brittle? It'll fail if the address format changes.
+      within ".pac-container" do
+        expect(page).to have_content "Bruce Road, Glenbrook, New South Wales"
+      end
+
+      # TODO: Actually test clicking the suggestion and seeing results
+    end
+  end
 end

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -104,12 +104,6 @@ feature "Sign up for alerts" do
     end
 
     context "with javascript" do
-      before do
-        # This is a hack to get around the ssl_required? method in
-        # the application controller which redirects poltergeist to https.
-        allow(Rails.env).to receive(:development?).and_return true
-      end
-
       scenario "autocomplete results are displayed", js: true do
         visit applications_path(authority_id: "glenbrook")
 
@@ -200,12 +194,6 @@ feature "Sign up for alerts" do
   end
 
   context "with javascript" do
-    before do
-      # This is a hack to get around the ssl_required? method in
-      # the application controller which redirects poltergeist to https.
-      allow(Rails.env).to receive(:development?).and_return true
-    end
-
     scenario "autocomplete results are displayed", js: true do
       visit '/alerts/signup'
 

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -102,6 +102,33 @@ feature "Sign up for alerts" do
 
       expect(page).to have_content("your alert has been activated")
     end
+
+    context "with javascript" do
+      before do
+        # This is a hack to get around the ssl_required? method in
+        # the application controller which redirects poltergeist to https.
+        allow(Rails.env).to receive(:development?).and_return true
+      end
+
+      scenario "autocomplete results are displayed", js: true do
+        visit applications_path(authority_id: "glenbrook")
+
+        fill_in "Enter a street address", with: "24 Bruce Road Glenb"
+
+        # this simulates focusing on the input field, which triggers the autocomplete search
+        page.execute_script("el = document.querySelector('.address-autocomplete-input');
+                            event = document.createEvent('HTMLEvents');
+                            event.initEvent('focus', false, true);
+                            el.dispatchEvent(event);")
+
+        # Confirm that the suggested addresses appear.
+        within ".pac-container" do
+          expect(page).to have_content "Bruce Road, Glenbrook, New South Wales"
+        end
+
+        # TODO: Actually test clicking the suggestion and seeing results
+      end
+    end
   end
 
   context "when there is already an unconfirmed alert for the address" do
@@ -180,6 +207,33 @@ feature "Sign up for alerts" do
         expect(page).to have_content("your alert has been activated")
         expect(page).to have_content("24 Bruce Rd, Glenbrook NSW 2773")
       end
+    end
+  end
+
+  context "with javascript" do
+    before do
+      # This is a hack to get around the ssl_required? method in
+      # the application controller which redirects poltergeist to https.
+      allow(Rails.env).to receive(:development?).and_return true
+    end
+
+    scenario "autocomplete results are displayed", js: true do
+      visit '/alerts/signup'
+
+      fill_in "Enter a street address", with: "24 Bruce Road Glenb"
+
+      # this simulates focusing on the input field, which triggers the autocomplete search
+      page.execute_script("el = document.querySelector('.address-autocomplete-input');
+                           event = document.createEvent('HTMLEvents');
+                           event.initEvent('focus', false, true);
+                           el.dispatchEvent(event);")
+
+      # Confirm that the suggested addresses appear.
+      within ".pac-container" do
+        expect(page).to have_content "Bruce Road, Glenbrook, New South Wales"
+      end
+
+      # TODO: Actually test clicking the suggestion and seeing results
     end
   end
 

--- a/spec/features/sign_up_for_alerts_spec.rb
+++ b/spec/features/sign_up_for_alerts_spec.rb
@@ -115,18 +115,7 @@ feature "Sign up for alerts" do
 
         fill_in "Enter a street address", with: "24 Bruce Road Glenb"
 
-        # this simulates focusing on the input field, which triggers the autocomplete search
-        page.execute_script("el = document.querySelector('.address-autocomplete-input');
-                            event = document.createEvent('HTMLEvents');
-                            event.initEvent('focus', false, true);
-                            el.dispatchEvent(event);")
-
-        # Confirm that the suggested addresses appear.
-        within ".pac-container" do
-          expect(page).to have_content "Bruce Road, Glenbrook, New South Wales"
-        end
-
-        # TODO: Actually test clicking the suggestion and seeing results
+        expect_autocomplete_suggestions_to_include "Bruce Road, Glenbrook, New South Wales"
       end
     end
   end
@@ -222,18 +211,7 @@ feature "Sign up for alerts" do
 
       fill_in "Enter a street address", with: "24 Bruce Road Glenb"
 
-      # this simulates focusing on the input field, which triggers the autocomplete search
-      page.execute_script("el = document.querySelector('.address-autocomplete-input');
-                           event = document.createEvent('HTMLEvents');
-                           event.initEvent('focus', false, true);
-                           el.dispatchEvent(event);")
-
-      # Confirm that the suggested addresses appear.
-      within ".pac-container" do
-        expect(page).to have_content "Bruce Road, Glenbrook, New South Wales"
-      end
-
-      # TODO: Actually test clicking the suggestion and seeing results
+      expect_autocomplete_suggestions_to_include "Bruce Road, Glenbrook, New South Wales"
     end
   end
 

--- a/spec/features/user_subscribes_for_regular_donation_spec.rb
+++ b/spec/features/user_subscribes_for_regular_donation_spec.rb
@@ -40,12 +40,6 @@ feature "Subscribing to donate monthly" do
     end
 
     context "with javascript" do
-      before do
-        # This is a hack to get around the ssl_required? method in
-        # the application controller which redirects poltergeist to https.
-        allow(Rails.env).to receive(:development?).and_return true
-      end
-
       it "successfully", js: true do
         visit new_donation_path
 

--- a/spec/requests/redirects_spec.rb
+++ b/spec/requests/redirects_spec.rb
@@ -28,14 +28,20 @@ describe "redirects" do
   end
 
   describe "ssl redirects" do
-    it "should redirect to ssl" do
-      get "http://www.planningalerts.org.au/applications"
-      expect(response).to redirect_to "https://www.planningalerts.org.au/applications"
-    end
+    context "in the production environment" do
+      before do
+        allow(Rails.env).to receive(:production?).and_return true
+      end
 
-    it "should redirect the api howto page" do
-      get "http://www.planningalerts.org.au/api/howto"
-      expect(response).to redirect_to "https://www.planningalerts.org.au/api/howto"
+      it "should redirect to ssl" do
+        get "http://www.planningalerts.org.au/applications"
+        expect(response).to redirect_to "https://www.planningalerts.org.au/applications"
+      end
+
+      it "should redirect the api howto page" do
+        get "http://www.planningalerts.org.au/api/howto"
+        expect(response).to redirect_to "https://www.planningalerts.org.au/api/howto"
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,12 +99,6 @@ RSpec.configure do |config|
     ActionMailer::Base.deliveries = []
   end
 
-  # This is a hack to get around the ssl_required? method in
-  # the application controller which redirects poltergeist to https.
-  config.before(:each, js: true) do
-    allow(Rails.env).to receive(:development?).and_return true
-  end
-
   config.include EmailSpec::Helpers
   config.include EmailSpec::Matchers
   config.include FactoryGirl::Syntax::Methods

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -106,4 +106,5 @@ RSpec.configure do |config|
   config.include SessionHelpers, type: :feature
   config.include EnvHelpers
   config.include MockLocationHelpers
+  config.include AutocompleteHelpers
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,6 +99,12 @@ RSpec.configure do |config|
     ActionMailer::Base.deliveries = []
   end
 
+  # This is a hack to get around the ssl_required? method in
+  # the application controller which redirects poltergeist to https.
+  config.before(:each, js: true) do
+    allow(Rails.env).to receive(:development?).and_return true
+  end
+
   config.include EmailSpec::Helpers
   config.include EmailSpec::Matchers
   config.include FactoryGirl::Syntax::Methods

--- a/spec/support/autocomplete_helpers.rb
+++ b/spec/support/autocomplete_helpers.rb
@@ -1,0 +1,14 @@
+module AutocompleteHelpers
+  def expect_autocomplete_suggestions_to_include(expected_address)
+    # this simulates focusing on the input field, which triggers the autocomplete search
+    page.execute_script("el = document.querySelector('.address-autocomplete-input');
+                          event = document.createEvent('HTMLEvents');
+                          event.initEvent('focus', false, true);
+                          el.dispatchEvent(event);")
+
+    # Confirm that the suggested addresses appear.
+    within ".pac-container" do
+      expect(page).to have_content expected_address
+    end
+  end
+end


### PR DESCRIPTION
This fixes a regression introduced last September that's causing autocomplete to not work on the alert signup forms, it only works in the address search on the homepage.

This line https://github.com/openaustralia/planningalerts/pull/1031/commits/95b8c5ca0cecbdf09cea0de241d93a6668880008#diff-d4b9d0943f985c5e598c24a7b46462faR2 replaced the element lookup here https://github.com/openaustralia/planningalerts/pull/1031/commits/95b8c5ca0cecbdf09cea0de241d93a6668880008#diff-d4b9d0943f985c5e598c24a7b46462faL3 which was targeting the signup forms for autocomplete.

We actually see in Google Analytics about a 15% increase in people seeing errors on the alert signup form after late September when that was introduced.

![screen shot 2017-02-09 at 1 50 54 pm](https://cloud.githubusercontent.com/assets/1239550/22767358/e09dc9bc-eece-11e6-951e-67ccd185b98f.png)

This PR fixes this by introducing a new class name we can use to add address autocomplete anywhere, rather than making the autocomplete script more complex again.

It also adds tests to make sure autocomplete results are being displayed on the homepage, alert signup page and in the signup on authority applications pages.

I couldn't for the life of me get capybara to actually click the suggested address to trigger the form submission—so the tests just look for results being displayed. It's a start.