### PR TITLE
Fix the issue #826

### DIFF
--- a/app/views/api/howto.html.haml
+++ b/app/views/api/howto.html.haml
@@ -4,7 +4,7 @@
 
 %p
   Planning application data is available programmatically as feeds which can
-  be used in most web mapping APIs and desktop GIS software like #{link_to "Yahoo Pipes", "http://pipes.yahoo.com/"}. Details of the API are listed below.
+  be used in most web mapping APIs and desktop GIS software like <a href="https://zapier.com/">Zapier</a>. Details of the API are listed below.
 
 %p
   Non&ndash;commercial, low&ndash;volume use of this service is free.

--- a/app/views/api/howto.html.haml
+++ b/app/views/api/howto.html.haml
@@ -4,7 +4,7 @@
 
 %p
   Planning application data is available programmatically as feeds which can
-  be used in most web mapping APIs and desktop GIS software like <a href="https://zapier.com/">Zapier</a>. Details of the API are listed below.
+  be used in most web mapping APIs and desktop GIS software like #{link_to "Superpipes", "https://github.com/superfeedr/superpipes"}. Details of the API are listed below.
 
 %p
   Non&ndash;commercial, low&ndash;volume use of this service is free.

--- a/app/views/applications/show.html.haml
+++ b/app/views/applications/show.html.haml
@@ -14,7 +14,7 @@
   #application
     %article#application-info
       %header
-        %h1.address= @application.address
+        %h3.address= @application.address
 
       - if @application.location
         #map_div

--- a/app/views/applications/show.html.haml
+++ b/app/views/applications/show.html.haml
@@ -14,7 +14,7 @@
   #application
     %article#application-info
       %header
-        %h3.address= @application.address
+        %h1.address= @application.address
 
       - if @application.location
         #map_div


### PR DESCRIPTION
Fix for the issue https://github.com/openaustralia/planningalerts/issues/826.
Yahoo! Pipes does not exist anymore. So, a good alternative to it seems to be Zapier https://zapier.com/ 
The link for Yahoo Pipes on the Get the Data - API page is fixed.