### PR TITLE
Adding Facebook Og Tags

### DIFF
--- a/app/views/applications/show.html.haml
+++ b/app/views/applications/show.html.haml
@@ -6,6 +6,11 @@
   %meta(name="twitter:title" content="#{@application.address}")
   %meta(name="twitter:description" content="#{@application.description[0..199] if @application.description}")
   %meta(name="twitter:image" content="#{google_static_streetview_url(@application, size: "120x120")}")
+  %meta(property="fb:app_id" content="335651659855671")
+  %meta(property="og:url" content="#{application_url(@application)}")
+  %meta(property="og:title" content="#{@application.address}")
+  %meta(property="og:description" content="#{@application.description[0..199] if @application.description}")
+  %meta(property="og:image" content="#{google_static_streetview_url(@application, size: "200x200")}")
 
 = render "applications/facebook"
 = render "applications/twitter"


### PR DESCRIPTION
I have added the og meta tags for the app. I tested it with Facebook Sharing Debugger and the warnings are now removed. Below is the image of the updated page in the facebook sharing debugger
![Image of Facebook sharing debugger](https://preview.ibb.co/eOiBY5/download.png).