### PR TITLE
Add versioned applications but don't use them yet

### DIFF
--- a/app/models/application_version.rb
+++ b/app/models/application_version.rb
@@ -4,5 +4,7 @@ class ApplicationVersion < ApplicationRecord
   belongs_to :application
   belongs_to :previous_version, class_name: "ApplicationVersion", optional: true
 
+  validates :current, uniqueness: { scope: :application_id }, if: :current
+
   delegate :authority, :council_reference, to: :application
 end

--- a/app/models/application_version.rb
+++ b/app/models/application_version.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ApplicationVersion < ApplicationRecord
+  belongs_to :application
+  belongs_to :previous_version, class_name: "ApplicationVersion", optional: true
+
+  delegate :authority, :council_reference, to: :application
+end

--- a/db/migrate/20190320005757_add_application_versions_table.rb
+++ b/db/migrate/20190320005757_add_application_versions_table.rb
@@ -1,0 +1,40 @@
+class AddApplicationVersionsTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :application_versions do |t|
+      # Can't create a foreign key constraints to this table until this table
+      # is created. So, doing it below as seperate steps
+      t.references :application, null: false, type: :int
+      t.references :previous_version
+
+      t.boolean :current, null: false
+
+      # Core data that we get by scraping
+      t.text :address, null: false
+      t.text :description, null: false
+      t.string :info_url, limit: 1024, null: false
+      t.string :comment_url, limit: 1024
+      t.date :date_received
+      t.date :on_notice_from
+      t.date :on_notice_to
+      t.timestamp :date_scraped, default: -> { "CURRENT_TIMESTAMP" }, null: false
+
+      # Fields populated by geocoding (which includes normalising and
+      # splitting addresses)
+      t.float :lat
+      t.float :lng
+      t.string :suburb, limit: 50
+      t.string :state, limit: 10
+      t.string :postcode, limit: 4
+
+      t.timestamps
+
+      t.index :date_scraped
+      t.index [:lat, :lng, :date_scraped]
+      t.index :postcode
+      t.index :state
+      t.index :suburb
+    end
+    add_foreign_key :application_versions, :applications
+    add_foreign_key :application_versions, :application_versions, column: :previous_version_id
+  end
+end

--- a/db/migrate/20190320024550_copy_data_to_application_versions.rb
+++ b/db/migrate/20190320024550_copy_data_to_application_versions.rb
@@ -1,0 +1,48 @@
+class CopyDataToApplicationVersions < ActiveRecord::Migration[5.2]
+  def up
+    execute <<-SQL
+      INSERT INTO application_versions (
+        application_id,
+        current,
+        address,
+        description,
+        info_url,
+        comment_url,
+        date_received,
+        on_notice_from,
+        on_notice_to,
+        date_scraped,
+        lat,
+        lng,
+        suburb,
+        state,
+        postcode,
+        created_at,
+        updated_at
+      )
+      SELECT
+        id,
+        TRUE,
+        address,
+        description,
+        info_url,
+        comment_url,
+        date_received,
+        on_notice_from,
+        on_notice_to,
+        date_scraped,
+        lat,
+        lng,
+        suburb,
+        state,
+        postcode,
+        NOW(),
+        NOW()
+      FROM applications
+    SQL
+  end
+
+  def down
+    ApplicationVersion.delete_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_19_233210) do
+ActiveRecord::Schema.define(version: 2019_03_20_005757) do
 
   create_table "active_admin_comments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci", force: :cascade do |t|
     t.string "resource_id", null: false
@@ -50,6 +50,34 @@ ActiveRecord::Schema.define(version: 2019_03_19_233210) do
     t.datetime "updated_at", null: false
     t.index ["application_id"], name: "index_application_redirects_on_application_id"
     t.index ["redirect_application_id"], name: "fk_rails_24f1a5992a"
+  end
+
+  create_table "application_versions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci", force: :cascade do |t|
+    t.integer "application_id", null: false
+    t.bigint "previous_version_id"
+    t.boolean "current", null: false
+    t.text "address", null: false
+    t.text "description", null: false
+    t.string "info_url", limit: 1024, null: false
+    t.string "comment_url", limit: 1024
+    t.date "date_received"
+    t.date "on_notice_from"
+    t.date "on_notice_to"
+    t.timestamp "date_scraped", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.float "lat"
+    t.float "lng"
+    t.string "suburb", limit: 50
+    t.string "state", limit: 10
+    t.string "postcode", limit: 4
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["application_id"], name: "index_application_versions_on_application_id"
+    t.index ["date_scraped"], name: "index_application_versions_on_date_scraped"
+    t.index ["lat", "lng", "date_scraped"], name: "index_application_versions_on_lat_and_lng_and_date_scraped"
+    t.index ["postcode"], name: "index_application_versions_on_postcode"
+    t.index ["previous_version_id"], name: "index_application_versions_on_previous_version_id"
+    t.index ["state"], name: "index_application_versions_on_state"
+    t.index ["suburb"], name: "index_application_versions_on_suburb"
   end
 
   create_table "applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci", force: :cascade do |t|
@@ -301,6 +329,8 @@ ActiveRecord::Schema.define(version: 2019_03_19_233210) do
   end
 
   add_foreign_key "application_redirects", "applications", column: "redirect_application_id"
+  add_foreign_key "application_versions", "application_versions", column: "previous_version_id"
+  add_foreign_key "application_versions", "applications"
   add_foreign_key "applications", "authorities", name: "applications_authority_id_fk"
   add_foreign_key "comments", "applications"
   add_foreign_key "comments", "councillors"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_20_005757) do
