### PR TITLE
Two step contribution

### DIFF
--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -1,0 +1,2 @@
+class ContributorsController < ApplicationController
+end

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -1,2 +1,6 @@
 class ContributorsController < ApplicationController
+  def new
+    @contributor = Contributor.new
+  end
+
 end

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -1,4 +1,6 @@
 class ContributorsController < ApplicationController
+  before_action :check_if_feature_flag_is_on
+
   def new
     @contributor = Contributor.new
   end
@@ -8,6 +10,18 @@ class ContributorsController < ApplicationController
     if @contributor.save
       flash[:notice] = "Thank you"
       redirect_to root_url
+    end
+  end
+
+private
+
+  def contributor_params
+    params.require(:contributor).permit(:name, :email)
+  end
+
+  def check_if_feature_flag_is_on
+    unless ENV["CONTRIBUTE_COUNCILLORS_ENABLED"].present?
+      render "static/error_404", status: 404
     end
   end
 end

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -9,6 +9,8 @@ class ContributorsController < ApplicationController
     @contributor = Contributor.new(contributor_params)
     @suggested_councillor = SuggestedCouncillor.find(params[:contributor][:suggested_councillor_id])
     if @contributor.save
+      @suggested_councillor.contributor_id = @contributor.id
+      @suggested_councillor.save
       flash[:notice] = "Thank you"
       redirect_to root_url
     end

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -3,4 +3,11 @@ class ContributorsController < ApplicationController
     @contributor = Contributor.new
   end
 
+  def create
+    @contributor = Contributor.new
+    if @contributor.save
+      flash[:notice] = "Thank you"
+      redirect_to root_url
+    end
+  end
 end

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -6,7 +6,8 @@ class ContributorsController < ApplicationController
   end
 
   def create
-    @contributor = Contributor.new
+    @contributor = Contributor.new(contributor_params)
+    @suggested_councillor = SuggestedCouncillor.find(params[:contributor][:suggested_councillor_id])
     if @contributor.save
       flash[:notice] = "Thank you"
       redirect_to root_url

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -9,8 +9,7 @@ class ContributorsController < ApplicationController
     @contributor = Contributor.new(contributor_params)
     @suggested_councillor = SuggestedCouncillor.find(params[:contributor][:suggested_councillor_id])
     if @contributor.save
-      @suggested_councillor.contributor_id = @contributor.id
-      @suggested_councillor.save
+      @suggested_councillor.update(contributor: @contributor)
       flash[:notice] = "Thank you"
       redirect_to root_url
     end

--- a/app/controllers/suggested_councillors_controller.rb
+++ b/app/controllers/suggested_councillors_controller.rb
@@ -11,7 +11,6 @@ class SuggestedCouncillorsController < ApplicationController
     @suggested_councillor = @authority.suggested_councillors.build(suggested_councillor_params)
 
     if @suggested_councillor.save
-      flash[:notice] = "Thank you"
       redirect_to new_contributor_url(suggested_councillor_id: @suggested_councillor.id)
     else
       render :new

--- a/app/controllers/suggested_councillors_controller.rb
+++ b/app/controllers/suggested_councillors_controller.rb
@@ -4,7 +4,6 @@ class SuggestedCouncillorsController < ApplicationController
   def new
     @suggested_councillor = SuggestedCouncillor.new
     @authority = Authority.find_by_short_name_encoded!(params[:authority_id])
-    @contributor = Contributor.new
   end
 
   def create

--- a/app/controllers/suggested_councillors_controller.rb
+++ b/app/controllers/suggested_councillors_controller.rb
@@ -21,7 +21,7 @@ class SuggestedCouncillorsController < ApplicationController
 private
 
   def suggested_councillor_params
-    params.require(:suggested_councillor).permit(:name, :email, {contributor_attributes: [:name, :email]})
+    params.require(:suggested_councillor).permit(:name, :email)
   end
 
   def check_if_feature_flag_is_on

--- a/app/controllers/suggested_councillors_controller.rb
+++ b/app/controllers/suggested_councillors_controller.rb
@@ -12,7 +12,7 @@ class SuggestedCouncillorsController < ApplicationController
 
     if @suggested_councillor.save
       flash[:notice] = "Thank you"
-      redirect_to authority_url(@authority.short_name_encoded)
+      redirect_to new_contributor_url(suggested_councillor_id: @suggested_councillor.id)
     else
       render :new
     end

--- a/app/views/contributors/new.html.haml
+++ b/app/views/contributors/new.html.haml
@@ -1,0 +1,16 @@
+%h1 Thank you! Please tell us about yourself
+%h2 so we can send you a little note of appreciation and updates!
+
+= form_for @contributor do |f|
+  %fieldset
+    %legend
+      Please tell us who you are
+    = f.fields_for :contributor, @contributor do |contributor_field|
+      %p
+        = contributor_field.label :name
+        = contributor_field.text_field :name
+      %p
+        = contributor_field.label :email
+        = contributor_field.text_field :email
+    %p.button
+      = f.submit "Submit"

--- a/app/views/contributors/new.html.haml
+++ b/app/views/contributors/new.html.haml
@@ -4,7 +4,7 @@
   = f.hidden_field :suggested_councillor_id, value: params[:suggested_councillor_id]
   %fieldset
     %legend
