### PR TITLE
added link to JSON data of applications on applications/index.html.haml

### DIFF
--- a/app/helpers/applications_helper.rb
+++ b/app/helpers/applications_helper.rb
@@ -1,6 +1,4 @@
 module ApplicationsHelper
-
-
   def display_description_with_address(application)
     display_description =
       if application.description
@@ -70,7 +68,7 @@ module ApplicationsHelper
     "#{@application.address} | #{@application.date_scraped.to_date.to_formatted_s(:rfc822)}"
   end
 
-  def applications_json_path(authority)
+  def authority_applications_json_path_for_current_user(authority)
     authority_applications_path(authority.short_name_encoded, format: :js, key: current_user.api_key)
   end
 

--- a/app/helpers/applications_helper.rb
+++ b/app/helpers/applications_helper.rb
@@ -67,9 +67,14 @@ module ApplicationsHelper
     # Include the scraping date in the title so that multiple applications from the same address have different titles
     "#{@application.address} | #{@application.date_scraped.to_date.to_formatted_s(:rfc822)}"
   end
+  
+  # TODO: extract to theme
+  def api_host
+   "api.planningalerts.org.au"
+  end
 
-  def authority_applications_json_path_for_current_user(authority)
-    authority_applications_path(authority.short_name_encoded, format: :js, key: current_user.api_key)
+  def authority_applications_json_url_for_current_user(authority)
+    authority_applications_url(authority.short_name_encoded, host: api_host, format: :js, key: current_user.api_key)
   end
 
   def google_static_map(application, options)

--- a/app/helpers/applications_helper.rb
+++ b/app/helpers/applications_helper.rb
@@ -1,4 +1,6 @@
 module ApplicationsHelper
+
+
   def display_description_with_address(application)
     display_description =
       if application.description
@@ -68,6 +70,10 @@ module ApplicationsHelper
     "#{@application.address} | #{@application.date_scraped.to_date.to_formatted_s(:rfc822)}"
   end
 
+  def applications_json_path(authority)
+    authority_applications_path(authority.short_name_encoded, format: :js, key: current_user.api_key)
+  end
+
   def google_static_map(application, options)
     google_static_map2(options.merge(lat: application.lat, lng: application.lng, label: "Map of #{application.address}"))
   end
@@ -92,4 +98,5 @@ module ApplicationsHelper
     size = options[:size] || "350x200"
     image_tag(google_static_streetview_url(application, options), size: size, alt: "Streetview of #{application.address}")
   end
+
 end

--- a/app/mailers/confirmation_mailer.rb
+++ b/app/mailers/confirmation_mailer.rb
@@ -1,6 +1,8 @@
 class ConfirmationMailer < ActionMailer::Base
   include ActionMailerThemer
 
+  add_template_helper(CommentsHelper)
+
   def confirm(theme, object)
     class_name = object.class.name.underscore
     # This seems a bit long-winded. Is there a better way?

--- a/app/views/applications/index.html.haml
+++ b/app/views/applications/index.html.haml
@@ -14,5 +14,8 @@
     %span.highlight It looks like something might be wrong. The latest application was received #{time_ago_in_words(@authority.latest_application_date)} ago.
     = link_to "Why?", faq_path(:anchor => "broken_scraper")
 
+- if current_user && @authority
+  = link_to "View as JSON", applications_json_path(@authority)
+
 = paginated_section @applications, :previous_label => "« Newer", :next_label => "Older »" do
   = render "applications", :applications => @applications

--- a/app/views/applications/index.html.haml
+++ b/app/views/applications/index.html.haml
@@ -14,8 +14,8 @@
     %span.highlight It looks like something might be wrong. The latest application was received #{time_ago_in_words(@authority.latest_application_date)} ago.
     = link_to "Why?", faq_path(:anchor => "broken_scraper")
 
-- if current_user && @authority
-  = link_to "View as JSON", applications_json_path(@authority)
-
 = paginated_section @applications, :previous_label => "« Newer", :next_label => "Older »" do
   = render "applications", :applications => @applications
+
+- if current_user && @authority
+  = link_to "View as JSON", authority_applications_json_url_for_current_user(@authority)

--- a/app/views/confirmation_mailer/comment.html.haml
+++ b/app/views/confirmation_mailer/comment.html.haml
@@ -7,9 +7,9 @@
 
 %p If your email program does not let you click on this link, just copy and paste it into your web browser and hit return.
 
-%p
-  Your comment:
-  = comment_as_html(@comment.text)
+%p Your comment:
+
+%blockquote= comment_as_html(@comment.text)
 
 %p
   On the application:

--- a/app/views/confirmation_mailer/comment.html.haml
+++ b/app/views/confirmation_mailer/comment.html.haml
@@ -9,7 +9,7 @@
 
 %p
   Your comment:
