### PR TITLE
Created council directory

### DIFF
--- a/app/controllers/councillor_contributions_controller.rb
+++ b/app/controllers/councillor_contributions_controller.rb
@@ -30,6 +30,13 @@ class CouncillorContributionsController < ApplicationController
     end
   end
 
+  def council_directory
+    @authorities = Authority.all
+    if params[:council_name]
+         @authorities_search = Authority.where(short_name: params[:council_name].titlecase)
+    end
+  end
+
   private
 
   def councillor_contribution_params

--- a/app/views/councillor_contributions/council_directory.html.haml
+++ b/app/views/councillor_contributions/council_directory.html.haml
@@ -1,0 +1,25 @@
+%h3 Council Directory
+
+= form_tag council_directory_path, :method => :get do |f|
+  %label
+    Search the council you want to contribute
+  %p
+    = label_tag :council_name
+    = text_field_tag :council_name
+  %p.button
+    = submit_tag "Search", :action => :get
+  %ul
+    - if @authorities_search.nil?
+      - @authorities.each do |a|
+        %li
+        = link_to a.full_name, a.website_url
+
+    - elsif @authorities_search.empty?
+      %br
+      %p.attention Sorry, no results found!
+
+    - elsif @authorities_search
+      - @authorities_search.each do |a|
+        %li
+          %h2
+            = link_to a.full_name, a.website_url

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,7 @@ PlanningalertsApp::Application.routes.draw do
   end
 
   post "/authorities/:authority_id/councillor_contributions/new", to: "councillor_contributions#new"
+  get '/council_directory' => 'councillor_contributions#council_directory'
 
   resources :contributors, only:[:new, :create]
     get "/contributors/no_info", to: "contributors#no_contributor_info"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,7 @@ PlanningalertsApp::Application.routes.draw do
 
   post "/authorities/:authority_id/councillor_contributions/new", to: "councillor_contributions#new"
   get '/council_directory' => 'councillor_contributions#council_directory'
+  get '/council_directory/search/' => 'council_directory#search'
 
   resources :contributors, only:[:new, :create]
     get "/contributors/no_info", to: "contributors#no_contributor_info"

--- a/db/migrate/20170815234101_add_website_url_to_authorities.rb
+++ b/db/migrate/20170815234101_add_website_url_to_authorities.rb
@@ -1,0 +1,5 @@
+class AddWebsiteUrlToAuthorities < ActiveRecord::Migration
+  def change
+    add_column :authorities, :website_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170704165351) do
+ActiveRecord::Schema.define(version: 20170822175851) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "resource_id",   limit: 255,   null: false
@@ -105,6 +105,7 @@ ActiveRecord::Schema.define(version: 20170704165351) do
     t.text    "last_scraper_run_log",         limit: 65535
     t.string  "morph_name",                   limit: 255
     t.boolean "write_to_councillors_enabled",               default: false, null: false
+    t.string  "website_url",                  limit: 255
   end
 
   add_index "authorities", ["short_name"], name: "short_name_unique", unique: true, using: :btree


### PR DESCRIPTION
This is to fix #1200

In this PR I added
- routes for council_directory and council_directory#search
- a method `council_directory` in councillor_contribution_controller
- a haml file of council_directory

Right now, this is how it looks in the browser:
<img width="614" alt="screen shot 2017-08-29 at 3 52 59 pm" src="https://user-images.githubusercontent.com/12241881/29841107-31d030b2-8cd2-11e7-84b3-5c8e14ba9abd.png">

The list of the existing councils/authorities are visible, because some people just look through the list instead of using the search function. But if that is too much visual noise, we can not show it too.

When you enter the council/authority name and if it matches it displays as below:
<img width="605" alt="screen shot 2017-08-29 at 3 54 51 pm" src="https://user-images.githubusercontent.com/12241881/29841199-8736baf8-8cd2-11e7-97a4-6717e9d0fe01.png">

and when there is no match it displays as below
<img width="890" alt="screen shot 2017-08-29 at 3 56 40 pm" src="https://user-images.githubusercontent.com/12241881/29841245-b79dcbbe-8cd2-11e7-90ff-b521339d485a.png">

Right now I made it to a separate page, but potentially it can be integrated somewhere, or we can include the link in the contribution guide. I appreciate your feedback for the next step! @henare @equivalentideas 