### PR TITLE
Correct semantic heading for address page

### DIFF
--- a/app/views/applications/show.html.haml
+++ b/app/views/applications/show.html.haml
@@ -14,7 +14,7 @@
   #application
     %article#application-info
       %header
-        %h3.address= @application.address
+        %h1.address= @application.address
 
       - if @application.location
         #map_div


### PR DESCRIPTION
This pull request aims to fix the issue https://github.com/openaustralia/planningalerts/issues/614

The title of the application address page uses an h3, while it should be an h1 to improve its accessibility for web crawlers. It has now been changed to h1.
Although this increases the size of the header, it is a better option as it is important for search engines to index the page properly.
The heading now uses the correct semantic heading level.