### PR TITLE
Contribution validation email

### DIFF
--- a/app/assets/stylesheets/partials/_form.scss
+++ b/app/assets/stylesheets/partials/_form.scss
@@ -55,6 +55,23 @@ textarea {
   }
 }
 
+// TODO: This form doesn't use the Semantic Form library (from formtastic gem) that our other forms do.
+//       We're actually writing over a lot of the css we get from that library for those forms,
+//       so for this new form we decided it would be less complex to use the vanilla rails form helper.
+//       The CSS from Semantic Form is technical debt at this point, and should be gradually removed as we touch
+//       each of those forms. These new styles could be the base for those styles.
+.councillor-contribution-form {
+  .field_with_errors {
+    input {
+      border-color: $form-error-color;
+    }
+
+    .councillor-contribution-error {
+      color: $form-error-color;
+    }
+  }
+}
+
 textarea {
   line-height: 1.5;
 }

--- a/app/controllers/councillor_contributions_controller.rb
+++ b/app/controllers/councillor_contributions_controller.rb
@@ -10,9 +10,7 @@ class CouncillorContributionsController < ApplicationController
       @councillor_contribution = CouncillorContribution.new
     end
 
-    if @councillor_contribution.suggested_councillors.empty? || @councillor_contribution.suggested_councillors.collect { |c| c.valid? }.exclude?(false)
-      @councillor_contribution.suggested_councillors.build({email: nil, name: nil})
-    end
+    @councillor_contribution.suggested_councillors.build({email: nil, name: nil}) if new_suggested_councillor_required?
   end
 
   def create
@@ -40,5 +38,9 @@ class CouncillorContributionsController < ApplicationController
       unless ENV["CONTRIBUTE_COUNCILLORS_ENABLED"].present?
         render "static/error_404", status: 404
       end
+  end
+
+  def new_suggested_councillor_required?
+    @councillor_contribution.suggested_councillors.empty? || @councillor_contribution.suggested_councillors.collect { |c| c.valid? }.exclude?(false)
   end
 end

--- a/app/controllers/councillor_contributions_controller.rb
+++ b/app/controllers/councillor_contributions_controller.rb
@@ -18,13 +18,14 @@ class CouncillorContributionsController < ApplicationController
     @authority = Authority.find_by_short_name_encoded!(params[:authority_id])
     @councillor_contribution = @authority.councillor_contributions.build(councillor_contribution_params)
 
+    if @councillor_contribution.suggested_councillors.empty?
+      @councillor_contribution.suggested_councillors.build({email: nil, name: nil})
+    end
+
     if @councillor_contribution.save
       redirect_to new_contributor_url(councillor_contribution_id: @councillor_contribution.id)
     else
       flash[:error] = "There's a problem with the information you entered. See the messages below and resolve the issue before submitting your councillors."
-      if @councillor_contribution.suggested_councillors.empty?
-        @councillor_contribution.suggested_councillors.build({email: nil, name: nil})
-      end
       render :new
     end
   end

--- a/app/controllers/councillor_contributions_controller.rb
+++ b/app/controllers/councillor_contributions_controller.rb
@@ -9,8 +9,9 @@ class CouncillorContributionsController < ApplicationController
     else
       @councillor_contribution = CouncillorContribution.new
     end
-
-    @councillor_contribution.suggested_councillors.build({email: nil, name: nil})
+    if @councillor_contribution.suggested_councillors.empty? || @councillor_contribution.suggested_councillors.collect { |c| c.valid? }.exclude?(false)
+      @councillor_contribution.suggested_councillors.build({email: nil, name: nil})
+    end
   end
 
   def create
@@ -20,6 +21,10 @@ class CouncillorContributionsController < ApplicationController
     if @councillor_contribution.save
       redirect_to new_contributor_url(councillor_contribution_id: @councillor_contribution.id)
     else
+      flash[:error] = "There's a problem with the information you entered. See the messages below and resolve the issue before submitting your councillors."
+      if @councillor_contribution.suggested_councillors.empty?
+        @councillor_contribution.suggested_councillors.build({email: nil, name: nil})
+      end
       render :new
     end
   end

