### PR TITLE
Updated the authority name in the instruction to the link to the council website

### DIFF
--- a/app/assets/stylesheets/partials/special_forms/_councillor_contribution_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_councillor_contribution_form.scss
@@ -48,6 +48,10 @@
   }
 }
 
+.button-add-input {
+  font-size: 1em !important;
+}
+
 .councillor-contribution-actions {
   text-align: right;
 }

--- a/app/assets/stylesheets/partials/special_forms/_councillor_contribution_form.scss
+++ b/app/assets/stylesheets/partials/special_forms/_councillor_contribution_form.scss
@@ -49,6 +49,7 @@
 }
 
 .button-add-input {
+  margin-top: 1em;
   font-size: 1em !important;
 }
 

--- a/app/helpers/councillor_contributions_helper.rb
+++ b/app/helpers/councillor_contributions_helper.rb
@@ -1,0 +1,5 @@
+module CouncillorContributionsHelper
+  def link_to_or_name_of(authority)
+    link_to_if(authority.website_url.present?,"#{authority.full_name}", authority.website_url, title: "Go to the #{authority.full_name} website.", target: "_blank")
+  end
+end

--- a/app/helpers/councillor_contributions_helper.rb
+++ b/app/helpers/councillor_contributions_helper.rb
@@ -2,7 +2,7 @@ module CouncillorContributionsHelper
   def link_to_or_name_of(authority)
     link_to_if(
       authority.website_url.present?,
-      "#{authority.full_name}",
+      authority.full_name,
       authority.website_url,
       title: "Go to the #{authority.full_name} website.",
       target: "_blank"

--- a/app/helpers/councillor_contributions_helper.rb
+++ b/app/helpers/councillor_contributions_helper.rb
@@ -1,5 +1,11 @@
 module CouncillorContributionsHelper
   def link_to_or_name_of(authority)
-    link_to_if(authority.website_url.present?,"#{authority.full_name}", authority.website_url, title: "Go to the #{authority.full_name} website.", target: "_blank")
+    link_to_if(
+      authority.website_url.present?,
+      "#{authority.full_name}",
+      authority.website_url,
+      title: "Go to the #{authority.full_name} website.",
+      target: "_blank"
+    )
   end
 end

--- a/app/views/councillor_contributions/_instructions_body.md
+++ b/app/views/councillor_contributions/_instructions_body.md
@@ -1,4 +1,4 @@
-You should be able to find the information we need from the <%= link_to_if(@authority.website_url.present?,"#{@authority.full_name}", @authority.website_url, title: "Go to the #{@authority.full_name} website.") %> website.
+You should be able to find the information we need from the <%= link_to_if(@authority.website_url.present?,"#{@authority.full_name}", @authority.website_url, title: "Go to the #{@authority.full_name} website.", target: "_blank") %> website.
 Find their list of elected "councillors" or "aldermen" and for each one add their full name and email into the form below.
 
 * **Full Name** should be just their given names, first name first. Leave out titles and other information. For example, if you find "_Lord Mayor Alderman Dr Sue Robbins Chen OAM_" just enter "_Sue Robbins Chen_".

--- a/app/views/councillor_contributions/_instructions_body.md
+++ b/app/views/councillor_contributions/_instructions_body.md
@@ -1,4 +1,4 @@
-You should be able to find the information we need from the <%= @authority.full_name %> website.
+You should be able to find the information we need from the <%= link_to_if(@authority.website_url.present?,"#{@authority.full_name}", @authority.website_url)  %> website.
 Find their list of elected "councillors" or "aldermen" and for each one add their full name and email into the form below.
 
 * **Full Name** should be just their given names, first name first. Leave out titles and other information. For example, if you find "_Lord Mayor Alderman Dr Sue Robbins Chen OAM_" just enter "_Sue Robbins Chen_".

--- a/app/views/councillor_contributions/_instructions_body.md
+++ b/app/views/councillor_contributions/_instructions_body.md
@@ -1,4 +1,4 @@
-You should be able to find the information we need from the <%= link_to_if(@authority.website_url.present?,"#{@authority.full_name}", @authority.website_url, title: "Go to the #{@authority.full_name} website.", target: "_blank") %> website.
+You should be able to find the information we need from the <%= link_to_or_name_of(@authority) %> website.
 Find their list of elected "councillors" or "aldermen" and for each one add their full name and email into the form below.
 
 * **Full Name** should be just their given names, first name first. Leave out titles and other information. For example, if you find "_Lord Mayor Alderman Dr Sue Robbins Chen OAM_" just enter "_Sue Robbins Chen_".

--- a/app/views/councillor_contributions/_instructions_body.md
+++ b/app/views/councillor_contributions/_instructions_body.md
@@ -1,4 +1,4 @@
-You should be able to find the information we need from the <%= link_to_if(@authority.website_url.present?,"#{@authority.full_name}", @authority.website_url)  %> website.
+You should be able to find the information we need from the <%= link_to_if(@authority.website_url.present?,"#{@authority.full_name}", @authority.website_url, title: "Go to the #{@authority.full_name} website.") %> website.
 Find their list of elected "councillors" or "aldermen" and for each one add their full name and email into the form below.
 
 * **Full Name** should be just their given names, first name first. Leave out titles and other information. For example, if you find "_Lord Mayor Alderman Dr Sue Robbins Chen OAM_" just enter "_Sue Robbins Chen_".

--- a/app/views/councillor_contributions/new.html.haml
+++ b/app/views/councillor_contributions/new.html.haml
@@ -13,6 +13,6 @@
     .councillor-contribution-councillors
       - @councillor_contribution.suggested_councillors.each do |s|
         = render 'contribution_form_input', f: f, suggested_councillor: s
-      %button{formaction: new_authority_councillor_contribution_path(@authority.short_name_encoded), class: "button"} Add another councillor
+      %button{formaction: new_authority_councillor_contribution_path(@authority.short_name_encoded), class: "button button-add-input"} Add another councillor
     .councillor-contribution-actions
       = f.submit "Submit #{pluralize(@councillor_contribution.suggested_councillors.length, "new councillor")}", class: "button-action"

--- a/db/migrate/20170830203313_add_wesbite_url_in_authorities.rb
+++ b/db/migrate/20170830203313_add_wesbite_url_in_authorities.rb
@@ -1,0 +1,5 @@
+class AddWesbiteUrlInAuthorities < ActiveRecord::Migration
+  def change
+    add_column :authorities, :website_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170704165351) do
+ActiveRecord::Schema.define(version: 20170830203313) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "resource_id",   limit: 255,   null: false
@@ -105,6 +105,7 @@ ActiveRecord::Schema.define(version: 20170704165351) do
     t.text    "last_scraper_run_log",         limit: 65535
     t.string  "morph_name",                   limit: 255
     t.boolean "write_to_councillors_enabled",               default: false, null: false
