### PR TITLE
Added a short instruction of how to contribute 

### DIFF
--- a/app/assets/stylesheets/partials/_page.scss
+++ b/app/assets/stylesheets/partials/_page.scss
@@ -303,6 +303,49 @@ hr {
   margin-bottom: 1em;
 }
 
+details {
+  border-radius: 1em;
+  background: #eee;
+  padding: 0;
+  cursor: pointer;
+
+  &[open] {
+    cursor: default;
+    padding: 0 1em 1em;
+  }
+}
+
+summary {
+  padding: 1em;
+  display: block;
+  cursor: pointer;
+
+  details[open] > & {
+    padding: 1em 0;
+    font-weight: bold;
+  }
+
+  &::before {
+    content: 'Show';
+    padding-right: 0.5em;
+
+    details[open] > & {
+      content: none;
+    }
+  }
+
+  &::after {
+    details[open] > & {
+      content: 'Hide';
+      float: right;
+    }
+  }
+
+  &::-webkit-details-marker {
+    display: none;
+  }
+}
+
 /* Attention grabbers */
 body .container .attention {
   @include boxed-content;

--- a/app/assets/stylesheets/partials/special_forms/_councillor_contribution_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_councillor_contribution_form.scss
@@ -11,6 +11,12 @@
     font-weight: 500;
   }
 
