### PR TITLE
Council directory

### DIFF
--- a/app/admin/authorities.rb
+++ b/app/admin/authorities.rb
@@ -11,6 +11,7 @@ ActiveAdmin.register Authority do
     column "Name", :full_name
     column :state
     column :email
+    column :council_website
     column(:applications) { |a| a.applications.count }
     column(:total_comments) { |a| a.comments.count }
     column(:comments_to_councillors) { |a| a.comments.to_councillor.count }
@@ -26,6 +27,7 @@ ActiveAdmin.register Authority do
       row :short_name
       row :state
       row :email
+      row :council_website
       row :write_to_councillors_enabled
       row :population_2011
       row :morph_name
@@ -63,6 +65,7 @@ ActiveAdmin.register Authority do
     inputs "Details" do
       input :state
       input :email
+      input :council_website
       input :population_2011
       input :write_to_councillors_enabled
     end

--- a/db/migrate/20170707011439_add_council_website_url_to_authoritie.rb
+++ b/db/migrate/20170707011439_add_council_website_url_to_authoritie.rb
@@ -1,0 +1,5 @@
+class AddCouncilWebsiteUrlToAuthoritie < ActiveRecord::Migration
+  def change
+    add_column :authorities, :council_website, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170623024916) do
+ActiveRecord::Schema.define(version: 20170707011439) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "resource_id",   limit: 255,   null: false
@@ -105,6 +105,7 @@ ActiveRecord::Schema.define(version: 20170623024916) do
     t.text    "last_scraper_run_log",         limit: 65535
     t.string  "morph_name",                   limit: 255
     t.boolean "write_to_councillors_enabled",               default: false, null: false
+    t.string  "council_website",              limit: 255
   end
 
   add_index "authorities", ["short_name"], name: "short_name_unique", unique: true, using: :btree


### PR DESCRIPTION
This is a part of the #1182 to make it easier to search council website by creating a directly.

I added council_website column in the authorities table as well as the admin/authorities.rb
It seems like adding authorities to the date base is not an automated process?

Not sure of the next step. I'm guessing I can start making the tutorial page?  I very much appreciate your insight! @equivalentideas @henare 

