### PR TITLE
Don't use our Google Maps Premium Plan credits for map loads

### DIFF
--- a/.env
+++ b/.env
@@ -57,8 +57,12 @@ SECRET_KEY_BASE=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # Optional: You can specify the Honeybadger environment. Useful for staging:
 #HONEYBADGER_ENV=staging
 
+# Sign up for a free Google Maps API key and enter it here so we can show maps on pages
+#GOOGLE_MAPS_API_KEY=xxxxxxxxxxx
+
 # If you have Google Maps API for Business (OpenAustralia Foundation gets it through the
 # Google Maps API grants programme for charities) uncomment and fill out the two lines below
+# so that this is used by the geocoder
 #GOOGLE_MAPS_CLIENT_ID=xxxxxxxxxxx
 #GOOGLE_MAPS_CRYPTOGRAPHIC_KEY=xxxxxxxxxxx
 

--- a/app/views/shared/_end_matter.haml
+++ b/app/views/shared/_end_matter.haml
@@ -3,6 +3,6 @@
   :javascript
     document.getElementById('#{@set_focus_control}').focus();
 - if with_maps_scripts
-  %script(src="https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&libraries=places&region=au" type="text/javascript")
+  %script(src="https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&v=3&libraries=places&region=au" type="text/javascript")
 = javascript_include_tag "application"
 = vanity_js

--- a/app/views/shared/_end_matter.haml
+++ b/app/views/shared/_end_matter.haml
@@ -3,9 +3,6 @@
   :javascript
     document.getElementById('#{@set_focus_control}').focus();
 - if with_maps_scripts
-  - if @themer.google_maps_client_id
-    %script(src="https://maps.googleapis.com/maps/api/js?client=#{@themer.google_maps_client_id}&v=3.13&libraries=places" type="text/javascript")
-  - else
-    %script(src="https://maps.googleapis.com/maps/api/js?libraries=places&region=au" type="text/javascript")
+  %script(src="https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&libraries=places&region=au" type="text/javascript")
 = javascript_include_tag "application"
 = vanity_js


### PR DESCRIPTION
In #1122 we identified that map loads are considerably draining our Google Maps Premium Plan credits. However since we're a free site we should be using a free plan for these map loads.

This PR adds a configuration option for the API key and uses that instead of the Premium plan ID.