### PR TITLE
Add Dependabot Tapioca workflow

### DIFF
--- a/.github/workflows/dependabot-tapioca.yml
+++ b/.github/workflows/dependabot-tapioca.yml
@@ -56,6 +56,8 @@ jobs:
           bin/tapioca dsl
           bin/tapioca dsl --environment=test
       - name: Commit updated RBI files
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           if git diff --quiet --exit-code -- sorbet; then
             echo "No Tapioca changes to commit"
@@ -66,4 +68,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add sorbet
           git commit -m "Update Tapioca RBI files"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          git push origin HEAD:$PR_HEAD_REF

--- a/.github/workflows/dependabot-tapioca.yml
+++ b/.github/workflows/dependabot-tapioca.yml
@@ -1,0 +1,69 @@
+name: Dependabot Tapioca
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+
+jobs:
+  update_tapioca:
+    if: >
+      github.actor == 'dependabot[bot]' &&
+      startsWith(github.head_ref, 'dependabot/bundler/') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgis/postgis:15-3.3
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: "postgis://postgres:postgres@localhost:5432/rails_test"
+    permissions:
+      contents: write
+    concurrency:
+      group: dependabot-tapioca-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout Dependabot branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1.305.0
+        with:
+          bundler-cache: true
+      - name: Create database
+        run: bin/rails db:create
+      - name: Set up database schema
+        run: bin/rails db:schema:load
+      - name: Update Tapioca RBI files
+        run: |
+          bin/tapioca gem
+          bin/tapioca dsl
+          bin/tapioca dsl --environment=test
+      - name: Commit updated RBI files
+        run: |
+          if git diff --quiet --exit-code -- sorbet; then
+            echo "No Tapioca changes to commit"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add sorbet
+          git commit -m "Update Tapioca RBI files"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?
Adds a GitHub Actions workflow for Dependabot to automatically update Tapioca RBI files.

## Why was this needed?
CI will always fail when Dependabot creates a PR, as the Tapioca gems are not updated. This new Github action ensures that when Dependabot creates or updates a PR, the Tapioca RBI files are updated.

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)

