### PR TITLE
Ignore docker compose overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
+# Ignore docker compose overrides
+/docker-compose.override.yml
+
 # Ignore bundler config.
 .bundle
 


### PR DESCRIPTION
## Relevant issue(s)

* #2014
* #2016

## What does this do?

Ignores local docker compose override files

## Why was this needed?

So I could use docker compose the way I prefer on my local system, running DB in docker and mostly running ruby code via IDE

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
