### PR TITLE
Don't escape the url in OpenGraph metadata

### DIFF
--- a/app/helpers/applications_helper.rb
+++ b/app/helpers/applications_helper.rb
@@ -90,7 +90,12 @@ module ApplicationsHelper
   def google_static_map2(options)
     size = options[:size] || "350x200"
     label = options[:label] || "Map"
-    image_tag(google_static_map_url(options), size: size, alt: label)
+    type = options[:type] || "img"
+    if type == "url"
+      google_static_map_url(options)
+    else
+      image_tag(google_static_map_url(options), size: size, alt: label)
+    end
   end
 
   def google_static_map_url(options)

--- a/app/views/applications/show.html.haml
+++ b/app/views/applications/show.html.haml
@@ -5,7 +5,7 @@
   %meta{ name: "twitter:site", content: "@PlanningAlerts" }
   %meta{ name: "twitter:title", content: @application.address }
   %meta{ name: "twitter:description", content: (@application.description[0..199] if @application.description) }
-  %meta{ name: "twitter:image", content: google_static_map(@application, size: "120x120") }
+  %meta{ name: "twitter:image", content: google_static_map(@application, type: "url", size: "120x120") }
 
 = render "applications/facebook"
 = render "applications/twitter"


### PR DESCRIPTION
Further fix for #1320 