+    t.string  "website_url",                  limit: 255
   end
 
   add_index "authorities", ["short_name"], name: "short_name_unique", unique: true, using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,4 +4,5 @@ Authority.create! full_name: 'Marrickville Council',
                   state: 'NSW',
                   email: 'council@marrickville.nsw.gov.au',
                   population_2011: '81489',
-                  morph_name: 'planningalerts-scrapers/marrickville'
+                  morph_name: 'planningalerts-scrapers/marrickville',
+                  website_url: 'http://www.marrickville.nsw.gov.au'

--- a/spec/views/councillor_contributions/instructions_body_spec.rb
+++ b/spec/views/councillor_contributions/instructions_body_spec.rb
@@ -24,7 +24,7 @@ describe "councillor_contributions/_instructions_body" do
       )
     end
 
-    it "render it's name with no link" do
+    it "render its name with no link" do
       render "instructions_body"
 
       expect(rendered).to_not include "<a title=\"Go to the Example Council website.\" target=\"_blank\" href=\"https://example.nsw.gov.au\">Example Council</a>"

--- a/spec/views/councillor_contributions/instructions_body_spec.rb
+++ b/spec/views/councillor_contributions/instructions_body_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe "councillor_contributions/_instructions_body" do
+  context "when the authority has a website url" do
+    it "render a link to the website" do
+      assign(
+        :authority,
+        create(:authority, full_name: "Example Council", website_url: "https://example.nsw.gov.au")
+      )
+
+      render "instructions_body"
+
+      expect(rendered).to include "<a href=\"https://example.nsw.gov.au\">Example Council</a>"
+    end
+  end
+
+  context "when the authority does not have a website url" do
+    it "render it's name with no link" do
+      assign(
+        :authority,
+        create(:authority, full_name: "Example Council", website_url: nil)
+      )
+
+      render "instructions_body"
+
+      expect(rendered).to_not include "<a href='https://example.nsw.gov.au'>Example Council</a>"
+      expect(rendered).to include "Example Council"
+    end
+  end
+end

