### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/openaustralia/planningalerts.png?label=ready&title=Ready)](https://waffle.io/openaustralia/planningalerts)
 # PlanningAlerts
 
 Find out and have your say about development applications in your area.


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/openaustralia/planningalerts

This was requested by a real person (user kat) on waffle.io, we're not trying to spam you.