### PR TITLE
Added source_url in councillor contribution table and created a form in councillor_contribution#new

### DIFF
--- a/app/admin/councillor_contributions.rb
+++ b/app/admin/councillor_contributions.rb
@@ -14,6 +14,8 @@ ActiveAdmin.register CouncillorContribution do
       row :contributor
       row :id
       row :authority
+      row :source_url
+
     end
 
     h3 "Suggested Councillors"

--- a/app/admin/councillor_contributions.rb
+++ b/app/admin/councillor_contributions.rb
@@ -15,7 +15,6 @@ ActiveAdmin.register CouncillorContribution do
       row :id
       row :authority
       row :source_url
-
     end
 
     h3 "Suggested Councillors"

--- a/app/controllers/councillor_contributions_controller.rb
+++ b/app/controllers/councillor_contributions_controller.rb
@@ -33,7 +33,7 @@ class CouncillorContributionsController < ApplicationController
   private
 
   def councillor_contribution_params
-    params.require(:councillor_contribution).permit(suggested_councillors_attributes: [:name, :email])
+    params.require(:councillor_contribution).permit(suggested_councillors_attributes: [:name, :email], :source_url)
   end
 
   def check_if_feature_flag_is_on

--- a/app/controllers/councillor_contributions_controller.rb
+++ b/app/controllers/councillor_contributions_controller.rb
@@ -33,7 +33,7 @@ class CouncillorContributionsController < ApplicationController
   private
 
   def councillor_contribution_params
-    params.require(:councillor_contribution).permit(suggested_councillors_attributes: [:name, :email], :source_url)
+    params.require(:councillor_contribution).permit(:source_url, suggested_councillors_attributes: [:name, :email])
   end
 
   def check_if_feature_flag_is_on

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -6,8 +6,8 @@
         = render 'contribution_form_input', f: f, suggested_councillor: s
       %button{formaction: new_authority_councillor_contribution_path(@authority.short_name_encoded), class: "button"} Add another councillor
     .councillor-contribtution-source
-      %p Where did you find this information? please include a link if possible
-      = f.label :name, "Source URL"
-      = f.text_field :source_url
+      %p If you found this information online, please provide the URL where we can check it.
+      = f.label :name, "Source"
+      = f.text_area :source
     .councillor-contribution-actions
       = f.submit "Submit #{pluralize(@councillor_contribution.suggested_councillors.length, "new councillor")}", class: "button-action"

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -5,5 +5,9 @@
       - @councillor_contribution.suggested_councillors.each do |s|
         = render 'contribution_form_input', f: f, suggested_councillor: s
       %button{formaction: new_authority_councillor_contribution_path(@authority.short_name_encoded), class: "button"} Add another councillor
+    .councillor-contribtution-source
+      %p Where did you find this information? please include a link if possible
+      = f.label :name, "Source URL"
+      = f.text_field :source_url
     .councillor-contribution-actions
       = f.submit "Submit #{pluralize(@councillor_contribution.suggested_councillors.length, "new councillor")}", class: "button-action"

--- a/db/migrate/20170818220607_add_source_url_to_councilor_contributions.rb
+++ b/db/migrate/20170818220607_add_source_url_to_councilor_contributions.rb
@@ -1,0 +1,5 @@
+class AddSourceUrlToCouncilorContributions < ActiveRecord::Migration
+  def change
+    add_column :councillor_contributions, :source_url, :string
+  end
+end

--- a/db/migrate/20170822154624_change_source_url_to_source_in_councillor_contribution.rb
+++ b/db/migrate/20170822154624_change_source_url_to_source_in_councillor_contribution.rb
@@ -1,0 +1,6 @@
+class ChangeSourceUrlToSourceInCouncillorContribution < ActiveRecord::Migration
+  def change
+    remove_column :councillor_contributions, :source_url, :string
+    add_column :councillor_contributions, :source, :string
+  end
+end

--- a/db/migrate/20170822175851_change_source_from_string_to_text.rb
+++ b/db/migrate/20170822175851_change_source_from_string_to_text.rb
@@ -1,0 +1,6 @@
+class ChangeSourceFromStringToText < ActiveRecord::Migration
+  def change
+    remove_column :councillor_contributions, :source, :string
+    add_column :councillor_contributions, :source, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170818220607) do
+ActiveRecord::Schema.define(version: 20170822154624) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "resource_id",   limit: 255,   null: false
@@ -143,7 +143,7 @@ ActiveRecord::Schema.define(version: 20170818220607) do
     t.integer  "authority_id",   limit: 4
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
-    t.string   "source_url",     limit: 255
+    t.string   "source",         limit: 255
   end
 
   create_table "councillors", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170704165351) do
+ActiveRecord::Schema.define(version: 20170818220607) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "resource_id",   limit: 255,   null: false
@@ -141,8 +141,9 @@ ActiveRecord::Schema.define(version: 20170704165351) do
   create_table "councillor_contributions", force: :cascade do |t|
     t.integer  "contributor_id", limit: 4
     t.integer  "authority_id",   limit: 4
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.string   "source_url",     limit: 255
   end
 
   create_table "councillors", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170822154624) do
+ActiveRecord::Schema.define(version: 20170822175851) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "resource_id",   limit: 255,   null: false
@@ -141,9 +141,9 @@ ActiveRecord::Schema.define(version: 20170822154624) do
   create_table "councillor_contributions", force: :cascade do |t|
     t.integer  "contributor_id", limit: 4
     t.integer  "authority_id",   limit: 4
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.string   "source",         limit: 255
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.text     "source",         limit: 65535
   end
 
   create_table "councillors", force: :cascade do |t|


### PR DESCRIPTION
** please marge #1226 before this PR**

this is to fix #1221 

So far, I did:
* added `source_url` in councillor contribution model,
* added `source_url` in the strong params in the councillor_contributions controller. 
* created a form field for the source_url in councillor_contribution#new
* added `source_url` in admin/councillor_contribution#show

<img width="857" alt="screen shot 2017-08-18 at 6 45 40 pm" src="https://user-images.githubusercontent.com/12241881/29480379-f8e16b16-8445-11e7-976c-fdab1f04ff77.png">
<img width="500" alt="screen shot 2017-08-18 at 6 45 24 pm" src="https://user-images.githubusercontent.com/12241881/29480382-fcc75614-8445-11e7-9826-c2263b61fc76.png">

However, the admin display is planned to be look like below in #1226 for the case without contributor info
<img width="872" alt="screen shot 2017-08-18 at 5 00 26 pm" src="https://user-images.githubusercontent.com/12241881/29480423-389ad116-8446-11e7-8c31-a2c6d4dc38cb.png">

And in case with contributor info
<img width="1139" alt="screen shot 2017-08-17 at 1 09 22 pm" src="https://user-images.githubusercontent.com/12241881/29424779-f4ec32ae-834e-11e7-880e-0276626a34b0.png">

So I think we should work on merging #1226, and then we can change the admin page. 
@henare @equivalentideas 

