### PR TITLE
Set the default username for Capistrano deployment

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,5 +1,5 @@
 # typed: false
 
-aws_ec2_register
+aws_ec2_register(user: "deploy")
 
 set :deploy_to, "/srv/www/production"


### PR DESCRIPTION
## Relevant issue(s)
- N/A

## What does this do?
- Sets the username to SSH to servers using capistrano to "deploy"

## Why was this needed?
- Reduces the amount of local configuration required to get SSH to work via Capistrano

## Implementation/Deploy Steps (Optional)
- No deployment required

## Notes to reviewer (Optional)
- This can be tested by making sure there is no custom configuration in ~/.ssh/config and then attempting to run a capistrano command.
