### PR TITLE
Increase default trial daily limit from 1 to 10

### DIFF
--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -71,7 +71,7 @@ class ApiKey < ApplicationRecord
 
   sig { returns(Integer) }
   def self.default_daily_limit_trial
-    1
+    10
   end
 
   # TODO: Should this be longer (like 28 days)?


### PR DESCRIPTION
## Relevant issue(s)
Fixes #2030

## What does this do?
Increases the default daily API call limit for trial users from 1 to 10.

## Why was this needed?
The previous limit of 1 call per day was insufficient for users to effectively test the service without risking abuse.

## Implementation/Deploy Steps (Optional)
- Deployment using existing processes

## Notes to reviewer (Optional)
