### PR TITLE
Change how abuse reports are sent so they get delivered

### DIFF
--- a/.env
+++ b/.env
@@ -87,7 +87,7 @@ THEME_NSW_CUTTLEFISH_PASSWORD=xxxxxxxxxxxxxxxxxxxx
 
 THEME_NSW_GOOGLE_ANALYTICS_KEY=UA-3107958-12
 
-# CAPTCHA for reporting comments
+# CAPTCHA for protecting comment reports from spammers
 # Get your own keys from https://www.google.com/recaptcha/admin
 RECAPTCHA_SITE_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 RECAPTCHA_SECRET_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/.env
+++ b/.env
@@ -89,5 +89,5 @@ THEME_NSW_GOOGLE_ANALYTICS_KEY=UA-3107958-12
 
 # CAPTCHA for protecting comment reports from spammers
 # Get your own keys from https://www.google.com/recaptcha/admin
-RECAPTCHA_SITE_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-RECAPTCHA_SECRET_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+#RECAPTCHA_SITE_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+#RECAPTCHA_SECRET_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/.env
+++ b/.env
@@ -86,3 +86,8 @@ THEME_NSW_CUTTLEFISH_USER_NAME=xxxxxxxxxxxxxxxxx
 THEME_NSW_CUTTLEFISH_PASSWORD=xxxxxxxxxxxxxxxxxxxx
 
 THEME_NSW_GOOGLE_ANALYTICS_KEY=UA-3107958-12
+
+# CAPTCHA for reporting comments
+# Get your own keys from https://www.google.com/recaptcha/admin
+RECAPTCHA_SITE_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+RECAPTCHA_SECRET_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,4 @@
 EMAIL_MODERATOR=moderator@planningalerts.org.au
+
+# reCAPTCHA is disabled in test but we need this to just display the form
+RECAPTCHA_SITE_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem 'everypolitician-popolo', git: 'https://github.com/everypolitician/everypoli
 # Using master until an updated version of the Gem is released https://github.com/ciudadanointeligente/writeit-rails/issues/4
 gem 'writeit-rails', git: 'https://github.com/ciudadanointeligente/writeit-rails.git', branch: 'master'
 gem 'mime-types', '~> 2.99' # our writeit gem version is incompatible with newer versions
+gem 'recaptcha', require: 'recaptcha/rails'
 
 group :test do
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -366,6 +366,8 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
+    recaptcha (4.3.1)
+      json
     redcarpet (3.4.0)
     ref (2.0.0)
     refills (0.1.0)
@@ -571,6 +573,7 @@ DEPENDENCIES
   rake
   rb-fsevent
   rb-inotify
+  recaptcha
   redcarpet
   refills
   rspec-activemodel-mocks
@@ -597,4 +600,4 @@ DEPENDENCIES
   writeit-rails!
 
 BUNDLED WITH
-   1.14.3
+   1.14.6

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -11,6 +11,7 @@ class ReportsController < ApplicationController
     if verify_recaptcha && @report.save
       ReportNotifier.notify(@report).deliver_later
     else
+      # TODO: Show an error message because the CAPTCHA probably wasn't verified
       render 'new'
     end
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -12,7 +12,7 @@ class ReportsController < ApplicationController
       ReportNotifier.notify(@report).deliver_later
     else
       if flash[:recaptcha_error]
-        flash[:error] = "Sorry, we couldn't verify that you're not a robot. Make sure you click the <em>I'm not a robot</em> box below and try again.".html_safe
+        flash[:error] = "Sorry, we couldn’t verify that you’re not a robot. Make sure you click the <em>I’m not a robot</em> box below and try again.".html_safe
       end
 
       render 'new'

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -8,10 +8,14 @@ class ReportsController < ApplicationController
     @comment = Comment.visible.find(params[:comment_id])
     @report = @comment.reports.build(name: params[:report][:name], email: params[:report][:email], details: params[:report][:details])
 
-    if verify_recaptcha && @report.save
-      ReportNotifier.notify(@report).deliver_later
+    if verify_recaptcha
+      if @report.save
+        ReportNotifier.notify(@report).deliver_later
+      else
+        render 'new'
+      end
     else
-      # TODO: Show an error message because the CAPTCHA probably wasn't verified
+      flash[:error] = "Sorry, we couldn't verify that you're not a robot. Make sure you click the <em>I'm not a robot</em> box below and try again.".html_safe
       render 'new'
     end
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -6,16 +6,12 @@ class ReportsController < ApplicationController
 
   def create
     @comment = Comment.visible.find(params[:comment_id])
+    @report = @comment.reports.build(name: params[:report][:name], email: params[:report][:email], details: params[:report][:details])
 
