### PR TITLE
Added download link for suggested councillors csv file in admin/councillor_contribution#show

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,28 @@ AllCops:
   Exclude:
     -  db/schema.rb
 
+Style/FirstParameterIndentation:
+  StyleGuide: https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutfirstparameterindentation
+  Enabled: true
+
+Style/AlignParameters:
+  StyleGuide: https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutalignparameters
+  Enabled: true
+  EnforcedStyle: with_first_parameter
+
+Style/IndentationWidth:
+  StyleGuide: https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutindentationwidth
+  Enabled: true
+
+Style/IndentationConsistency:
+  StyleGuide: https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutindentationconsistency
+  Enabled: true
+  EnforcedStyle: normal
+
+Style/ClosingParenthesisIndentation:
+  StyleGuide: https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutclosingparenthesisindentation
+  Enabled: true
+
 Style/HashSyntax:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-literals
   EnforcedStyle: ruby19

--- a/app/admin/councillor_contributions.rb
+++ b/app/admin/councillor_contributions.rb
@@ -20,4 +20,8 @@ ActiveAdmin.register CouncillorContribution do
       column :email
     end
   end
+
+  action_item :download,:only => [:show] do
+    link_to "Download the suggested councillors CSV", authority_councillor_contribution_path(resource.authority, resource.id, format: :csv)
+  end
 end

--- a/app/controllers/councillor_contributions_controller.rb
+++ b/app/controllers/councillor_contributions_controller.rb
@@ -37,7 +37,7 @@ class CouncillorContributionsController < ApplicationController
       format.csv do
         send_data(
           @councillor_contribution.to_csv,
-          filename: "councillor_contribution for #{@councillor_contribution.authority.full_name},#{@councillor_contribution.created_at}.csv",
+          filename: "#{@councillor_contribution.created_at.to_date.to_s}_#{@councillor_contribution.authority.short_name.downcase}_councillor_contribution.csv",
           content_type: Mime[:csv]
         )
       end

--- a/app/controllers/councillor_contributions_controller.rb
+++ b/app/controllers/councillor_contributions_controller.rb
@@ -36,9 +36,9 @@ class CouncillorContributionsController < ApplicationController
     respond_to do |format|
       format.csv do
         send_data(
-        @councillor_contribution.to_csv,
-        filename: "councillor_contribution for #{@councillor_contribution.authority.full_name},#{@councillor_contribution.created_at}.csv",
-        content_type: Mime[:csv]
+          @councillor_contribution.to_csv,
+          filename: "councillor_contribution for #{@councillor_contribution.authority.full_name},#{@councillor_contribution.created_at}.csv",
+          content_type: Mime[:csv]
         )
       end
     end

--- a/app/controllers/councillor_contributions_controller.rb
+++ b/app/controllers/councillor_contributions_controller.rb
@@ -31,6 +31,19 @@ class CouncillorContributionsController < ApplicationController
     end
   end
 
+  def show
+    @councillor_contribution = CouncillorContribution.find(params[:id])
+    respond_to do |format|
+      format.csv do
+        send_data(
+        @councillor_contribution.to_csv,
+        filename: "councillor_contribution for #{@councillor_contribution.authority.full_name},#{@councillor_contribution.created_at}.csv",
+        content_type: Mime[:csv]
+        )
+      end
+    end
+  end
+
   private
 
   def councillor_contribution_params

--- a/app/controllers/councillor_contributions_controller.rb
+++ b/app/controllers/councillor_contributions_controller.rb
@@ -37,7 +37,7 @@ class CouncillorContributionsController < ApplicationController
       format.csv do
         send_data(
           @councillor_contribution.to_csv,
-          filename: "#{@councillor_contribution.created_at.to_date.to_s}_#{@councillor_contribution.authority.short_name.downcase}_councillor_contribution.csv",
+          filename: "#{@councillor_contribution.created_at.to_date.to_s}_#{@councillor_contribution.authority.short_name.downcase}_councillor_contribution_#{@councillor_contribution.id}.csv",
           content_type: Mime[:csv]
         )
       end

--- a/app/models/councillor_contribution.rb
+++ b/app/models/councillor_contribution.rb
@@ -20,8 +20,8 @@ class CouncillorContribution < ActiveRecord::Base
 
   def to_csv
     attributes = %w{
-      name start_date end_date exective council council_website id email image
-      party source ward phone_mobile
+      name start_date end_date exective council council_website
+      id email image party source ward phone_mobile
     }
 
     CSV.generate(headers: true) do |csv|
