### PR TITLE
Authority count refactor

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
   # Scrub sensitive parameters from your log
   # filter_parameter_logging :password
 
-  before_filter :load_configuration, :set_view_path
+  before_filter :set_header_variable, :set_view_path
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def authenticate_active_admin_user!
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def load_configuration
+  def set_header_variable
     @alert_count = Stat.applications_sent
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,6 @@ class ApplicationController < ActionController::Base
 
   def load_configuration
     @alert_count = Stat.applications_sent
-    @authority_count = Authority.active.count
   end
 
   def set_view_path

--- a/app/controllers/authorities_controller.rb
+++ b/app/controllers/authorities_controller.rb
@@ -1,6 +1,7 @@
 class AuthoritiesController < ApplicationController
   def index
     @authority_count = Authority.active.count
+    @percentage_population_covered_by_all_active_authorities = Authority.percentage_population_covered_by_all_active_authorities.to_i
 
     # map from state name to authorities in that state
     states = Authority.enabled.group(:state).order(:state).map{|a| a.state}

--- a/app/controllers/authorities_controller.rb
+++ b/app/controllers/authorities_controller.rb
@@ -1,5 +1,7 @@
 class AuthoritiesController < ApplicationController
   def index
+    @authority_count = Authority.active.count
+
     # map from state name to authorities in that state
     states = Authority.enabled.group(:state).order(:state).map{|a| a.state}
     @authorities = {}

--- a/app/views/authorities/index.html.haml
+++ b/app/views/authorities/index.html.haml
@@ -5,7 +5,7 @@
   New authorities are being added all the time, so if your local authority isn't listed below
   #{link_to "sign up anyway", new_alert_path} and you'll start receiving alerts once it has been included.
 %p
-  We currently cover #{Authority.percentage_population_covered_by_all_active_authorities.to_i}% of Australia's population within #{@authority_count} authorities. For this number we're only counting places where the main planning authority is covered. As an example, most of Victoria is covered by the SPEAR system but not all Victorian planning applications go through it. So, we don't include SPEAR in our population count.
+  We currently cover #{@percentage_population_covered_by_all_active_authorities}% of Australia's population within #{@authority_count} authorities. For this number we're only counting places where the main planning authority is covered. As an example, most of Victoria is covered by the SPEAR system but not all Victorian planning applications go through it. So, we don't include SPEAR in our population count.
 %p
   If you are a programmer and would like to write a scraper for your local authority, or work for a local authority
   and would like to make your data available, #{link_to "find out how you can get involved", get_involved_path}.


### PR DESCRIPTION
During some recent work I realised we were setting `@authority_count` on every request but we stopped using it in the header quite a while back. This refactor is mainly to address that but I've also tried to make things a bit nicer too.