### PR TITLE
Fix for the issue https://github.com/openaustralia/planningalerts/issues/794

### DIFF
--- a/app/views/comments/_comment_form.html.haml
+++ b/app/views/comments/_comment_form.html.haml
@@ -7,5 +7,3 @@
   %p
     = link_to "How to comment", @application.comment_url
     on this application (from #{@application.authority.full_name}).
-    - if @application.on_notice_to
-      = on_notice_text(@application)

--- a/app/views/comments/_comments_area.html.haml
+++ b/app/views/comments/_comments_area.html.haml
@@ -1,6 +1,9 @@
 #comments-area
   - if @comments.present?
     %h4= pluralize(@comments.count, "Comment")
+    %p
+      - if @application.on_notice_to
+        = on_notice_text(@application)
     %p.small.quiet
       Have your say by #{link_to "adding your own comment", "#add-comment", class: "link-to-comment-form"}.
     %ol#comments


### PR DESCRIPTION
This PR tries to fix the issue #794 
The important information that there's a limited time to comment on an application is buried and it should be moved to the new position as specified in the issue.