### PR TITLE
Add distance and heading to emails

### DIFF
--- a/app/helpers/applications_helper.rb
+++ b/app/helpers/applications_helper.rb
@@ -147,6 +147,12 @@ module ApplicationsHelper
     (value + 0.5).floor
   end
 
+  def distance_and_heading_in_words(from, to)
+    meters_in_words(from.distance_to(to)) +
+      " " +
+      heading_in_words(from.heading_to(to))
+  end
+
   private
 
   def google_signed_url(domain:, path:, query:, key: "GOOGLE_MAPS_API_KEY")

--- a/app/helpers/applications_helper.rb
+++ b/app/helpers/applications_helper.rb
@@ -126,12 +126,35 @@ module ApplicationsHelper
     image_tag(google_static_streetview_url(application, size: size, fov: fov, key: key), size: size, alt: "Streetview of #{application.address}")
   end
 
+  # Given a distance in metres returns some words describing the distance
+  # in human terms
   def distance_in_words(distance)
     if distance >= 1000
       "#{(distance / 1000).round(1)}km"
     else
       "#{distance.round}m"
     end
+  end
+
+  HEADING_SECTOR_NAMES = %w[N NE E SE S SW W NW].freeze
+
+  def heading_in_words(degrees)
+    # Dividing the compass into 8 sectors that are centred on north
+    sector = non_symmetric_round(degrees * 8 / 360.0).modulo(8)
+    HEADING_SECTOR_NAMES[sector]
+  end
+
+  # This rounds up for both and positive and negative numbers
+  # You can do this natively in ruby 2.4 or 2.5 I think but
+  # we don't have they yet on PlanningAlerts
+  # -1.5 => -1
+  # -1.0 => -1
+  # -0.5 => 0
+  #  0   => 0
+  #  0.5 => 1
+  #  1.0 => 1
+  def non_symmetric_round(value)
+    (value + 0.5).floor
   end
 
   private

--- a/app/helpers/applications_helper.rb
+++ b/app/helpers/applications_helper.rb
@@ -126,16 +126,6 @@ module ApplicationsHelper
     image_tag(google_static_streetview_url(application, size: size, fov: fov, key: key), size: size, alt: "Streetview of #{application.address}")
   end
 
-  # Given a distance in metres returns some words describing the distance
-  # in human terms
-  def distance_in_words(distance)
-    if distance >= 1000
-      "#{(distance / 1000).round(1)}km"
-    else
-      "#{distance.round}m"
-    end
-  end
-
   HEADING_SECTOR_NAMES = %w[N NE E SE S SW W NW].freeze
 
   def heading_in_words(degrees)

--- a/app/helpers/applications_helper.rb
+++ b/app/helpers/applications_helper.rb
@@ -126,6 +126,14 @@ module ApplicationsHelper
     image_tag(google_static_streetview_url(application, size: size, fov: fov, key: key), size: size, alt: "Streetview of #{application.address}")
   end
 
+  def distance_in_words(distance)
+    if distance >= 1000
+      "#{(distance / 1000).round(1)}km"
+    else
+      "#{distance.round}m"
+    end
+  end
+
   private
 
   def google_signed_url(domain:, path:, query:, key: "GOOGLE_MAPS_API_KEY")

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -15,6 +15,12 @@ class Location
     loc1.distance_to(loc2, units: :kms) * 1000.0
   end
 
+  def heading_to(loc)
+    loc1 = Geokit::LatLng.new(lat, lng)
+    loc2 = Geokit::LatLng.new(loc.lat, loc.lng)
+    loc1.heading_to(loc2)
+  end
+
   # Distance given is in metres
   def endpoint(bearing, distance)
     loc = Geokit::LatLng.new(lat, lng)

--- a/app/views/alert_mailer/_application.html.haml
+++ b/app/views/alert_mailer/_application.html.haml
@@ -3,6 +3,9 @@
     %tr
       %td.address{ colspan: "2" }
         = link_to application.address, application_url_with_tracking(id: application.id)
+    %tr
+      %td{ colspan: "2" }
+        = distance_and_heading_in_words(alert.location, application.location)
     - if application.location
       %tr
         - if SiteSetting.get(:streetview_in_emails_enabled)

