### PR TITLE
Allow override of DB host and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ docker rm 98ba717d944d01976ac9074e6a1119e70d3aebd53f5d5449957324926f0bbb4b
 docker volume rm planningalerts_gem_cache
 ```
 
+### Overriding DB host and port for non docker dev
+
+To use docker for the database, but allow you to run the application locally, for example to simplify single step debugging in IDE's, you can overide the following ENV vars in `.envrc` (for `direnv`) or manually:
+
+```
+export DB_HOST=localhost
+export DB_PORT=15432
+```
+
 ### Setup The Database
 
 Set up the databases - `docker compose run web bin/rake db:setup`

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,21 +6,24 @@ default: &default
 
 development:
   <<: *default
-  host: postgres
+  host: <%= ENV.fetch("DB_HOST") { "postgres" } %>
+  port: <%= ENV.fetch("DB_PORT") { "5432" } %>
   database: pa_development
   username: postgres
   password: password
 
 test:
   <<: *default
-  host: postgres
+  host: <%= ENV.fetch("DB_HOST") { "postgres" } %>
+  port: <%= ENV.fetch("DB_PORT") { "5432" } %>
   database: pa_test
   username: postgres
   password: password
 
 production:
   <<: *default
-  host: "<%= Rails.application.credentials.dig(:database, :postgres, :host) %>"
+  host: "<%= ENV.fetch("DB_HOST") { Rails.application.credentials.dig(:database, :postgres, :host) } %>"
+  port: <%= ENV.fetch("DB_PORT") { "5432" } %>
   database: pa-production
   # For postgres read-only access (during maintenance switch out the two lines below)
   # username: pa-production-readonly


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/planningalerts/issues/2016

## What does this do?

Allows you to run on different DB host and ports, which means you can run the app locally but use the docker postgres DB container

## Why was this needed?

Makes debugging with Rubymine easier

## Implementation/Deploy Steps (Optional)

Follow instructions in README

## Notes to reviewer (Optional)