-      %p Please tell us about yourself, so we can send you a little note of appreciation and updates about your contribution when it goes live.
+      Please tell us about yourself, so we can send you a little note of appreciation and updates about your contribution when it goes live.
       %p This field is optional.
       %p
         = f.label :name

--- a/app/views/contributors/new.html.haml
+++ b/app/views/contributors/new.html.haml
@@ -2,6 +2,7 @@
 %h2 so we can send you a little note of appreciation and updates!
 
 = form_for @contributor do |f|
+  = f.hidden_field :suggested_councillor_id, value: params[:suggested_councillor_id]
   %fieldset
     %legend
       Please tell us who you are

--- a/app/views/contributors/new.html.haml
+++ b/app/views/contributors/new.html.haml
@@ -1,11 +1,11 @@
-%h1 Thank you! Please tell us about yourself
-%h2 so we can send you a little note of appreciation and updates!
-
+%h1 Thank you!
+%p This data you contributed will be reviewd by an administrator, and go live shortly.
 = form_for @contributor do |f|
   = f.hidden_field :suggested_councillor_id, value: params[:suggested_councillor_id]
   %fieldset
     %legend
-      Please tell us who you are
+      %p Please tell us about yourself, so we can send you a little note of appreciation and updates about your contribution when it goes live.
+      %p This field is optional.
     = f.fields_for :contributor, @contributor do |contributor_field|
       %p
         = contributor_field.label :name
@@ -15,3 +15,4 @@
         = contributor_field.text_field :email
     %p.button
       = f.submit "Submit"
+    = link_to "I prefer not to", root_url

--- a/app/views/contributors/new.html.haml
+++ b/app/views/contributors/new.html.haml
@@ -1,10 +1,13 @@
 %h1 Thank you!
-%p This data you contributed will be reviewd by an administrator, and go live shortly.
+%p
+  This data you contributed will be reviewd
+  by an administrator, and go live shortly.
 = form_for @contributor do |f|
   = f.hidden_field :suggested_councillor_id, value: params[:suggested_councillor_id]
   %fieldset
     %legend
-      Please tell us about yourself, so we can send you a little note of appreciation and updates about your contribution when it goes live.
+      Please tell us about yourself, so we can send you a little note of appreciation
+      and updates about your contribution when it goes live.
       %p This field is optional.
       %p
         = f.label :name

--- a/app/views/contributors/new.html.haml
+++ b/app/views/contributors/new.html.haml
@@ -6,13 +6,12 @@
     %legend
       %p Please tell us about yourself, so we can send you a little note of appreciation and updates about your contribution when it goes live.
       %p This field is optional.
-    = f.fields_for :contributor, @contributor do |contributor_field|
       %p
-        = contributor_field.label :name
-        = contributor_field.text_field :name
+        = f.label :name
+        = f.text_field :name
       %p
-        = contributor_field.label :email
-        = contributor_field.text_field :email
+        = f.label :email
+        = f.text_field :email
     %p.button
       = f.submit "Submit"
     = link_to "I prefer not to", root_url

--- a/app/views/suggested_councillors/new.html.haml
+++ b/app/views/suggested_councillors/new.html.haml
@@ -11,15 +11,5 @@
       = f.label :email
       = f.text_field :email
 
-  %fieldset
-    %legend
-      Please tell us who you are
-    = f.fields_for :contributor, @contributor do |contributor_field|
-      %p
-        = contributor_field.label :name
-        = contributor_field.text_field :name
-      %p
-        = contributor_field.label :email
-        = contributor_field.text_field :email
     %p.button
       = f.submit "Submit"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,7 +109,6 @@ PlanningalertsApp::Application.routes.draw do
   end
   resources :contributors, only:[:new, :create]
 
-
   namespace :atdis do
     get :test
     post :test, action: 'test_redirect'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,8 @@ PlanningalertsApp::Application.routes.draw do
       get :test_feed
     end
   end
+  resources :contributors, only:[:new, :create]
+
 
   namespace :atdis do
     get :test

--- a/spec/features/user_contributes_new_councillor_spec.rb
+++ b/spec/features/user_contributes_new_councillor_spec.rb
@@ -17,7 +17,7 @@ feature "Contributing a new councillor for an authority" do
         test.run
       end
     end
-    
+
     scenario "on the contribution page" do
       visit new_authority_suggested_councillor_path(authority.short_name_encoded)
 
@@ -31,10 +31,14 @@ feature "Contributing a new councillor for an authority" do
         fill_in "Name", with: "Mila Gilic"
         fill_in "Email", with: "mgilic@casey.vic.gov.au"
       end
-      within_fieldset "Please tell us who you are" do
+
+      click_button "Submit"
+
+      within_fieldset "Please tell us about yourself, so we can send you a little note of appreciation and updates about your contribution when it goes live." do
         fill_in "Name", with: "Jane Contributes"
         fill_in "Email", with: "jane@contributor.com"
       end
+
       click_button "Submit"
 
       expect(page).to have_content "Thank you"


### PR DESCRIPTION
this fixes #1186 

I used a hidden_field to track the suggested_councillor_id in contributor table, and not sure if this is the best practice. Please let me know otherwise.