--- a/app/controllers/councillor_contributions_controller.rb
+++ b/app/controllers/councillor_contributions_controller.rb
@@ -4,11 +4,12 @@ class CouncillorContributionsController < ApplicationController
   def new
     @authority = Authority.find_by_short_name_encoded!(params[:authority_id])
 
-    if params["councillor_contribution"]
-      @councillor_contribution = @authority.councillor_contributions.build(councillor_contribution_params)
-    else
-      @councillor_contribution = CouncillorContribution.new
-    end
+    @councillor_contribution =
+      if params["councillor_contribution"]
+        @authority.councillor_contributions.build(councillor_contribution_params)
+      else
+        CouncillorContribution.new
+      end
 
     @councillor_contribution.suggested_councillors.build({email: nil, name: nil}) if new_suggested_councillor_required?
   end

--- a/app/controllers/councillor_contributions_controller.rb
+++ b/app/controllers/councillor_contributions_controller.rb
@@ -9,6 +9,7 @@ class CouncillorContributionsController < ApplicationController
     else
       @councillor_contribution = CouncillorContribution.new
     end
+
     if @councillor_contribution.suggested_councillors.empty? || @councillor_contribution.suggested_councillors.collect { |c| c.valid? }.exclude?(false)
       @councillor_contribution.suggested_councillors.build({email: nil, name: nil})
     end

--- a/app/models/councillor_contribution.rb
+++ b/app/models/councillor_contribution.rb
@@ -3,4 +3,5 @@ class CouncillorContribution < ActiveRecord::Base
   belongs_to :authority
   has_many :suggested_councillors, inverse_of: :councillor_contribution
   accepts_nested_attributes_for :suggested_councillors, reject_if: :all_blank
+  validates_associated :suggested_councillors
 end

--- a/app/models/suggested_councillor.rb
+++ b/app/models/suggested_councillor.rb
@@ -2,4 +2,5 @@ class SuggestedCouncillor < ActiveRecord::Base
   has_one :authority, through: :councillor_contribution
   belongs_to :councillor_contribution
   validates :councillor_contribution, :name, :email, presence: true
+  validates_email_format_of :email, message: "must be a valid email address, e.g. jane@example.com"
 end

--- a/app/views/councillor_contributions/_contribution_form_input.html.haml
+++ b/app/views/councillor_contributions/_contribution_form_input.html.haml
@@ -4,6 +4,12 @@
       .suggested-councillor-input-group
         = suggested_councillor_field.label :name, "Full name", class: "councillor-contribution-label"
         = suggested_councillor_field.text_field :name
+        - if suggested_councillor.errors[:name].any?
+          = suggested_councillor_field.label :name, class: "councillor-contribution-error" do
+            = suggested_councillor.errors.full_messages_for(:name).to_sentence
       .suggested-councillor-input-group
         = suggested_councillor_field.label :email, class: "councillor-contribution-label"
         = suggested_councillor_field.text_field :email
+        - if suggested_councillor.errors[:email].any?
+          = suggested_councillor_field.label :email, class: "councillor-contribution-error" do
+            = suggested_councillor.errors.full_messages_for(:email).to_sentence

--- a/app/views/councillor_contributions/_contribution_form_input.html.haml
+++ b/app/views/councillor_contributions/_contribution_form_input.html.haml
@@ -1,6 +1,6 @@
 %fieldset
   .suggested-councillor-input-wrapper
-    = f.fields_for :suggested_councillors, @councillor_contribution.suggested_councillors.last do |suggested_councillor_field|
+    = f.fields_for :suggested_councillors, suggested_councillor do |suggested_councillor_field|
       .suggested-councillor-input-group
         = suggested_councillor_field.label :name, "Full name", class: "councillor-contribution-label"
         = suggested_councillor_field.text_field :name

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -1,9 +1,9 @@
 .councillor-contributions
   %h1.page-title Add a new councillor for #{@authority.full_name}
