### PR TITLE
Migrate Google Maps from client ID to API key before May 2026 on PlanningAlerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
+# Ignore docker compose overrides
+/docker-compose.override.yml
+
 # Ignore bundler config.
 .bundle
 


### PR DESCRIPTION
## Relevant issue(s)

* #2014

## What does this do?

Changes to using new key type

## Why was this needed?

Existing key will no longer work from May 2026

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
