### PR TITLE
Add basic styles to the councillor contribution form

### DIFF
--- a/app/assets/stylesheets/partials/_form.scss
+++ b/app/assets/stylesheets/partials/_form.scss
@@ -221,3 +221,4 @@ form.donate {
 @import "special_forms/autocomplete";
 @import "special_forms/comment_form";
 @import "special_forms/payment_form";
+@import "special_forms/councillor_contribution_form";

--- a/app/assets/stylesheets/partials/_grid.scss
+++ b/app/assets/stylesheets/partials/_grid.scss
@@ -515,7 +515,6 @@
 }
 
 .councillor-contribution-form {
-  dl,
   .suggested-councillor-input-wrapper {
     @include at-breakpoint(30em) {
       display: flex;

--- a/app/assets/stylesheets/partials/_grid.scss
+++ b/app/assets/stylesheets/partials/_grid.scss
@@ -504,3 +504,14 @@
     }
   }
 }
+
+.councillor-contributions {
+  box-sizing: border-box;
+
+  @include at-breakpoint(60em) {
+    @include span-columns(8, 12);
+    float: none;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}

--- a/app/assets/stylesheets/partials/_grid.scss
+++ b/app/assets/stylesheets/partials/_grid.scss
@@ -515,13 +515,15 @@
 }
 
 .councillor-contribution-form {
+  dl,
   fieldset {
     display: flex;
     justify-content: space-between;
   }
 
   .suggested-councillor-input-group {
-    flex: 1 0 auto;
+    width: 50%;
+    box-sizing: border-box;
   }
 
   input {
@@ -530,11 +532,13 @@
 }
 
 .suggested-councillor-input-group {
+  padding-right: 1em;
+
   input {
     width: 100%;
   }
 
   & + & {
-    margin-left: 2em;
+    padding-right: 0;
   }
 }

--- a/app/assets/stylesheets/partials/_grid.scss
+++ b/app/assets/stylesheets/partials/_grid.scss
@@ -506,12 +506,35 @@
 }
 
 .councillor-contributions {
-  box-sizing: border-box;
-
   @include at-breakpoint(60em) {
     @include span-columns(8, 12);
     float: none;
     margin-left: auto;
     margin-right: auto;
+  }
+}
+
+.councillor-contribution-form {
+  fieldset {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .suggested-councillor-input-group {
+    flex: 1 0 auto;
+  }
+
+  input {
+    box-sizing: border-box;
+  }
+}
+
+.suggested-councillor-input-group {
+  input {
+    width: 100%;
+  }
+
+  & + & {
+    margin-left: 2em;
   }
 }

--- a/app/assets/stylesheets/partials/_grid.scss
+++ b/app/assets/stylesheets/partials/_grid.scss
@@ -517,13 +517,17 @@
 .councillor-contribution-form {
   dl,
   fieldset {
-    display: flex;
-    justify-content: space-between;
+    @include at-breakpoint(30em) {
+      display: flex;
+      justify-content: space-between;
+    }
   }
 
   .suggested-councillor-input-group {
-    width: 50%;
-    box-sizing: border-box;
+    @include at-breakpoint(30em) {
+      width: 50%;
+      box-sizing: border-box;
+    }
   }
 
   input {
@@ -532,13 +536,17 @@
 }
 
 .suggested-councillor-input-group {
-  padding-right: 1em;
+  @include at-breakpoint(30em) {
+    padding-right: 1em;
+  }
 
   input {
     width: 100%;
   }
 
   & + & {
-    padding-right: 0;
+    @include at-breakpoint(30em) {
+      padding-right: 0;
+    }
   }
 }

--- a/app/assets/stylesheets/partials/_grid.scss
+++ b/app/assets/stylesheets/partials/_grid.scss
@@ -516,7 +516,7 @@
 
 .councillor-contribution-form {
   dl,
-  fieldset {
+  .suggested-councillor-input-wrapper {
     @include at-breakpoint(30em) {
       display: flex;
       justify-content: space-between;

--- a/app/assets/stylesheets/partials/special_forms/_councillor_contribution_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_councillor_contribution_form.scss
@@ -22,3 +22,11 @@
     display: none;
   }
 }
+
+.councillor-contribution-councillors {
+  padding-bottom: 2em;
+}
+
+.councillor-contribution-actions {
+  text-align: right;
+}

--- a/app/assets/stylesheets/partials/special_forms/_councillor_contribution_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_councillor_contribution_form.scss
@@ -3,7 +3,7 @@
 //       There is probably a refactor to make these the base/raw form styles
 //       and to move them into _form.scss
 .councillor-contribution-form {
-  label {
+  .councillor-contribution-label {
     display: block;
     margin: .75em 0 .25em;
     padding: 0;
@@ -24,6 +24,12 @@
 
   fieldset {
     margin-bottom: 1em;
+  }
+
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
   }
 }
 

--- a/app/assets/stylesheets/partials/special_forms/_councillor_contribution_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_councillor_contribution_form.scss
@@ -35,6 +35,11 @@
 
 .councillor-contribution-councillors {
   padding-bottom: 2em;
+
+  input,
+  dd {
+    font-size: 1.2em;
+  }
 }
 
 .councillor-contribution-actions {

--- a/app/assets/stylesheets/partials/special_forms/_councillor_contribution_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_councillor_contribution_form.scss
@@ -1,0 +1,24 @@
+// TODO: These forms styles are very repetitive with #new_add_comment and .formtastic child styles
+//       They just don't have the .formatastic overrides.
+//       There is probably a refactor to make these the base/raw form styles
+//       and to move them into _form.scss
+.councillor-contribution-form {
+  label {
+    display: block;
+    margin: .75em 0 .25em;
+    padding: 0;
+    font-size: 1em;
+    font-weight: 500;
+  }
+
+  input {
+    display: block;
+    padding: .25em;
+    font-family: $blueprint-font-family;
+    font-size: 100%;
+  }
+
+  [aria-hidden="true"] {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/partials/special_forms/_councillor_contribution_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_councillor_contribution_form.scss
@@ -21,6 +21,10 @@
   [aria-hidden="true"] {
     display: none;
   }
+
+  fieldset {
+    margin-bottom: 1em;
+  }
 }
 
 .councillor-contribution-councillors {

--- a/app/assets/stylesheets/partials/special_forms/_councillor_contribution_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_councillor_contribution_form.scss
@@ -18,10 +18,6 @@
     font-size: 100%;
   }
 
-  [aria-hidden="true"] {
-    display: none;
-  }
-
   fieldset {
     margin-bottom: 1em;
   }

--- a/app/assets/stylesheets/partials/special_forms/_councillor_contribution_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_councillor_contribution_form.scss
@@ -40,6 +40,10 @@
   dd {
     font-size: 1.2em;
   }
+
+  dt {
+    color: $cool-highlight;
+  }
 }
 
 .councillor-contribution-actions {

--- a/app/views/councillor_contributions/_contribution_form_input.html.haml
+++ b/app/views/councillor_contributions/_contribution_form_input.html.haml
@@ -2,8 +2,8 @@
   %legend Add a councillor
   = f.fields_for :suggested_councillors, @councillor_contribution.suggested_councillors.last do |suggested_councillor_field|
     .suggested-councillor-input-group
-      = suggested_councillor_field.label :name, "Full name"
+      = suggested_councillor_field.label :name, "Full name", class: "councillor-contribution-label"
       = suggested_councillor_field.text_field :name
     .suggested-councillor-input-group
-      = suggested_councillor_field.label :email
+      = suggested_councillor_field.label :email, class: "councillor-contribution-label"
       = suggested_councillor_field.text_field :email

--- a/app/views/councillor_contributions/_contribution_form_input.html.haml
+++ b/app/views/councillor_contributions/_contribution_form_input.html.haml
@@ -1,5 +1,4 @@
 %fieldset
-  %legend Add a councillor
   = f.fields_for :suggested_councillors, @councillor_contribution.suggested_councillors.last do |suggested_councillor_field|
     .suggested-councillor-input-group
       = suggested_councillor_field.label :name, "Full name", class: "councillor-contribution-label"

--- a/app/views/councillor_contributions/_contribution_form_input.html.haml
+++ b/app/views/councillor_contributions/_contribution_form_input.html.haml
@@ -1,7 +1,9 @@
 %fieldset
   %legend Add a councillor
   = f.fields_for :suggested_councillors, @councillor_contribution.suggested_councillors.last do |suggested_councillor_field|
-    = suggested_councillor_field.label :name
-    = suggested_councillor_field.text_field :name
-    = suggested_councillor_field.label :email
-    = suggested_councillor_field.text_field :email
+    .suggested-councillor-input-group
+      = suggested_councillor_field.label :name
+      = suggested_councillor_field.text_field :name
+    .suggested-councillor-input-group
+      = suggested_councillor_field.label :email
+      = suggested_councillor_field.text_field :email

--- a/app/views/councillor_contributions/_contribution_form_input.html.haml
+++ b/app/views/councillor_contributions/_contribution_form_input.html.haml
@@ -1,8 +1,9 @@
 %fieldset
-  = f.fields_for :suggested_councillors, @councillor_contribution.suggested_councillors.last do |suggested_councillor_field|
-    .suggested-councillor-input-group
-      = suggested_councillor_field.label :name, "Full name", class: "councillor-contribution-label"
-      = suggested_councillor_field.text_field :name
-    .suggested-councillor-input-group
-      = suggested_councillor_field.label :email, class: "councillor-contribution-label"
-      = suggested_councillor_field.text_field :email
+  .suggested-councillor-input-wrapper
+    = f.fields_for :suggested_councillors, @councillor_contribution.suggested_councillors.last do |suggested_councillor_field|
+      .suggested-councillor-input-group
+        = suggested_councillor_field.label :name, "Full name", class: "councillor-contribution-label"
+        = suggested_councillor_field.text_field :name
+      .suggested-councillor-input-group
+        = suggested_councillor_field.label :email, class: "councillor-contribution-label"
+        = suggested_councillor_field.text_field :email

--- a/app/views/councillor_contributions/_contribution_submit_buttons.html.haml
+++ b/app/views/councillor_contributions/_contribution_submit_buttons.html.haml
@@ -1,2 +1,2 @@
-%button{:formaction => new_authority_councillor_contribution_path} Add another councillor
+%button{formaction: new_authority_councillor_contribution_path, class: "button"} Add another councillor
 = f.submit "Submit #{@councillor_contribution.suggested_councillors.length} new councillors", class: "button-action"

--- a/app/views/councillor_contributions/_contribution_submit_buttons.html.haml
+++ b/app/views/councillor_contributions/_contribution_submit_buttons.html.haml
@@ -1,2 +1,0 @@
-%button{formaction: new_authority_councillor_contribution_path, class: "button"} Add another councillor
-= f.submit "Submit #{@councillor_contribution.suggested_councillors.length} new councillors", class: "button-action"

--- a/app/views/councillor_contributions/_contribution_submit_buttons.html.haml
+++ b/app/views/councillor_contributions/_contribution_submit_buttons.html.haml
@@ -1,2 +1,2 @@
 %button{:formaction => new_authority_councillor_contribution_path} Add another councillor
-= f.submit "Submit #{@councillor_contribution.suggested_councillors.length} new councillors"
+= f.submit "Submit #{@councillor_contribution.suggested_councillors.length} new councillors", class: "button-action"

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -12,10 +12,12 @@
           - @councillor_contribution.suggested_councillors[0...-1].each do |s|
             %li
               %dl
-                %dt Full name
-                %dd= s.name
-                %dt Email
-                %dd= s.email
+                .suggested-councillor-input-group
+                  %dt.councillor-contribution-label Full name
+                  %dd= s.name
+                .suggested-councillor-input-group
+                  %dt.councillor-contribution-label Email
+                  %dd= s.email
       = render 'contribution_form_input', f: f
       %button{formaction: new_authority_councillor_contribution_path, class: "button"} Add another councillor
     .councillor-contribution-actions

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -1,19 +1,21 @@
 %h1.page-title Add a new councillor for #{@authority.full_name}
-- if @councillor_contribution.suggested_councillors.many?
-  %h2 The councillor(s) you submitted:
-  %ul
-    - @councillor_contribution.suggested_councillors[0...-1].each do |s|
-      %li
-        %dl
-          %dt Name
-          %dd= s.name
-          %dt Email
-          %dd= s.email
 = form_for [@authority, @councillor_contribution], url: authority_councillor_contributions_path, html: { class: "councillor-contribution-form" } do |f|
   - @councillor_contribution.suggested_councillors[0...-1].each do |s|
     = f.fields_for :suggested_councillors, @councillor_contribution.suggested_councillors.last do |suggested_councillor_field|
       = suggested_councillor_field.hidden_field :name, value: s.name
       = suggested_councillor_field.hidden_field :email, value: s.email
-  = render 'contribution_form_input', f: f
-  %button{formaction: new_authority_councillor_contribution_path, class: "button"} Add another councillor
-  = f.submit "Submit #{@councillor_contribution.suggested_councillors.length} new councillors", class: "button-action"
+  .councillor-contribution-councillors
+    - if @councillor_contribution.suggested_councillors.many?
+      %h2 The councillor(s) you submitted:
+      %ul
+        - @councillor_contribution.suggested_councillors[0...-1].each do |s|
+          %li
+            %dl
+              %dt Name
+              %dd= s.name
+              %dt Email
+              %dd= s.email
+    = render 'contribution_form_input', f: f
+    %button{formaction: new_authority_councillor_contribution_path, class: "button"} Add another councillor
+  .councillor-contribution-actions
+    = f.submit "Submit #{@councillor_contribution.suggested_councillors.length} new councillors", class: "button-action"

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -9,7 +9,7 @@
           %dd= s.name
           %dt Email
           %dd= s.email
-= form_for [@authority, @councillor_contribution], url: authority_councillor_contributions_path do |f|
+= form_for [@authority, @councillor_contribution], url: authority_councillor_contributions_path, html: { class: "councillor-contribution-form" } do |f|
   - @councillor_contribution.suggested_councillors[0...-1].each do |s|
     = f.fields_for :suggested_councillors, @councillor_contribution.suggested_councillors.last do |suggested_councillor_field|
       = suggested_councillor_field.hidden_field :name, value: s.name

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -7,7 +7,6 @@
         = suggested_councillor_field.hidden_field :email, value: s.email
     .councillor-contribution-councillors
       - if @councillor_contribution.suggested_councillors.many?
-        %h2 The councillor(s) you submitted:
         %ul
           - @councillor_contribution.suggested_councillors[0...-1].each do |s|
             %li

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -1,4 +1,4 @@
-%h1 Add a new councillor for #{@authority.full_name}
+%h1.page-title Add a new councillor for #{@authority.full_name}
 - if @councillor_contribution.suggested_councillors.many?
   %h2 The councillor(s) you submitted:
   %ul

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -1,21 +1,22 @@
-%h1.page-title Add a new councillor for #{@authority.full_name}
-= form_for [@authority, @councillor_contribution], url: authority_councillor_contributions_path, html: { class: "councillor-contribution-form" } do |f|
-  - @councillor_contribution.suggested_councillors[0...-1].each do |s|
-    = f.fields_for :suggested_councillors, @councillor_contribution.suggested_councillors.last do |suggested_councillor_field|
-      = suggested_councillor_field.hidden_field :name, value: s.name
-      = suggested_councillor_field.hidden_field :email, value: s.email
-  .councillor-contribution-councillors
-    - if @councillor_contribution.suggested_councillors.many?
-      %h2 The councillor(s) you submitted:
-      %ul
-        - @councillor_contribution.suggested_councillors[0...-1].each do |s|
-          %li
-            %dl
-              %dt Name
-              %dd= s.name
-              %dt Email
-              %dd= s.email
-    = render 'contribution_form_input', f: f
-    %button{formaction: new_authority_councillor_contribution_path, class: "button"} Add another councillor
-  .councillor-contribution-actions
-    = f.submit "Submit #{@councillor_contribution.suggested_councillors.length} new councillors", class: "button-action"
+.councillor-contributions
+  %h1.page-title Add a new councillor for #{@authority.full_name}
+  = form_for [@authority, @councillor_contribution], url: authority_councillor_contributions_path, html: { class: "councillor-contribution-form" } do |f|
+    - @councillor_contribution.suggested_councillors[0...-1].each do |s|
+      = f.fields_for :suggested_councillors, @councillor_contribution.suggested_councillors.last do |suggested_councillor_field|
+        = suggested_councillor_field.hidden_field :name, value: s.name
+        = suggested_councillor_field.hidden_field :email, value: s.email
+    .councillor-contribution-councillors
+      - if @councillor_contribution.suggested_councillors.many?
+        %h2 The councillor(s) you submitted:
+        %ul
+          - @councillor_contribution.suggested_councillors[0...-1].each do |s|
+            %li
+              %dl
+                %dt Name
+                %dd= s.name
+                %dt Email
+                %dd= s.email
+      = render 'contribution_form_input', f: f
+      %button{formaction: new_authority_councillor_contribution_path, class: "button"} Add another councillor
+    .councillor-contribution-actions
+      = f.submit "Submit #{@councillor_contribution.suggested_councillors.length} new councillors", class: "button-action"

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -10,7 +10,7 @@
         %ul
           - @councillor_contribution.suggested_councillors[0...-1].each do |s|
             %li
-              %dl
+              %dl.suggested-councillor-input-wrapper
                 .suggested-councillor-input-group
                   %dt.councillor-contribution-label Full name
                   %dd= s.name

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -15,4 +15,5 @@
       = suggested_councillor_field.hidden_field :name, value: s.name
       = suggested_councillor_field.hidden_field :email, value: s.email
   = render 'contribution_form_input', f: f
-  = render 'contribution_submit_buttons', f: f
+  %button{formaction: new_authority_councillor_contribution_path, class: "button"} Add another councillor
+  = f.submit "Submit #{@councillor_contribution.suggested_councillors.length} new councillors", class: "button-action"

--- a/spec/features/user_contributes_new_councillor_spec.rb
+++ b/spec/features/user_contributes_new_councillor_spec.rb
@@ -27,7 +27,7 @@ feature "Contributing new councillors for an authority" do
     it "works successfully when the contributor provides their information" do
       visit new_authority_councillor_contribution_path(authority.short_name_encoded)
 
-      within_fieldset "Add a councillor" do
+      within ".councillor-contribution-councillors fieldset" do
         fill_in "Full name", with: "Mila Gilic"
         fill_in "Email", with: "mgilic@casey.vic.gov.au"
       end
@@ -47,7 +47,7 @@ feature "Contributing new councillors for an authority" do
     it "works successfully without contributor information" do
       visit new_authority_councillor_contribution_path(authority.short_name_encoded)
 
-      within_fieldset "Add a councillor" do
+      within ".councillor-contribution-councillors fieldset" do
         fill_in "Full name", with: "Mila Gilic"
         fill_in "Email", with: "mgilic@casey.vic.gov.au"
       end
@@ -57,7 +57,7 @@ feature "Contributing new councillors for an authority" do
       expect(page).to have_content "Mila Gilic"
       expect(page).to have_content "mgilic@casey.vic.gov.au"
 
-      within_fieldset "Add a councillor" do
+      within ".councillor-contribution-councillors fieldset" do
         fill_in "Full name", with: "Rosalie Crestani"
         fill_in "Email", with: "rcrestani@casey.vic.gov.au"
       end
@@ -70,21 +70,21 @@ feature "Contributing new councillors for an authority" do
     it "successfully with three councillors and one blank councillor" do
       visit new_authority_councillor_contribution_path(authority.short_name_encoded)
 
-      within_fieldset "Add a councillor" do
+      within ".councillor-contribution-councillors fieldset" do
         fill_in "Full name", with: "Mila Gilic"
         fill_in "Email", with: "mgilic@casey.vic.gov.au"
       end
 
       click_button "Add another councillor"
 
-      within_fieldset "Add a councillor" do
+      within ".councillor-contribution-councillors fieldset" do
         fill_in "Full name", with: "Rosalie Crestani"
         fill_in "Email", with: "rcrestani@casey.vic.gov.au"
       end
 
       click_button "Add another councillor"
 
-      within_fieldset "Add a councillor" do
+      within ".councillor-contribution-councillors fieldset" do
         fill_in "Full name", with: "Rosalie Crestani"
         fill_in "Email", with: "rcrestani@casey.vic.gov.au"
       end
@@ -100,21 +100,21 @@ feature "Contributing new councillors for an authority" do
     it "successfully with three councillors" do
       visit new_authority_councillor_contribution_path(authority.short_name_encoded)
 
-      within_fieldset "Add a councillor" do
+      within ".councillor-contribution-councillors fieldset" do
         fill_in "Full name", with: "Mila Gilic"
         fill_in "Email", with: "mgilic@casey.vic.gov.au"
       end
 
       click_button "Add another councillor"
 
-      within_fieldset "Add a councillor" do
+      within ".councillor-contribution-councillors fieldset" do
         fill_in "Full name", with: "Rosalie Crestani"
         fill_in "Email", with: "rcrestani@casey.vic.gov.au"
       end
 
       click_button "Add another councillor"
 
-      within_fieldset "Add a councillor" do
+      within ".councillor-contribution-councillors fieldset" do
         fill_in "Full name", with: "Rosalie Crestani"
         fill_in "Email", with: "rcrestani@casey.vic.gov.au"
       end


### PR DESCRIPTION
This PR closes https://github.com/openaustralia/planningalerts/issues/1180 by adding some basic styles to get the councillor contribution form to a first pass we can present to people.

The changes are:

* Get the heading down to a size that doesn't dominate the form.
* Style the form input elements to match the general app style that works well, bolder labels and clearer inputs.
* Differentiate the submit form and add a councillor buttons, in both colour and proximity.
* Align the form inputs, and the submitted council records horizontally, so that the names and emails of all the councillors submitted line up. This helps you see if there's a typo in the email formatting, and quickly scan up and down the names.
* [Remove the 'councillors submitted' heading](https://github.com/openaustralia/planningalerts/commit/3e7e125febcc268d0584748099fa9a4a080129c1) and the [add a councillor](https://github.com/openaustralia/planningalerts/commit/ed9c1120fe921df90ce9b3c947b08905949cb195) heading. I think these are both unnecessary (see commit messages for more).
* Bring more focus to the data being inputted by [making the text bigger](https://github.com/openaustralia/planningalerts/commit/54d82577a32b2f47d102bd6ff61dcc1d4e15bb32) and [fading back the labels a little](https://github.com/openaustralia/planningalerts/commit/0c9d3af35b991f00a9c4fa4aa9c1d214ef6b1f15).


## Before

![screen shot 2017-08-01 at 1 35 34 pm](https://user-images.githubusercontent.com/1239550/28808332-5ea2d812-76be-11e7-81e6-cfb0c8d8253d.png)

## After

![screen shot 2017-08-01 at 1 35 04 pm](https://user-images.githubusercontent.com/1239550/28808334-6361a784-76be-11e7-8f76-9c97fd4a082d.png)