-  = form_for [@authority, @councillor_contribution], url: authority_councillor_contributions_path, html: { class: "councillor-contribution-form" } do |f|
+  = form_for [@authority, @councillor_contribution], url: authority_councillor_contributions_path(@authority.short_name_encoded), html: { class: "councillor-contribution-form" } do |f|
     .councillor-contribution-councillors
       - @councillor_contribution.suggested_councillors.each do |s|
         = render 'contribution_form_input', f: f, suggested_councillor: s
-      %button{formaction: new_authority_councillor_contribution_path, class: "button"} Add another councillor
+      %button{formaction: new_authority_councillor_contribution_path(@authority.short_name_encoded), class: "button"} Add another councillor
     .councillor-contribution-actions
       = f.submit "Submit #{pluralize(@councillor_contribution.suggested_councillors.length, "new councillor")}", class: "button-action"

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -1,23 +1,9 @@
 .councillor-contributions
   %h1.page-title Add a new councillor for #{@authority.full_name}
   = form_for [@authority, @councillor_contribution], url: authority_councillor_contributions_path, html: { class: "councillor-contribution-form" } do |f|
-    - @councillor_contribution.suggested_councillors[0...-1].each do |s|
-      = f.fields_for :suggested_councillors, @councillor_contribution.suggested_councillors.last do |suggested_councillor_field|
-        = suggested_councillor_field.hidden_field :name, value: s.name
-        = suggested_councillor_field.hidden_field :email, value: s.email
     .councillor-contribution-councillors
-      - if @councillor_contribution.suggested_councillors.many?
-        %ul
-          - @councillor_contribution.suggested_councillors[0...-1].each do |s|
-            %li
-              %dl.suggested-councillor-input-wrapper
-                .suggested-councillor-input-group
-                  %dt.councillor-contribution-label Full name
-                  %dd= s.name
-                .suggested-councillor-input-group
-                  %dt.councillor-contribution-label Email
-                  %dd= s.email
-      = render 'contribution_form_input', f: f
+      - @councillor_contribution.suggested_councillors.each do |s|
+        = render 'contribution_form_input', f: f, suggested_councillor: s
       %button{formaction: new_authority_councillor_contribution_path, class: "button"} Add another councillor
     .councillor-contribution-actions
       = f.submit "Submit #{pluralize(@councillor_contribution.suggested_councillors.length, "new councillor")}", class: "button-action"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -120,6 +120,10 @@ FactoryGirl.define do
   factory :suggested_councillor do
     name "Mila Gilic"
     email "mgilic@casey.vic.gov.au"
+    councillor_contribution
+  end
+
+  factory :councillor_contribution do
     association :authority
   end
 end

--- a/spec/features/user_contributes_new_councillor_spec.rb
+++ b/spec/features/user_contributes_new_councillor_spec.rb
@@ -18,6 +18,74 @@ feature "Contributing new councillors for an authority" do
       end
     end
 
+  context "when a person submits a councillor with all blank attributes" do
+    before :each do
+      visit new_authority_councillor_contribution_path(authority.short_name_encoded)
+
+      within ".councillor-contribution-councillors fieldset" do
+        fill_in "Full name", with: ""
+        fill_in "Email", with: ""
+      end
+
+      click_button "Submit"
+    end
+
+    it "displays an error message" do
+      pending("this is yet to be implemented, it needs to be clear to people what to do if they accidentally add an extra councillor fieldset before we prevent a blank one from being submitted")
+      expect(page).to have_content("Name can't be blank")
+      expect(page).to have_content("Email can't be blank")
+    end
+
+    it "does not go to the contributor information page" do
+      pending("this is yet to be implemented, it needs to be clear to people what to do if they accidentally add an extra councillor fieldset before we prevent a blank one from being submitted")
+      expect(page).to have_current_path(new_authority_councillor_contribution_path(authority.short_name_encoded))
+    end
+  end
+
+    context "when a person submits a blank email" do
+      before :each do
+        visit new_authority_councillor_contribution_path(authority.short_name_encoded)
+
+        within ".councillor-contribution-councillors fieldset" do
+          fill_in "Full name", with: "Mila Gilic"
+          fill_in "Email", with: ""
+        end
+
+        click_button "Submit"
+      end
+
+      it "displays an error message" do
+        expect(page).to have_content("Email can't be blank")
+      end
+
+      it "does not go into the list of the suggested councillors" do
+        expect(page).to have_no_content("Full name: Mila Gilic")
+        expect(page).to have_no_content("Email:")
+      end
+    end
+
+    context "when a person submit an invalid email" do
+      before :each do
+        visit new_authority_councillor_contribution_path(authority.short_name_encoded)
+
+        within ".councillor-contribution-councillors fieldset" do
+          fill_in "Full name", with: "Mila Gilic"
+          fill_in "Email", with: "mgilic.invalid"
+        end
+
+        click_button "Submit"
+      end
+
+      it "displays an error message" do
+        expect(page).to have_content("Email must be a valid email address, e.g. jane@example.com")
+      end
+
+      it "does not go into the list of the suggested councillors" do
+        expect(page).to have_no_content("Full name: Mila Gilic")
+        expect(page).to have_no_content("Email: mglic.invalid")
+      end
+    end
+
     it "successfully with three councillors and one blank councillor" do
       visit new_authority_councillor_contribution_path(authority.short_name_encoded)
 

