### PR TITLE
added a devise method send_devise_notification in user.rb, and change…

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,8 @@ class User < ActiveRecord::Base
   def set_api_key
     self.api_key = Digest::MD5.base64digest(id.to_s + rand.to_s + Time.now.to_s)[0...20]
   end
+
+  def send_devise_notification(notification, *args)
+    devise_mailer.send(notification, self, *args).deliver_later
+  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,7 +43,7 @@ PlanningalertsApp::Application.configure do
   # config.force_ssl = true
 
   # Set to :debug to see everything in the log.
-  config.log_level = :info
+  config.log_level = :warn
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]

--- a/spec/features/user_sign_up_spec.rb
+++ b/spec/features/user_sign_up_spec.rb
@@ -18,7 +18,6 @@ feature "Signing up for an API account" do
     expect(unread_emails_for("henare@oaf.org.au").size).to eq(1)
     open_email("henare@oaf.org.au")
     expect(current_email).to have_subject("Please confirm your account")
-
     expect(current_email.default_part_body.to_s).to include("Please click on the link below to confirm your email address to register for a PlanningAlerts")
   end
 end

--- a/spec/features/user_sign_up_spec.rb
+++ b/spec/features/user_sign_up_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 feature "Signing up for an API account" do
-  scenario "Successfully signing up" do
+  scenario "Successfully signing up", truncation: true do
     visit "/api/howto"
     click_link "Register for an account"
 
@@ -14,5 +14,11 @@ feature "Signing up for an API account" do
     expect(page).to have_content "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
     expect(User.find_by(email: "henare@oaf.org.au").name).to eq "Henare Degan"
     expect(User.find_by(email: "henare@oaf.org.au").organisation).to eq "OpenAustralia Foundation"
+
+    expect(unread_emails_for("henare@oaf.org.au").size).to eq(1)
+    open_email("henare@oaf.org.au")
+    expect(current_email).to have_subject("Please confirm your account")
+
+    expect(current_email.default_part_body.to_s).to include("Please click on the link below to confirm your email address to register for a PlanningAlerts")
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,6 +61,10 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
   end
 
+  config.before(:each, truncation: true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
   config.before(:each, type: :feature) do
     # :rack_test driver's Rack app under test shares database connection
     # with the specs, so continue to use transaction strategy for speed.


### PR DESCRIPTION
…d the config.log_level to :warn from :info to send the devise email using background que

this is to fix <a href="https://github.com/openaustralia/planningalerts/issues/676"> issue#676</a>
@henare I haven't wrote the test for this, because I wasn't sure if I should since it's a kind of change that buried in devise..please let me know the next step 🤓 