### PR TITLE
Issue#669 bad page number parameters causing ArgumentError

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,10 +49,10 @@ class ApplicationController < ActionController::Base
   # this method is to respond to the will_paginate bug of invalid page number leading to error being thrown.
   # see discussion here https://github.com/mislav/will_paginate/issues/271
   def validate_page_param
-    unless params[:page].present? && params[:page].to_i > 0
-     params[:page] = nil
+    if params[:page].present? && params[:page].to_i > 0
+      params[:page] = params[:page].to_i
     else
-     params[:page] = params[:page].to_i
-   end
+      params[:page] = nil
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,6 +46,8 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :organisation])
   end
 
+  # this method is to respond to the will_paginate bug of invalid page number leading to error being thrown.
+  # see discussion here https://github.com/mislav/will_paginate/issues/271
   def validate_page_param
     unless params[:page].present? && params[:page].to_i > 0
      params[:page] = nil

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
   # Scrub sensitive parameters from your log
   # filter_parameter_logging :password
 
-  before_filter :set_header_variable, :set_view_path
+  before_filter :set_header_variable, :set_view_path, :validate_page_param
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def authenticate_active_admin_user!
@@ -44,5 +44,13 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :organisation])
+  end
+
+  def validate_page_param
+    unless params[:page].present? && params[:page].to_i > 0
+     params[:page] = 1
+    else
+     params[:page] = params[:page].to_i
+   end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,7 +48,7 @@ class ApplicationController < ActionController::Base
 
   def validate_page_param
     unless params[:page].present? && params[:page].to_i > 0
-     params[:page] = 1
+     params[:page] = nil
     else
      params[:page] = params[:page].to_i
    end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe ApplicationController do
+  controller do
+    def index
+      render text: nil
+    end
+  end
+
+  describe "#validate_page_param" do
+    it "should try to convert page param to an integer" do
+      get :index, page: "2%5B&q"
+
+      expect(controller.params[:page]).to eq(2)
+    end
+
+    it "should default to page nil when no page number param is given" do
+      get :index, page: "%5B&q"
+
+      expect(controller.params[:page]).to eq(nil)
+    end
+  end
+end

--- a/spec/controllers/applications_controller_spec.rb
+++ b/spec/controllers/applications_controller_spec.rb
@@ -16,20 +16,6 @@ describe ApplicationsController do
         expect(assigns[:rss]).to be_nil
       end
 
-      it "should try to convert page param to an integer" do
-        VCR.use_cassette('planningalerts') do
-          get :index, page: "2%5B&q"
-        end
-        expect(controller.params[:page]).to eq(2)
-      end
-
-      it "should default to page nil when no page number param is given" do
-        VCR.use_cassette('planningalerts') do
-        get :index, page: "%5B&q"
-      end
-        expect(controller.params[:page]).to eq(nil)
-      end
-
     end
 
     describe "error checking on parameters used" do

--- a/spec/controllers/applications_controller_spec.rb
+++ b/spec/controllers/applications_controller_spec.rb
@@ -15,7 +15,6 @@ describe ApplicationsController do
         get :index
         expect(assigns[:rss]).to be_nil
       end
-
     end
 
     describe "error checking on parameters used" do

--- a/spec/controllers/applications_controller_spec.rb
+++ b/spec/controllers/applications_controller_spec.rb
@@ -15,6 +15,21 @@ describe ApplicationsController do
         get :index
         expect(assigns[:rss]).to be_nil
       end
+
+      it "should try to convert page param to an integer" do
+        VCR.use_cassette('planningalerts') do
+          get :index, page: "2%5B&q"
+        end
+        expect(controller.params[:page]).to eq(2)
+      end
+
+      it "should default to page nil when no page number param is given" do
+        VCR.use_cassette('planningalerts') do
+        get :index, page: "%5B&q"
+      end
+        expect(controller.params[:page]).to eq(nil)
+      end
+
     end
 
     describe "error checking on parameters used" do


### PR DESCRIPTION
Fixes #669.

I wrote 2 test for this method because
when the string passed starts with integer, to_i returns the same integer (ex. "2K%&)".to_i = 2) 
and other time it returns 0 (ex. "%&43{".to_i = 0)

and I'm not super sure this is the appropriate way to do it? please let me know!
@equivalentideas @henare 