+ActiveRecord::Schema.define(version: 2019_03_20_024550) do
 
   create_table "active_admin_comments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci", force: :cascade do |t|
     t.string "resource_id", null: false

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -28,6 +28,14 @@ FactoryBot.define do
     end
   end
 
+  factory :application_version do
+    association :application, factory: :geocoded_application
+    address { "A test address" }
+    description { "pretty" }
+    info_url { "http://foo.com" }
+    current { false }
+  end
+
   factory :application_redirect do
     application_id { 1 }
     association :redirect_application, factory: :geocoded_application

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -289,4 +289,92 @@ describe Application do
       end
     end
   end
+
+  describe "versioning" do
+    let(:application) do
+      Application.create!(
+        authority: authority,
+        date_scraped: Date.new(2001, 1, 10),
+        council_reference: "123/45",
+        address: "Some kind of address",
+        description: "A really nice change",
+        info_url: "http://foo.com",
+        comment_url: "http://foo.com/comment",
+        date_received: Date.new(2001, 1, 1),
+        on_notice_from: Date.new(2002, 1, 1),
+        on_notice_to: Date.new(2002, 2, 1),
+        lat: 1.0,
+        lng: 2.0,
+        suburb: "Sydney",
+        state: "NSW",
+        postcode: "2000"
+      )
+    end
+
+    it "should automatically create a version on creating an application" do
+      expect(application.versions.count).to eq 1
+    end
+
+    it "should populate the version with the current information" do
+      version = application.versions.first
+      expect(version.application).to eq application
+      expect(version.previous_version).to be_nil
+      expect(version.authority).to eq authority
+      expect(version.date_scraped).to eq Date.new(2001, 1, 10)
+      expect(version.council_reference).to eq "123/45"
+      expect(version.address).to eq "Some kind of address"
+      expect(version.description).to eq "A really nice change"
+      expect(version.info_url).to eq "http://foo.com"
+      expect(version.comment_url).to eq "http://foo.com/comment"
+      expect(version.date_received).to eq Date.new(2001, 1, 1)
+      expect(version.on_notice_from).to eq Date.new(2002, 1, 1)
+      expect(version.on_notice_to).to eq Date.new(2002, 2, 1)
+      expect(version.lat).to eq 1.0
+      expect(version.lng).to eq 2.0
+      expect(version.suburb).to eq "Sydney"
+      expect(version.state).to eq "NSW"
+      expect(version.postcode).to eq "2000"
+      expect(version.current).to eq true
+    end
+
+    context "updated application with new data" do
+      before(:each) { application.update(address: "A better kind of address") }
+
+      it "should create a new version when updating" do
+        expect(application.versions.count).to eq 2
+      end
+
+      it "should have the new value" do
+        expect(application.address).to eq "A better kind of address"
+      end
+
+      it "should have the new value in the latest version" do
+        expect(application.versions[0].address).to eq "A better kind of address"
+      end
+
+      it "should point to the previous version in the latest version" do
+        expect(application.versions[0].previous_version).to eq application.versions[1]
+      end
+
+      it "should have the old value in the previous version" do
+        expect(application.versions[1].address).to eq "Some kind of address"
+      end
+
+      it "the latest version should now be current" do
+        expect(application.versions[0].current).to eq true
+      end
+
+      it "the previous version should now be not current" do
+        expect(application.versions[1].current).to eq false
+      end
+    end
+
+    context "updated application with unchanged data" do
+      before(:each) { application.update(address: "Some kind of address") }
+
+      it "should not create a new version when the data hasn't changed" do
+        expect(application.versions.count).to eq 1
+      end
+    end
+  end
 end

--- a/spec/models/application_version_spec.rb
+++ b/spec/models/application_version_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ApplicationVersion do
+  describe "validations" do
+    describe "current" do
+      # Creates a bare application with no application versions
+      let(:application1) do
+        application = create(:geocoded_application)
+        application.versions.destroy_all
+        application
+      end
+
+      let(:application2) do
+        application = create(:geocoded_application)
+        application.versions.destroy_all
+        application
+      end
+
+      it "should allow multiple versions for the same application that are not current" do
+        create(:application_version, application: application1, current: false)
+        version2 = build(:application_version, application: application1, current: false)
+        expect(version2).to be_valid
+      end
+
+      it "should allow one version for the same application to be current" do
+        create(:application_version, application: application1, current: false)
+        version2 = build(:application_version, application: application1, current: true)
+        expect(version2).to be_valid
+      end
+
+      it "should allow one version for the same application to be current" do
+        create(:application_version, application: application1, current: true)
+        version2 = build(:application_version, application: application1, current: false)
+        expect(version2).to be_valid
+      end
+
+      it "should not allow more than one version to be current" do
+        create(:application_version, application: application1, current: true)
+        version2 = build(:application_version, application: application1, current: true)
+        expect(version2).to_not be_valid
+      end
+
+      it "should allow more than one version to be current for different applications" do
+        create(:application_version, application: application1, current: true)
+        version2 = build(:application_version, application: application2, current: true)
+        expect(version2).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is the first step in versioning application data. It creates a table to hold the versioned data and migrates the data across. It also automatically creates the data on new applications and when applications are updated (which in practise they are currently not).

However, the web app doesn't currently use the versioned data to display any of the information. It currently comes from the applications table, just as before. This is to ensure that the data migration can happen as part of this PR before we deploy the rest of the changes