--- a/spec/features/user_contributes_new_councillor_spec.rb
+++ b/spec/features/user_contributes_new_councillor_spec.rb
@@ -31,13 +31,11 @@ feature "Contributing new councillors for an authority" do
     end
 
     it "displays an error message" do
-      pending("this is yet to be implemented, it needs to be clear to people what to do if they accidentally add an extra councillor fieldset before we prevent a blank one from being submitted")
       expect(page).to have_content("Name can't be blank")
       expect(page).to have_content("Email can't be blank")
     end
 
     it "does not go to the contributor information page" do
-      pending("this is yet to be implemented, it needs to be clear to people what to do if they accidentally add an extra councillor fieldset before we prevent a blank one from being submitted")
       expect(page).to have_content "Add a new councillor for Casey City Council"
     end
   end

--- a/spec/features/user_contributes_new_councillor_spec.rb
+++ b/spec/features/user_contributes_new_councillor_spec.rb
@@ -84,33 +84,52 @@ feature "Contributing new councillors for an authority" do
       end
     end
 
-    it "successfully with three councillors and one blank councillor" do
-      visit new_authority_councillor_contribution_path(authority.short_name_encoded)
+    context "with three councillors and one blank councillor" do
+      before :each do
+        visit new_authority_councillor_contribution_path(authority.short_name_encoded)
 
-      within "fieldset" do
-        fill_in "Full name", with: "Mila Gilic"
-        fill_in "Email", with: "mgilic@casey.vic.gov.au"
+        within "fieldset" do
+          fill_in "Full name", with: "Mila Gilic"
+          fill_in "Email", with: "mgilic@casey.vic.gov.au"
+        end
+
+        click_button "Add another councillor"
+
+        within "fieldset:nth-child(2)" do
+          fill_in "Full name", with: "Rosalie Crestani"
+          fill_in "Email", with: "rcrestani@casey.vic.gov.au"
+        end
+
+        click_button "Add another councillor"
+
+        within "fieldset:nth-child(3)" do
+          fill_in "Full name", with: "Rosalie Crestani"
+          fill_in "Email", with: "rcrestani@casey.vic.gov.au"
+        end
+
+        click_button "Add another councillor"
+
+        click_button "Submit 4 new councillors"
       end
 
-      click_button "Add another councillor"
-
-      within "fieldset:nth-child(2)" do
-        fill_in "Full name", with: "Rosalie Crestani"
-        fill_in "Email", with: "rcrestani@casey.vic.gov.au"
+      # TODO: This really should return the blank councillor as invalid.
+      #       but the person then needs a way to remove it if they added the
+      #       extra councillor by accident and they don't want to submit it.
+      #       Remove this once the two in exchange for the two pending tests below.
+      it "successfully" do
+        expect(page).to have_content "Thank you"
       end
 
-      click_button "Add another councillor"
-
-      within "fieldset:nth-child(3)" do
-        fill_in "Full name", with: "Rosalie Crestani"
-        fill_in "Email", with: "rcrestani@casey.vic.gov.au"
+      it "displays an error message" do
+        pending("this is yet to be implemented, it needs to be clear to people what to do if they accidentally add an extra councillor fieldset before we prevent a blank one from being submitted")
+        expect(page).to have_content("Name can't be blank")
+        expect(page).to have_content("Email can't be blank")
       end
 
