### PR TITLE
'Return to' text and link on 'now check your email' page fixed (#1120)

### DIFF
--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -12,6 +12,7 @@ class AlertsController < ApplicationController
   end
 
   def create
+    @address = params[:alert][:address]
     @alert = NewAlertParser.new(
       Alert.new(
         email: params[:alert][:email],


### PR DESCRIPTION
This will fix the issue #1120 -'Return to' text and link on 'now check your email' page
The link was broken because the 'address' parameter was not set. This parameter has been set in the alerts controller file to the street address of the respective application. 