### PR TITLE
Updated Yahoo! Pipes link to Superpipes

### DIFF
--- a/app/views/api/howto.html.haml
+++ b/app/views/api/howto.html.haml
@@ -4,7 +4,7 @@
 
 %p
   Planning application data is available programmatically as feeds which can
-  be used in most web mapping APIs and desktop GIS software like #{link_to "Yahoo Pipes", "http://pipes.yahoo.com/"}. Details of the API are listed below.
+  be used in most web mapping APIs and desktop GIS software like #{link_to "Superpipes", "https://github.com/superfeedr/superpipes"}. Details of the API are listed below.
 
 %p
   Non&ndash;commercial, low&ndash;volume use of this service is free.


### PR DESCRIPTION
This pull request aims to fix the issue https://github.com/openaustralia/planningalerts/issues/826

The Yahoo! Pipes link on the API - Get the Data page is dead as Yahoo! Pipes does not exist anymore.
Hence the link has been updated to Superpipes ( https://github.com/superfeedr/superpipes ).
Superpipes is an open-source Yahoo! Pipes equivalent, which was developed to replace it, when they had anticipated their closing.