-      click_button "Add another councillor"
-
-      click_button "Submit 4 new councillors"
-
-      expect(page).to have_content "Thank you"
+      it "does not go to the contributor information page" do
+        pending("this is yet to be implemented, it needs to be clear to people what to do if they accidentally add an extra councillor fieldset before we prevent a blank one from being submitted")
+        expect(page).to have_content "Add a new councillor for Casey City Council"
+      end
     end
 
     it "successfully with three councillors" do

--- a/spec/features/user_contributes_new_councillor_spec.rb
+++ b/spec/features/user_contributes_new_councillor_spec.rb
@@ -38,7 +38,7 @@ feature "Contributing new councillors for an authority" do
 
     it "does not go to the contributor information page" do
       pending("this is yet to be implemented, it needs to be clear to people what to do if they accidentally add an extra councillor fieldset before we prevent a blank one from being submitted")
-      expect(page).to have_current_path(new_authority_councillor_contribution_path(authority.short_name_encoded))
+      expect(page).to have_content "Add a new councillor for Casey City Council"
     end
   end
 

--- a/spec/features/user_contributes_new_councillor_spec.rb
+++ b/spec/features/user_contributes_new_councillor_spec.rb
@@ -21,21 +21,21 @@ feature "Contributing new councillors for an authority" do
     it "successfully with three councillors and one blank councillor" do
       visit new_authority_councillor_contribution_path(authority.short_name_encoded)
 
-      within ".councillor-contribution-councillors fieldset" do
+      within "fieldset" do
         fill_in "Full name", with: "Mila Gilic"
         fill_in "Email", with: "mgilic@casey.vic.gov.au"
       end
 
       click_button "Add another councillor"
 
-      within ".councillor-contribution-councillors fieldset" do
+      within "fieldset:nth-child(2)" do
         fill_in "Full name", with: "Rosalie Crestani"
         fill_in "Email", with: "rcrestani@casey.vic.gov.au"
       end
 
       click_button "Add another councillor"
 
-      within ".councillor-contribution-councillors fieldset" do
+      within "fieldset:nth-child(3)" do
         fill_in "Full name", with: "Rosalie Crestani"
         fill_in "Email", with: "rcrestani@casey.vic.gov.au"
       end
@@ -50,21 +50,21 @@ feature "Contributing new councillors for an authority" do
     it "successfully with three councillors" do
       visit new_authority_councillor_contribution_path(authority.short_name_encoded)
 
-      within ".councillor-contribution-councillors fieldset" do
+      within "fieldset" do
         fill_in "Full name", with: "Mila Gilic"
         fill_in "Email", with: "mgilic@casey.vic.gov.au"
       end
 
       click_button "Add another councillor"
 
-      within ".councillor-contribution-councillors fieldset" do
+      within "fieldset:nth-child(2)" do
         fill_in "Full name", with: "Rosalie Crestani"
         fill_in "Email", with: "rcrestani@casey.vic.gov.au"
       end
 
       click_button "Add another councillor"
 
-      within ".councillor-contribution-councillors fieldset" do
+      within "fieldset:nth-child(3)" do
         fill_in "Full name", with: "Rosalie Crestani"
         fill_in "Email", with: "rcrestani@casey.vic.gov.au"
       end
@@ -72,6 +72,31 @@ feature "Contributing new councillors for an authority" do
       click_button "Submit 3 new councillors"
 
       expect(page).to have_content "Thank you"