+  legend {
+    margin: 2em 0 1em;
+    display: block;
+    font-weight: 500;
+  }
+
   input {
     display: block;
     padding: .25em;

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -1,23 +1,25 @@
 .councillor-contributions
   %h1.page-title Who are the elected councillors for #{@authority.full_name}?
   %p Once we know, people will be able to ask them about development applications in PlanningAlerts. Collecting this information is a great contribution and will only take you a few minutes.
-  %p
-    You should be able to find the information we need from the #{@authority.full_name} website.
-    Find their list of elected "councillors" or "aldermen" and for each one add their full name and email into the form below.
-  %ul
-    %li
-      %strong Full Name
-      should be just their full name without titles, e.g. for "Lord Mayor Alderman Dr Sue Hicks OAM" just enter "Sue Hicks".
-    %li
-      %strong Email
-      should be the email address for contacting that individual councillor.
-  %p
-    You can add multiple councillors by clicking the "Add another councillor" button.
-    Add all the councillors into the form below and then submit them.
-  %p
-    If you have any questions or can't find all the information you need,
-    please let us know, we're here to help. Contact us by email at
-    = mail_to "contact@planningalerts.org.au", "contact@planningalerts.org.au."
+  %details
+    %summary Instructions
+    %p
+      You should be able to find the information we need from the #{@authority.full_name} website.
+      Find their list of elected "councillors" or "aldermen" and for each one add their full name and email into the form below.
+    %ul
+      %li
+        %strong Full Name
+        should be just their full name without titles, e.g. for "Lord Mayor Alderman Dr Sue Hicks OAM" just enter "Sue Hicks".
+      %li
+        %strong Email
+        should be the email address for contacting that individual councillor.
+    %p
+      You can add multiple councillors by clicking the "Add another councillor" button.
+      Add all the councillors into the form below and then submit them.
+    %p
+      If you have any questions or can't find all the information you need,
+      please let us know, we're here to help. Contact us by email at
+      = mail_to "contact@planningalerts.org.au", "contact@planningalerts.org.au."
 
   = form_for [@authority, @councillor_contribution], url: authority_councillor_contributions_path(@authority.short_name_encoded), html: { class: "councillor-contribution-form" } do |f|
     .councillor-contribution-councillors

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -2,16 +2,18 @@
   %h1.page-title Who are the elected councillors for #{@authority.full_name}?
   %p Once we know, people will be able to ask them about development applications in PlanningAlerts. Collecting this information is a great contribution and will only take you a few minutes.
   %p
-    You should be able to find the information we need from the #{@authority.full_name} website. Find their list of elected "councillors" or "aldermen" and for each one add their full name and email into the form below.
-
+    You should be able to find the information we need from the #{@authority.full_name} website.
+    Find their list of elected "councillors" or "aldermen" and for each one add their full name and email into the form below.
   %p
     Full Name should be just their full name without titles, e.g. for "Lord Mayor Alderman Dr Sue Hicks OAM" just enter "Sue Hicks".
   %p
     Email should be the email address for contacting that individual councillor.
   %p
-    You can add multiple councillors by clicking the "Add another councillor" button. Add all the councillors into the form below and then submit them.
+    You can add multiple councillors by clicking the "Add another councillor" button.
+    Add all the councillors into the form below and then submit them.
   %p
-    If you have any questions or can't find all the information you need, please let us know, we're here to help. Contact us by email at
+    If you have any questions or can't find all the information you need,
+    please let us know, we're here to help. Contact us by email at
     = mail_to "contact@planningalerts.org.au", "contact@planningalerts.org.au."
 
   = form_for [@authority, @councillor_contribution], url: authority_councillor_contributions_path(@authority.short_name_encoded), html: { class: "councillor-contribution-form" } do |f|

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -4,10 +4,9 @@
   %p
     You should be able to find the information we need from the #{@authority.full_name} website.
     Find their list of elected "councillors" or "aldermen" and for each one add their full name and email into the form below.
-  %p
-    Full Name should be just their full name without titles, e.g. for "Lord Mayor Alderman Dr Sue Hicks OAM" just enter "Sue Hicks".
-  %p
-    Email should be the email address for contacting that individual councillor.
+  %ul
+    %li Full Name should be just their full name without titles, e.g. for "Lord Mayor Alderman Dr Sue Hicks OAM" just enter "Sue Hicks".
+    %li Email should be the email address for contacting that individual councillor.
   %p
     You can add multiple councillors by clicking the "Add another councillor" button.
     Add all the councillors into the form below and then submit them.

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -14,7 +14,7 @@
         %strong Email
         should be the email address for contacting that individual councillor.
     %p
-      You can add multiple councillors by clicking the "Add another councillor" button.
+      Add all the councillors by clicking the "Add another councillor" button.
     %p
       If you have any questions or can't find all the information you need,
       please let us know, we're here to help. Contact us by email at

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -1,5 +1,18 @@
 .councillor-contributions
   %h1.page-title Add a new councillor for #{@authority.full_name}
+  %p
+    You should be able to find the information we need from the #{@authority.full_name} website. Find their list of elected "councillors" or "aldermen" and for each one add their full name and email into the form below.
+
+  %p
+    Full Name should be just their full name without titles, e.g. for "Lord Mayor Alderman Dr Sue Hicks OAM" just enter "Sue Hicks".
+  %p
+    Email should be the email address for contacting that individual councillor.
+  %p
+    You can add multiple councillors by clicking the "Add another councillor" button. Add all the councillors into the form below and then submit them.
+  %p
+    If you have any questions or can't find all the information you need, please let us know, we're here to help. Contact us by email at
+    = mail_to "contact@planningalerts.org.au", "contact@planningalerts.org.au."
+
   = form_for [@authority, @councillor_contribution], url: authority_councillor_contributions_path(@authority.short_name_encoded), html: { class: "councillor-contribution-form" } do |f|
     .councillor-contribution-councillors
       - @councillor_contribution.suggested_councillors.each do |s|

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -1,5 +1,5 @@
 .councillor-contributions
-  %h1.page-title Add a new councillor for #{@authority.full_name}
+  %h1.page-title Who are the elected councillors for #{@authority.full_name}?
   %p
     You should be able to find the information we need from the #{@authority.full_name} website. Find their list of elected "councillors" or "aldermen" and for each one add their full name and email into the form below.
 

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -1,5 +1,6 @@
 .councillor-contributions
   %h1.page-title Who are the elected councillors for #{@authority.full_name}?
+  %p Once we know, people will be able to ask them about development applications in PlanningAlerts. Collecting this information is a great contribution and will only take you a few minutes.
   %p
     You should be able to find the information we need from the #{@authority.full_name} website. Find their list of elected "councillors" or "aldermen" and for each one add their full name and email into the form below.
 

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -15,13 +15,13 @@
         should be the email address for contacting that individual councillor.
     %p
       You can add multiple councillors by clicking the "Add another councillor" button.
-      Add all the councillors into the form below and then submit them.
     %p
       If you have any questions or can't find all the information you need,
       please let us know, we're here to help. Contact us by email at
       = mail_to "contact@planningalerts.org.au", "contact@planningalerts.org.au."
 
   = form_for [@authority, @councillor_contribution], url: authority_councillor_contributions_path(@authority.short_name_encoded), html: { class: "councillor-contribution-form" } do |f|
+    %legend Add all the councillors details you can find:
     .councillor-contribution-councillors
       - @councillor_contribution.suggested_councillors.each do |s|
         = render 'contribution_form_input', f: f, suggested_councillor: s

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -5,8 +5,12 @@
     You should be able to find the information we need from the #{@authority.full_name} website.
     Find their list of elected "councillors" or "aldermen" and for each one add their full name and email into the form below.
   %ul
-    %li Full Name should be just their full name without titles, e.g. for "Lord Mayor Alderman Dr Sue Hicks OAM" just enter "Sue Hicks".
-    %li Email should be the email address for contacting that individual councillor.
+    %li
+      %strong Full Name
+      should be just their full name without titles, e.g. for "Lord Mayor Alderman Dr Sue Hicks OAM" just enter "Sue Hicks".
+    %li
+      %strong Email
+      should be the email address for contacting that individual councillor.
   %p
     You can add multiple councillors by clicking the "Add another councillor" button.
     Add all the councillors into the form below and then submit them.

--- a/spec/features/user_contributes_new_councillor_spec.rb
+++ b/spec/features/user_contributes_new_councillor_spec.rb
@@ -36,7 +36,7 @@ feature "Contributing new councillors for an authority" do
     end
 
     it "does not go to the contributor information page" do
-      expect(page).to have_content "Add a new councillor for Casey City Council"
+      expect(page).to have_content "Who are the elected councillors for Casey City Council?"
     end
   end
 


### PR DESCRIPTION
This is to fix #1234 

I added a brief instruction of the contribution on the same page as the form to be spontaneous.
It looks like this
<img width="682" alt="screen shot 2017-08-22 at 4 16 26 pm" src="https://user-images.githubusercontent.com/12241881/29585522-6ddb076c-8755-11e7-849a-d7788daed8fd.png">

Please let me know what you think @equivalentideas @henare 🎸 