--- a/app/views/alert_mailer/_application.text.erb
+++ b/app/views/alert_mailer/_application.text.erb
@@ -1,5 +1,6 @@
 
 <%= application.address %>
+<%= distance_and_heading_in_words(alert.location, application.location) %>
 
 <%= raw application.description %>
 

--- a/app/views/alert_mailer/_applications.html.haml
+++ b/app/views/alert_mailer/_applications.html.haml
@@ -1,7 +1,7 @@
 .box.applications-header
   The following <strong>new planning applications</strong> have been found within #{meters_in_words(alert.radius_meters)} of
   %strong= alert.address
-= render partial: "application", collection: applications[0..9]
+= render partial: "application", collection: applications[0..9], locals: { alert: alert }
 - if applications.size > 15
   %p.applications-more
     But wait, there are more! Browse the full #{link_to "list of recent nearby applications", address_applications_url(q: alert.address)}.

--- a/app/views/alert_mailer/_applications.text.erb
+++ b/app/views/alert_mailer/_applications.text.erb
@@ -1,5 +1,5 @@
 The following new planning applications have been found within <%= meters_in_words(alert.radius_meters) %> of <%= alert.address %>:
-<%= render partial: "application", collection: applications[0..9], spacer_template: "spacer" -%>
+<%= render partial: "application", collection: applications[0..9], spacer_template: "spacer", locals: { alert: alert } -%>
 <% if applications.size > 10 %>
 But wait, there are more! Browse the full list of recent nearby applications:
 <%= address_applications_url(q: alert.address) %>

--- a/spec/helpers/applications_helper_spec.rb
+++ b/spec/helpers/applications_helper_spec.rb
@@ -235,4 +235,18 @@ describe ApplicationsHelper do
       end
     end
   end
+
+  describe "#distance_in_words" do
+    it "should show a distance in metres" do
+      expect(helper.distance_in_words(50)).to eq "50m"
+    end
+
+    it "should round small distances to the nearest metre" do
+      expect(helper.distance_in_words(53.632)).to eq "54m"
+    end
+
+    it "should round distances in km to the nearest 100m" do
+      expect(helper.distance_in_words(1432.2)).to eq "1.4km"
+    end
+  end
 end

--- a/spec/helpers/applications_helper_spec.rb
+++ b/spec/helpers/applications_helper_spec.rb
@@ -236,20 +236,6 @@ describe ApplicationsHelper do
     end
   end
 
-  describe "#distance_in_words" do
-    it "should show a distance in metres" do
-      expect(helper.distance_in_words(50)).to eq "50m"
-    end
-
-    it "should round small distances to the nearest metre" do
-      expect(helper.distance_in_words(53.632)).to eq "54m"
-    end
-
-    it "should round distances in km to the nearest 100m" do
-      expect(helper.distance_in_words(1432.2)).to eq "1.4km"
-    end
-  end
-
   describe "#heading_in_words" do
     describe "north" do
       it { expect(helper.heading_in_words(0)).to eq "N" }

--- a/spec/helpers/applications_helper_spec.rb
+++ b/spec/helpers/applications_helper_spec.rb
@@ -249,4 +249,26 @@ describe ApplicationsHelper do
       expect(helper.distance_in_words(1432.2)).to eq "1.4km"
     end
   end
+
+  describe "#heading_in_words" do
+    describe "north" do
+      it { expect(helper.heading_in_words(0)).to eq "N" }
+      it { expect(helper.heading_in_words(-22.5)).to eq "N" }
+      it { expect(helper.heading_in_words(22.4)).to eq "N" }
+    end
+
+    describe "north east" do
+      it { expect(helper.heading_in_words(22.5)).to eq "NE" }
+      it { expect(helper.heading_in_words(45)).to eq "NE" }
+      it { expect(helper.heading_in_words(67.4)).to eq "NE" }
+    end
+
+    describe "east" do
+      it { expect(helper.heading_in_words(67.5)).to eq "E" }
+    end
+
+    describe "north west" do
+      it { expect(helper.heading_in_words(-22.6)).to eq "NW" }
+    end
+  end
 end

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -49,7 +49,7 @@ describe AlertMailer do
     end
 
     it "should nicely format (in text) a list of multiple planning applications" do