-    # First check if the honeypot field has been filled out by a spam bot
-    # If so, make it look like things worked but don't actually do anything
-    if params[:little_sweety].blank?
-      @report = @comment.reports.build(name: params[:report][:name], email: params[:report][:email], details: params[:report][:details])
-      if @report.save
-        ReportNotifier.notify(@report).deliver_later
-      else
-        render 'new'
-      end
+    if verify_recaptcha && @report.save
+      ReportNotifier.notify(@report).deliver_later
+    else
+      render 'new'
     end
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -8,14 +8,13 @@ class ReportsController < ApplicationController
     @comment = Comment.visible.find(params[:comment_id])
     @report = @comment.reports.build(name: params[:report][:name], email: params[:report][:email], details: params[:report][:details])
 
-    if verify_recaptcha
-      if @report.save
-        ReportNotifier.notify(@report).deliver_later
-      else
-        render 'new'
-      end
+    if verify_recaptcha && @report.save
+      ReportNotifier.notify(@report).deliver_later
     else
-      flash[:error] = "Sorry, we couldn't verify that you're not a robot. Make sure you click the <em>I'm not a robot</em> box below and try again.".html_safe
+      if flash[:recaptcha_error]
+        flash[:error] = "Sorry, we couldn't verify that you're not a robot. Make sure you click the <em>I'm not a robot</em> box below and try again.".html_safe
+      end
+
       render 'new'
     end
   end

--- a/app/mailers/report_notifier.rb
+++ b/app/mailers/report_notifier.rb
@@ -4,7 +4,8 @@ class ReportNotifier < ActionMailer::Base
     @comment = report.comment
     mail(
       to: ENV["EMAIL_MODERATOR"],
-      from: "#{report.name} <#{report.email}>",
+      from: "#{report.name} <#{ENV["EMAIL_MODERATOR"]}>",
+      reply_to: "#{report.name} <#{report.email}>",
       subject: "PlanningAlerts: Abuse report"
     )
   end

--- a/app/views/reports/new.html.haml
+++ b/app/views/reports/new.html.haml
@@ -11,10 +11,6 @@
     = f.input :name, label: "Your name", placeholder: "e.g. Jane Citizen", input_html: { required: "required" }
     = f.input :email, label: "Your email", placeholder: "e.g. your@email.com", input_html: { required: "required" }
     = f.input :details, label: "Why should this comment be removed?", as: :text, input_html: { required: "required" }
-    -# This is a spam bot honeytrap. A human being should not be filling this in
-    -# It's not awesome for screenreaders though
-    %li{style: "display: none;"}
-      = label_tag :little_sweety, 'Little Sweety'
-      = text_field_tag :little_sweety, "", placeholder: "Please leave this blank"
+    = recaptcha_tags
   = f.actions do
     = f.action :submit, label: "Send report", button_html: { class: "button button-action" }

--- a/spec/features/comment_to_authority_spec.rb
+++ b/spec/features/comment_to_authority_spec.rb
@@ -213,7 +213,8 @@ feature "Give feedback" do
 
     expect(unread_emails_for("moderator@planningalerts.org.au").size).to eq(1)
     open_email("moderator@planningalerts.org.au")
-    expect(current_email).to be_delivered_from("Joe Reporter <reporter@foo.com>")
+    expect(current_email).to be_delivered_from("Joe Reporter <moderator@planningalerts.org.au>")
+    expect(current_email).to have_reply_to("Joe Reporter <reporter@foo.com>")
     expect(current_email).to have_subject("PlanningAlerts: Abuse report")
   end
 

--- a/spec/mailers/report_notifier_spec.rb
+++ b/spec/mailers/report_notifier_spec.rb
@@ -18,8 +18,12 @@ describe ReportNotifier do
     @notifier = ReportNotifier.notify(@report)
   end
   
-  it "should come from the reporter's email address" do
-    expect(@notifier.from).to eq(["reporter@foo.com"])
+  it "should come from the moderator's email address" do
+    expect(@notifier.from).to eq(["moderator@planningalerts.org.au"])
+  end
+
+  it "should have a replyto of the reporter's email address" do
+    expect(@notifier.reply_to).to eq(["reporter@foo.com"])
   end
   
   it "should go to the moderator email address" do


### PR DESCRIPTION
Before this change we were sending abuse reports with the reporter's
address as the from address. It's common that a domain with a DMARC
policy would make the report get hard bounced and then Cuttlefish would
blacklist all further reports so we'd never see them.

This changes the from address to our address and sets the reporter's
address as the reply_to. This means the messages should get delivered
and administrators can still just hit reply if they want to respond to
the reporter.

Fixes #689.