+    end
+
+    it "successfully with councillors being edited after they're first added" do
+      visit new_authority_councillor_contribution_path(authority.short_name_encoded)
+
+      within "fieldset:first-child" do
+        fill_in "Full name", with: "Original Councillor"
+        fill_in "Email", with: "ngelic@casey.vic.gov.au"
+      end
+
+      click_button "Add another councillor"
+
+      find_field("Full name", with: "Original Councillor")
+      find_field("Email", with: "ngelic@casey.vic.gov.au")
+
+      within "fieldset:first-child" do
+        fill_in "Full name", with: "Changed Councillor"
+        fill_in "Email", with:"mgilic@casey.vic.gov.au"
+      end
+
+      click_button "Submit 2 new councillors"
+
+      expect(page).to have_content "Thank you"
+      expect(SuggestedCouncillor.find_by(name: "Original Councillor")).to be_nil
+      expect(SuggestedCouncillor.find_by(name: "Changed Councillor")).to be_present
     end
   end
 end

--- a/spec/features/user_contributes_new_councillor_spec.rb
+++ b/spec/features/user_contributes_new_councillor_spec.rb
@@ -18,7 +18,7 @@ feature "Contributing new councillors for an authority" do
       end
     end
 
-  context "when a person submits a councillor with all blank attributes" do
+  context "when a person submits one councillor with all blank attributes" do
     before :each do
       visit new_authority_councillor_contribution_path(authority.short_name_encoded)
 

--- a/spec/models/councillor_contribution_spec.rb
+++ b/spec/models/councillor_contribution_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+
+describe CouncillorContribution do
+  it "is not valid with an invalid suggested_councillor" do
+    suggested_councillor = build(:suggested_councillor)
+    councillor_contribution = build(:councillor_contribution, suggested_councillors: [suggested_councillor])
+
+    allow(suggested_councillor).to receive(:valid?).and_return false
+
+    expect(councillor_contribution).to_not be_valid
+  end
+end

--- a/spec/models/suggested_councillor_spec.rb
+++ b/spec/models/suggested_councillor_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require "validates_email_format_of/rspec_matcher"
 
 RSpec.describe SuggestedCouncillor, type: :model do
   describe "is invalid without an email" do
@@ -24,5 +25,9 @@ RSpec.describe SuggestedCouncillor, type: :model do
   describe "is invalid without an councillor_contribution_id" do
     subject { SuggestedCouncillor.new(name: "Milla", email: "test@test.com", councillor_contribution_id: nil) }
     it { is_expected.to_not be_valid }
+  end
+
+  describe "must have a valid email attribute" do
+    it { expect(SuggestedCouncillor.new).to validate_email_format_of(:email).with_message("must be a valid email address, e.g. jane@example.com") }
   end
 end

--- a/spec/views/councillor_contributions/new_spec.rb
+++ b/spec/views/councillor_contributions/new_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe "councillor_contributions/new" do
+  it "displays the full name of the assigned authority" do
+    assign(:authority, create(:authority, full_name: "Casey City Council"))
+    assign(:councillor_contribution, CouncillorContribution.new)
+
+    render
+
+    expect(rendered).to have_content("Casey City Council")
+  end
+end


### PR DESCRIPTION
This is a part of #1198 

I added `validates_email_format_of` gem in `suggested_councillor` controller.

As @equivalentideas suggested, I used `empty?` and `valid?` method in the `suggested_councillor_controller#new` to prevent refreshing the form/displaying the invalid contribution under "The councillor(s) you submitted" .

It does the job, but some more work is needed (test, error message, layout)

Try to submit invalid email format (without @email.com format)
<img width="502" alt="screen shot 2017-07-31 at 10 58 15 pm" src="https://user-images.githubusercontent.com/12241881/28807577-386f04f6-7644-11e7-84bf-466b2e67481e.png">

it does not accept the input, but it breaks the layout because of the error message div.
<img width="473" alt="screen shot 2017-07-31 at 10 58 28 pm" src="https://user-images.githubusercontent.com/12241881/28807627-7ce1db9a-7644-11e7-8d7c-452bc14ba431.png">
<img width="608" alt="screen shot 2017-07-31 at 10 59 04 pm" src="https://user-images.githubusercontent.com/12241881/28807633-826efc82-7644-11e7-8c24-f79f18f436cc.png">

if the email format is right, it refresh the form and display the contribution.
<img width="533" alt="screen shot 2017-07-31 at 10 59 28 pm" src="https://user-images.githubusercontent.com/12241881/28807647-97a9f1ce-7644-11e7-91f3-b84589f2f86c.png">