-      expect(email.text_part.body.to_s).to eq Rails.root.join("spec", "mailers", "regression", "alert_mailer", "email3.txt").read.gsub("\n", "\r\n")
+      expect(email.text_part.body.to_s.strip).to eq Rails.root.join("spec", "mailers", "regression", "alert_mailer", "email3.txt").read.gsub("\n", "\r\n").strip
     end
 
     it "should nicely format (in HTML) a list of multiple planning applications" do
@@ -65,7 +65,7 @@ describe AlertMailer do
     end
 
     it "should nicely format (in text) a list of multiple planning applications" do
-      expect(email.text_part.body.to_s).to eq Rails.root.join("spec", "mailers", "regression", "alert_mailer", "email2.txt").read.gsub("\n", "\r\n")
+      expect(email.text_part.body.to_s.strip).to eq Rails.root.join("spec", "mailers", "regression", "alert_mailer", "email2.txt").read.gsub("\n", "\r\n").strip
     end
 
     it "should nicely format (in HTML) a list of multiple planning applications" do
@@ -108,7 +108,7 @@ describe AlertMailer do
 
       context "Text email" do
         it "should nicely format a list of multiple planning applications" do
-          expect(@email.text_part.body.to_s).to eq Rails.root.join("spec", "mailers", "regression", "alert_mailer", "email1.txt").read.gsub("\n", "\r\n")
+          expect(@email.text_part.body.to_s.strip).to eq Rails.root.join("spec", "mailers", "regression", "alert_mailer", "email1.txt").read.gsub("\n", "\r\n").strip
         end
       end
 

--- a/spec/mailers/previews/alert_mailer_preview.rb
+++ b/spec/mailers/previews/alert_mailer_preview.rb
@@ -7,8 +7,8 @@ class AlertMailerPreview < ActionMailer::Preview
     # Not using Factory here because it seems to be causing problems
     # with the module reloading
     alert = Alert.create!(
-      lat: 0,
-      lng: 0,
+      lat: -33.902723,
+      lng: 151.163362,
       radius_meters: 1000,
       email: "mary@example.com",
       address: "1 Illawarra Road Marrickville 2204"

--- a/spec/mailers/previews/alert_mailer_preview.rb
+++ b/spec/mailers/previews/alert_mailer_preview.rb
@@ -13,7 +13,11 @@ class AlertMailerPreview < ActionMailer::Preview
       email: "mary@example.com",
       address: "1 Illawarra Road Marrickville 2204"
     )
-    mail = AlertMailer.alert(alert, [Application.first])
+    # This needs to have an application and a comment loaded for this to work
+    applications = [Application.first]
+    comments = [Comment.first]
+    replies = []
+    mail = AlertMailer.alert(alert, applications, comments, replies)
     alert.destroy
     mail
   end

--- a/spec/mailers/regression/alert_mailer/email1.html
+++ b/spec/mailers/regression/alert_mailer/email1.html
@@ -19,6 +19,11 @@ The following <strong>new planning applications</strong> have been found within 
 </td>
 </tr>
 <tr>
+<td colspan='2'>
+220 km SW
+</td>
+</tr>
+<tr>
 <td class='map'>
 <img alt="Map of Foo Street, Bar" src="https://maps.googleapis.com/maps/api/staticmap?maptype=roadmap&amp;markers=color%3Ared%7C0.1%2C0.2&amp;size=150x150&amp;zoom=16" width="150" height="150" />
 </td>
@@ -43,6 +48,11 @@ Knock something down
 <tr>
 <td class='address' colspan='2'>
 <a href="https://dev.planningalerts.org.au/applications/2?utm_campaign=view-application&amp;utm_medium=email&amp;utm_source=alerts">Bar Street, Foo</a>
+</td>
+</tr>
+<tr>
+<td colspan='2'>
+190 km SW
 </td>
 </tr>
 <tr>

--- a/spec/mailers/regression/alert_mailer/email1.txt
+++ b/spec/mailers/regression/alert_mailer/email1.txt
@@ -29,4 +29,3 @@ Discover our other projects: https://www.openaustraliafoundation.org.au/projects
 To change the size of the area you’re interested in: https://dev.planningalerts.org.au/alerts/abcdef/area
 
 To unsubscribe from alerts for this address: https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe
-

--- a/spec/mailers/regression/alert_mailer/email1.txt
+++ b/spec/mailers/regression/alert_mailer/email1.txt
@@ -1,6 +1,7 @@
 The following new planning applications have been found within 800 m of 24 Bruce Rd, Glenbrook NSW 2773:
 
 Foo Street, Bar
+220 km SW
 
 Knock something down
 
@@ -10,6 +11,7 @@ Add your own comment: https://dev.planningalerts.org.au/applications/1?utm_campa
 -----------------------------
 
 Bar Street, Foo
+190 km SW
 
 Put something up
 

--- a/spec/mailers/regression/alert_mailer/email2.html
+++ b/spec/mailers/regression/alert_mailer/email2.html
@@ -42,6 +42,11 @@ The following <strong>new planning applications</strong> have been found within 
 </td>
 </tr>
 <tr>
+<td colspan='2'>
+220 km SW
+</td>
+</tr>
+<tr>
 <td class='map'>
 <img alt="Map of Foo Street, Bar" src="https://maps.googleapis.com/maps/api/staticmap?maptype=roadmap&amp;markers=color%3Ared%7C0.1%2C0.2&amp;size=150x150&amp;zoom=16" width="150" height="150" />
 </td>
@@ -66,6 +71,11 @@ Knock something down
 <tr>
 <td class='address' colspan='2'>
 <a href="https://dev.planningalerts.org.au/applications/2?utm_campaign=view-application&amp;utm_medium=email&amp;utm_source=alerts">Bar Street, Foo</a>
+</td>
+</tr>
+<tr>
+<td colspan='2'>
+190 km SW
 </td>
 </tr>
 <tr>

--- a/spec/mailers/regression/alert_mailer/email2.txt
+++ b/spec/mailers/regression/alert_mailer/email2.txt
@@ -40,4 +40,3 @@ Discover our other projects: https://www.openaustraliafoundation.org.au/projects
 To change the size of the area you’re interested in: https://dev.planningalerts.org.au/alerts/abcdef/area
 
 To unsubscribe from alerts for this address: https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe
-

--- a/spec/mailers/regression/alert_mailer/email2.txt
+++ b/spec/mailers/regression/alert_mailer/email2.txt
@@ -12,6 +12,7 @@ https://dev.planningalerts.org.au/applications/3?utm_campaign=view-comment&utm_m
 The following new planning applications have been found within 800 m of 24 Bruce Rd, Glenbrook NSW 2773:
 
 Foo Street, Bar
+220 km SW
 
 Knock something down
 
@@ -21,6 +22,7 @@ Add your own comment: https://dev.planningalerts.org.au/applications/1?utm_campa
 -----------------------------
 
 Bar Street, Foo
+190 km SW
 
 Put something up
 

--- a/spec/mailers/regression/alert_mailer/email3.txt
+++ b/spec/mailers/regression/alert_mailer/email3.txt
@@ -31,4 +31,3 @@ Discover our other projects: https://www.openaustraliafoundation.org.au/projects
 To change the size of the area you’re interested in: https://dev.planningalerts.org.au/alerts/abcdef/area
 
 To unsubscribe from alerts for this address: https://dev.planningalerts.org.au/alerts/abcdef/unsubscribe
-

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -17,4 +17,13 @@ describe "Location" do
       expect(loc1.distance_to(loc2)).to be_within(0.1).of(72)
     end
   end
+
+  describe "#heading_to" do
+    it "should return results consistent with endpoint method" do
+      loc1 = Location.new(lat: -33.772609, lng: 150.624263)
+      # 500 metres NE
+      loc2 = loc1.endpoint(45, 500)
+      expect(loc1.heading_to(loc2)).to be_within(0.1).of(45)
+    end
+  end
 end


### PR DESCRIPTION
This adds the distance and heading (in short human terms like "1.4 km E") from the alert address for new applications in email alerts.

This is useful if you don't immediately recognise the address but it's useful for you to know "oh yeah that's on the other side of the railroad tracks".

This fixes #114 