### PR TITLE
Fixing style and unused association to merge person_contributes_councillor_info branch 

### DIFF
--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -15,7 +15,7 @@ class ContributorsController < ApplicationController
     end
   end
 
-private
+  private
 
   def contributor_params
     params.require(:contributor).permit(:name, :email)

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -1,4 +1,3 @@
 class Contributor < ActiveRecord::Base
-  has_many :suggested_councillors, through: :councillor_contributions
   has_many :councillor_contributions
 end

--- a/app/views/contributors/new.html.haml
+++ b/app/views/contributors/new.html.haml
@@ -1,6 +1,6 @@
 %h1 Thank you!
 %p
-  This data you contributed will be reviewd
+  This data you contributed will be reviewed
   by an administrator, and go live shortly.
 = form_for @contributor do |f|
   = f.hidden_field :councillor_contribution_id, value: params[:councillor_contribution_id]

--- a/spec/features/user_contributes_new_councillor_spec.rb
+++ b/spec/features/user_contributes_new_councillor_spec.rb
@@ -80,7 +80,6 @@ feature "Contributing new councillors for an authority" do
       click_button "Submit 4 new councillors"
 
       expect(page).to have_content "Thank you"
-
     end
 
     it "successfully with three councillors" do

--- a/spec/features/user_contributes_new_councillor_spec.rb
+++ b/spec/features/user_contributes_new_councillor_spec.rb
@@ -46,17 +46,9 @@ feature "Contributing new councillors for an authority" do
         fill_in "Email", with: "mgilic@casey.vic.gov.au"
       end
 
-      click_button "Add another councillor"
-
-      expect(page).to have_content "Mila Gilic"
-      expect(page).to have_content "mgilic@casey.vic.gov.au"
-
-      within ".councillor-contribution-councillors fieldset" do
-        fill_in "Full name", with: "Rosalie Crestani"
-        fill_in "Email", with: "rcrestani@casey.vic.gov.au"
-      end
-
       click_button "Submit"
+
+      click_link "I prefer not to"
 
       expect(page).to have_content "Thank you"
     end

--- a/spec/features/user_contributes_new_councillor_spec.rb
+++ b/spec/features/user_contributes_new_councillor_spec.rb
@@ -38,7 +38,7 @@ feature "Contributing new councillors for an authority" do
       expect(page).to have_content "Thank you"
     end
 
-    it "works successfully without contributor information" do
+    it "works successfully when the contributor does not provide their information" do
       visit new_authority_councillor_contribution_path(authority.short_name_encoded)
 
       within ".councillor-contribution-councillors fieldset" do

--- a/spec/features/user_contributes_new_councillor_spec.rb
+++ b/spec/features/user_contributes_new_councillor_spec.rb
@@ -18,13 +18,7 @@ feature "Contributing new councillors for an authority" do
       end
     end
 
-    it "lands on the contribution page of the chosen authority" do
-      visit new_authority_councillor_contribution_path(authority.short_name_encoded)
-
-      expect(page).to have_content("Casey City Council")
-    end
-
-    it "works successfully when the contributor provides their information" do
+    it "after landing on the contribution page, works successfully when the contributor provides their information" do
       visit new_authority_councillor_contribution_path(authority.short_name_encoded)
 
       within ".councillor-contribution-councillors fieldset" do

--- a/spec/features/user_contributes_new_councillor_spec.rb
+++ b/spec/features/user_contributes_new_councillor_spec.rb
@@ -56,7 +56,7 @@ feature "Contributing new councillors for an authority" do
         fill_in "Email", with: "rcrestani@casey.vic.gov.au"
       end
 
-      click_button "Submit 2 new councillors"
+      click_button "Submit"
 
       expect(page).to have_content "Thank you"
     end

--- a/spec/features/user_contributes_new_councillor_spec.rb
+++ b/spec/features/user_contributes_new_councillor_spec.rb
@@ -18,7 +18,7 @@ feature "Contributing new councillors for an authority" do
       end
     end
 
-    scenario "on the contribution page" do
+    it "lands on the contribution page of the chosen authority" do
       visit new_authority_councillor_contribution_path(authority.short_name_encoded)
 
       expect(page).to have_content("Casey City Council")

--- a/spec/models/contributor_spec.rb
+++ b/spec/models/contributor_spec.rb
@@ -1,5 +1,0 @@
-require 'spec_helper'
-
-RSpec.describe Contributor, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
this is to fix #1208

There are style changes, unused association, and more accurate test descriptions. 

There is another PR to follow up on the issue of thanking the contributor when they chose not to provide their contact information.
 