--- a/spec/views/councillor_contributions/instructions_body_spec.rb
+++ b/spec/views/councillor_contributions/instructions_body_spec.rb
@@ -2,12 +2,14 @@ require 'spec_helper'
 
 describe "councillor_contributions/_instructions_body" do
   context "when the authority has a website url" do
-    it "render a link to the website" do
+    before do
       assign(
         :authority,
         create(:authority, full_name: "Example Council", website_url: "https://example.nsw.gov.au")
       )
+    end
 
+    it "render a link to the website" do
       render "instructions_body"
 
       expect(rendered).to include "<a href=\"https://example.nsw.gov.au\">Example Council</a>"
@@ -15,12 +17,14 @@ describe "councillor_contributions/_instructions_body" do
   end
 
   context "when the authority does not have a website url" do
-    it "render it's name with no link" do
+    before do
       assign(
         :authority,
         create(:authority, full_name: "Example Council", website_url: nil)
       )
+    end
 
+    it "render it's name with no link" do
       render "instructions_body"
 
       expect(rendered).to_not include "<a href='https://example.nsw.gov.au'>Example Council</a>"

--- a/spec/views/councillor_contributions/instructions_body_spec.rb
+++ b/spec/views/councillor_contributions/instructions_body_spec.rb
@@ -12,7 +12,7 @@ describe "councillor_contributions/_instructions_body" do
     it "render a link to the website" do
       render "instructions_body"
 
-      expect(rendered).to include "<a href=\"https://example.nsw.gov.au\">Example Council</a>"
+      expect(rendered).to include "<a title=\"Go to the Example Council website.\" href=\"https://example.nsw.gov.au\">Example Council</a>"
     end
   end
 
@@ -27,7 +27,7 @@ describe "councillor_contributions/_instructions_body" do
     it "render it's name with no link" do
       render "instructions_body"
 
-      expect(rendered).to_not include "<a href='https://example.nsw.gov.au'>Example Council</a>"
+      expect(rendered).to_not include "<a href=\"https://example.nsw.gov.au\" title=\"Go to the Example Council website.\">Example Council</a>"
       expect(rendered).to include "Example Council"
     end
   end

--- a/spec/views/councillor_contributions/instructions_body_spec.rb
+++ b/spec/views/councillor_contributions/instructions_body_spec.rb
@@ -12,7 +12,7 @@ describe "councillor_contributions/_instructions_body" do
     it "render a link to the website" do
       render "instructions_body"
 
-      expect(rendered).to include "<a title=\"Go to the Example Council website.\" href=\"https://example.nsw.gov.au\">Example Council</a>"
+      expect(rendered).to include "<a title=\"Go to the Example Council website.\" target=\"_blank\" href=\"https://example.nsw.gov.au\">Example Council</a>"
     end
   end
 
@@ -27,7 +27,7 @@ describe "councillor_contributions/_instructions_body" do
     it "render it's name with no link" do
       render "instructions_body"
 
-      expect(rendered).to_not include "<a href=\"https://example.nsw.gov.au\" title=\"Go to the Example Council website.\">Example Council</a>"
+      expect(rendered).to_not include "<a title=\"Go to the Example Council website.\" target=\"_blank\" href=\"https://example.nsw.gov.au\">Example Council</a>"
       expect(rendered).to include "Example Council"
     end
   end


### PR DESCRIPTION
this is to fix #1200 

From the previous PR(#1239) targeting the same issue, @equivalentideas suggested:
>what if instead of having the user find the correct council, we just provide the link in the existing instructions:

>![screen shot 2017-08-30 at 4 54 36 pm](https://user-images.githubusercontent.com/1239550/29859178-27a19392-8da4-11e7-9e23-2db5582921e9.png)

And I think it's a great idea!

So in this PR, I update the `@authority.full_name` in the instruction to `@authority.website_url`.
`seed.rb` is updated accordingly, and I created migration file to add `website_url` in authorities table, as this PR is branched off from the master (currently has no `website_url` column).

Note: we need to update the column name in the column `council website` to `website url` in <a href="https://docs.google.com/spreadsheets/d/1_Ea99E5yXnHXW62o_lRo9khdbccEWfttpy2tyuYZYOE/edit">popolo spreadsheet </a>