### PR TITLE
Update CODEOWNERS to include new teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 # This file is used to define code owners for this repository.
 # See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-* @openaustralia/staff-devs
-
+* @openaustralia/code-reviewers @openaustralia/team-planningalerts


### PR DESCRIPTION
- Code ownership has been updated from `@openaustralia/staff-devs` (which no longer exists) to `@openaustralia/code-reviewers` and `@openaustralia/team-planningalerts`. Only one member from either team will need to approve a PR.