@@ -29,8 +29,8 @@ class CouncillorContribution < ActiveRecord::Base
 
       suggested_councillors.each do |s|
         csv << [
-          s.name, nil, nil, nil, authority.full_name, nil, s.popolo_id,
-          s.email, nil, nil, nil, nil, nil, nil
+          s.name, nil, nil, nil, authority.full_name, nil,
+          s.popolo_id, s.email, nil, nil, nil, nil, nil, nil
         ]
       end
     end

--- a/app/models/councillor_contribution.rb
+++ b/app/models/councillor_contribution.rb
@@ -1,3 +1,4 @@
+require 'csv'
 class CouncillorContribution < ActiveRecord::Base
   belongs_to :contributor
   belongs_to :authority
@@ -14,6 +15,24 @@ class CouncillorContribution < ActiveRecord::Base
       end
     else
       "Anonymous"
+    end
+  end
+
+  def to_csv
+    attributes = %w{
+      name start_date end_date exective council council_website id email image
+      party source ward phone_mobile
+    }
+
+    CSV.generate(headers: true) do |csv|
+      csv << attributes
+
+      suggested_councillors.each do |s|
+        csv << [
+          s.name, nil, nil, nil, authority.full_name, nil, s.popolo_id,
+          s.email, nil, nil, nil, nil, nil, nil
+        ]
+      end
     end
   end
 end

--- a/app/models/suggested_councillor.rb
+++ b/app/models/suggested_councillor.rb
@@ -3,4 +3,9 @@ class SuggestedCouncillor < ActiveRecord::Base
   belongs_to :councillor_contribution
   validates :councillor_contribution, :name, :email, presence: true
   validates_email_format_of :email, message: "must be a valid email address, e.g. jane@example.com"
+
+  def popolo_id
+    "#{councillor_contribution.authority.full_name.split.join("_").downcase}/#{self.name.split.join("_").downcase}"
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,7 +102,7 @@ PlanningalertsApp::Application.routes.draw do
         get :per_week
       end
     end
-    resources :councillor_contributions, only:[:new, :create]
+    resources :councillor_contributions, only:[:new, :create, :show]
     collection do
       get :test_feed
     end

--- a/spec/controllers/councillor_contributions_controller_spec.rb
+++ b/spec/controllers/councillor_contributions_controller_spec.rb
@@ -23,6 +23,7 @@ describe CouncillorContributionsController do
     describe "#show" do
       it "download csv file" do
         get :show, authority_id: authority.id, id: councillor_contribution.id, format: "csv"
