### PR TITLE
use admin policies for admin comments

### DIFF
--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -60,7 +60,7 @@ module Admin
     sig { void }
     def resend
       comment = Comment.find(T.cast(params[:id], String))
-      authorize comment, :resend?
+      authorize(comment, :resend?, policy_class: Admin::AuthorityPolicy)
       comment.send_comment!
       redirect_to({ action: :show }, notice: t(".success"))
     end


### PR DESCRIPTION
## Relevant issue(s)
https://github.com/openaustralia/planningalerts/issues/1969

## What does this do?
tells cancancan to use the admin policy

## Why was this needed?

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