-  = @comment.text
+  = comment_as_html(@comment.text)
 
 %p
   On the application:

--- a/spec/helpers/applications_helper_spec.rb
+++ b/spec/helpers/applications_helper_spec.rb
@@ -171,16 +171,15 @@ describe ApplicationsHelper do
       end
     end
 
-    describe "applications_json_path" do
+    describe "authority_applications_json_path_for_current_user" do
       let(:authority) { create(:authority, short_name: "marrickville", ) }
-      let(:user) { create(:user)}
-      it "returns authority applications path as JSON" do
-        expect(helper).to receive(:current_user).and_return(user)
-        user.api_key ="ABCDE12345"
-        expect(helper.applications_json_path(authority)).to eq(
-        "/authorities/marrickville/applications.js?key=ABCDE12345"
-        )
-      end
+      let(:user) { build(:user, api_key: "ABCDE12345" )}
+
+      before { expect(helper).to receive(:current_user).and_return(user) }
+
+      subject { helper.authority_applications_json_path_for_current_user(authority) }
+
+      it { is_expected.to eq("/authorities/marrickville/applications.js?key=ABCDE12345") }
     end
 
     describe "static maps" do

--- a/spec/helpers/applications_helper_spec.rb
+++ b/spec/helpers/applications_helper_spec.rb
@@ -171,15 +171,15 @@ describe ApplicationsHelper do
       end
     end
 
-    describe "authority_applications_json_path_for_current_user" do
+    describe "authority_applications_json_url_for_current_user" do
       let(:authority) { create(:authority, short_name: "marrickville", ) }
       let(:user) { build(:user, api_key: "ABCDE12345" )}
 
       before { expect(helper).to receive(:current_user).and_return(user) }
 
-      subject { helper.authority_applications_json_path_for_current_user(authority) }
+      subject { helper.authority_applications_json_url_for_current_user(authority) }
 
-      it { is_expected.to eq("/authorities/marrickville/applications.js?key=ABCDE12345") }
+      it { is_expected.to eq("http://api.planningalerts.org.au/authorities/marrickville/applications.js?key=ABCDE12345") }
     end
 
     describe "static maps" do

--- a/spec/helpers/applications_helper_spec.rb
+++ b/spec/helpers/applications_helper_spec.rb
@@ -171,6 +171,18 @@ describe ApplicationsHelper do
       end
     end
 
+    describe "applications_json_path" do
+      let(:authority) { create(:authority, short_name: "marrickville", ) }
+      let(:user) { create(:user)}
+      it "returns authority applications path as JSON" do
+        expect(helper).to receive(:current_user).and_return(user)
+        user.api_key ="ABCDE12345"
+        expect(helper.applications_json_path(authority)).to eq(
+        "/authorities/marrickville/applications.js?key=ABCDE12345"
+        )
+      end
+    end
+
     describe "static maps" do
       before :each do
         allow(@application).to receive(:address).and_return("Foo Road, NSW")

--- a/spec/mailers/regression/email_confirmable/comment.html
+++ b/spec/mailers/regression/email_confirmable/comment.html
@@ -5,10 +5,8 @@ If you didn't make a comment, then simply ignore this email and nothing further 
 </p>
 <a href="https://dev.planningalerts.org.au/comments/sdbfjsd3rs/confirmed">Confirm your comment</a>
 <p>If your email program does not let you click on this link, just copy and paste it into your web browser and hit return.</p>
-<p>
-Your comment:
-This is a comment
-</p>
+<p>Your comment:</p>
+<blockquote><p>This is a comment</p></blockquote>
 <p>
 On the application:
 10 Smith Street

--- a/spec/mailers/regression/email_confirmable/comment_nsw.html
+++ b/spec/mailers/regression/email_confirmable/comment_nsw.html
@@ -5,10 +5,8 @@ If you didn't make a comment, then simply ignore this email and nothing further 
 </p>
 <a href="http://nsw.127.0.0.1.xip.io:3000/comments/sdbfjsd3rs/confirmed">Confirm your comment</a>
 <p>If your email program does not let you click on this link, just copy and paste it into your web browser and hit return.</p>
-<p>
-Your comment:
-This is a comment
-</p>
+<p>Your comment:</p>
+<blockquote><p>This is a comment</p></blockquote>
 <p>
 On the application:
 10 Smith Street


### PR DESCRIPTION
I'm working on the issue #947, to create a link to see the list of applications as JSON data.
I haven't write the test yet as I have a question.

in this PR, I created application_json_path(authority) to direct user to /authorities/authority.short_name_encoded/application.js?key=current_user.api_key

I'm wondering if this link should *only* be on the applications index for a specific authority, or if it should also be on the general applications index like 
/applications.js?key=current_user.api_key  
(in which case the user needs bulk api access)
