### PR TITLE
Use :local flag to add rbenv support to capistrano deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -4,7 +4,7 @@ require 'delayed/recipes'
 set :stage, "test" unless exists? :stage
 if stage != "development"
   require 'rvm/capistrano'
-  set :rvm_ruby_string, ENV['GEM_HOME'].gsub(/.*\//,"")
+  set :rvm_ruby_string, :local
 end
 
 # This adds a task that precompiles assets for the asset pipeline


### PR DESCRIPTION
In rvm-capistrano, if you use the :local flag here, it will first check to
see if you're using rbenv and detect the local ruby verion. If you're
not using rbenv it falls back to expect rvm and uses the same statement
I'm replacing here to detect the version.

See this https://github.com/readly/rvm-capistrano/blob/master/lib/rvm/capistrano/base.rb#L77-L88

Fixes #1104