+
         response_csv = CSV.parse(response.body)
         expect((response_csv).first).to eql [
           "name", "start_date", "end_date", "exective", "council", "council_website",

--- a/spec/controllers/councillor_contributions_controller_spec.rb
+++ b/spec/controllers/councillor_contributions_controller_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe CouncillorContributionsController do
+    let(:authority) { create(:authority, full_name: "Casey City Council") }
+    let(:councillor_contribution) { create(:councillor_contribution, authority: authority) }
+
+  context "when the feature flag is on" do
+    around do |test|
+      with_modified_env CONTRIBUTE_COUNCILLORS_ENABLED: "true" do
+        test.run
+      end
+    end
+  before :each do
+  create(
+   :suggested_councillor,
+   name: "Mila Gilic",
+   email: "mgilic@casey.vic.gov.au",
+   councillor_contribution: councillor_contribution
+   )
+  end
+
+    describe "#show" do
+      it "download csv file" do
+        get :show, authority_id: authority.id, id: councillor_contribution.id, format: "csv"
+        response_csv = CSV.parse(response.body)
+        expect((response_csv).first).to eql [
+          "name", "start_date", "end_date", "exective", "council",
+          "council_website","id","email", "image", "party", "source",
+          "ward", "phone_mobile"
+        ]
+        expect(response_csv.last).to eql [
+          "Mila Gilic", nil, nil,nil,"Casey City Council",nil,
+          "casey_city_council/mila_gilic", "mgilic@casey.vic.gov.au", nil,
+          nil, nil, nil, nil, nil
+          ]
+      end
+    end
+  end
+end

--- a/spec/controllers/councillor_contributions_controller_spec.rb
+++ b/spec/controllers/councillor_contributions_controller_spec.rb
@@ -25,14 +25,12 @@ describe CouncillorContributionsController do
         get :show, authority_id: authority.id, id: councillor_contribution.id, format: "csv"
         response_csv = CSV.parse(response.body)
         expect((response_csv).first).to eql [
-          "name", "start_date", "end_date", "exective", "council",
-          "council_website","id","email", "image", "party", "source",
-          "ward", "phone_mobile"
+          "name", "start_date", "end_date", "exective", "council", "council_website",
+          "id","email", "image", "party", "source", "ward", "phone_mobile"
         ]
         expect(response_csv.last).to eql [
           "Mila Gilic", nil, nil,nil,"Casey City Council",nil,
-          "casey_city_council/mila_gilic", "mgilic@casey.vic.gov.au", nil,
-          nil, nil, nil, nil, nil
+          "casey_city_council/mila_gilic", "mgilic@casey.vic.gov.au", nil, nil, nil, nil, nil, nil
           ]
       end
     end

--- a/spec/controllers/councillor_contributions_controller_spec.rb
+++ b/spec/controllers/councillor_contributions_controller_spec.rb
@@ -29,7 +29,7 @@ describe CouncillorContributionsController do
           "id","email", "image", "party", "source", "ward", "phone_mobile"
         ]
         expect(response_csv.last).to eql [
-          "Mila Gilic", nil, nil,nil,"Casey City Council",nil,
+          "Mila Gilic", nil, nil, nil, "Casey City Council", nil,
           "casey_city_council/mila_gilic", "mgilic@casey.vic.gov.au", nil, nil, nil, nil, nil, nil
           ]
       end

--- a/spec/controllers/councillor_contributions_controller_spec.rb
+++ b/spec/controllers/councillor_contributions_controller_spec.rb
@@ -21,7 +21,7 @@ describe CouncillorContributionsController do
     end
 
     describe "#show" do
-      it "download csv file" do
+      it "returns a valid CSV file with the contribution" do
         get :show, authority_id: authority.id, id: councillor_contribution.id, format: "csv"
 
         response_csv = CSV.parse(response.body)

--- a/spec/controllers/councillor_contributions_controller_spec.rb
+++ b/spec/controllers/councillor_contributions_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe CouncillorContributionsController do
-    let(:authority) { create(:authority, full_name: "Casey City Council") }
-    let(:councillor_contribution) { create(:councillor_contribution, authority: authority) }
+  let(:authority) { create(:authority, full_name: "Casey City Council") }
+  let(:councillor_contribution) { create(:councillor_contribution, authority: authority) }
 
   context "when the feature flag is on" do
     around do |test|
@@ -10,14 +10,15 @@ describe CouncillorContributionsController do
         test.run
       end
     end
-  before :each do
-  create(
-   :suggested_councillor,
-   name: "Mila Gilic",
-   email: "mgilic@casey.vic.gov.au",
-   councillor_contribution: councillor_contribution
-   )
-  end
+
+    before :each do
+      create(
+        :suggested_councillor,
+        name: "Mila Gilic",
+        email: "mgilic@casey.vic.gov.au",
+        councillor_contribution: councillor_contribution
+      )
+    end
 
     describe "#show" do
       it "download csv file" do


### PR DESCRIPTION
This is to fix #1220 

I added back `admin/suggested_councillors.rb` to create the csv file, and created the link for the download in `admin/councillor_contribution#show`. 
<img width="1186" alt="screen shot 2017-08-24 at 2 39 38 pm" src="https://user-images.githubusercontent.com/12241881/29682866-86aafc3a-88da-11e7-96ee-2880db595a0b.png">
<img width="376" alt="screen shot 2017-08-24 at 2 41 44 pm" src="https://user-images.githubusercontent.com/12241881/29682881-94a20752-88da-11e7-80b7-19f7fb1d12e5.png">

Please let me know what you think @henare @equivalentideas 

I found an instruction of how to test csv download (https://stackoverflow.com/questions/29309324/how-to-test-csv-file-download-in-capybara-and-rspec), currently I don't see in spec/admin to test the download feature. Is this something we don't have to test?