### PR TITLE
Set systemd MemoryMax to restart puma/sidekiq upon excessive memory usage

### DIFF
--- a/Procfile.production
+++ b/Procfile.production
@@ -1,1 +1,1 @@
-worker: rvm . do bundle exec sidekiq -q default -q mailers -q searchkick -e production
+worker: rvm . do bundle exec sidekiq -c 3 -q default -q mailers -q searchkick -e production

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -74,6 +74,8 @@ set :aws_ec2_contact_point, :public_dns
 # Tagging options
 set :tagging3_format, ':stage_:release'
 
+set :foreman_timeout, 300
+
 desc "upload memcache.yml configuration"
 task :upload_memcache_config do
   # Each host is also running memcached. So...
@@ -88,7 +90,12 @@ namespace :foreman do
   desc "Export the Procfile to Ubuntu's upstart scripts"
   task :export do
     on roles(:app) do
-      execute "cd #{current_path} && sudo bundle exec foreman export systemd /etc/systemd/system -e .env.production -u deploy -a #{fetch(:application)}-#{fetch(:stage)} -f Procfile.production -l #{shared_path}/log --root #{current_path}"
+      execute "cd #{current_path} && " \
+        "sudo bundle exec " \
+        "foreman export systemd /etc/systemd/system -e .env.production -u deploy " \
+        "-a #{fetch(:application)}-#{fetch(:stage)} -f Procfile.production " \
+        "--timeout #{fetch(:foreman_timeout)} --template #{current_path}/config/foreman " \
+        "-l #{shared_path}/log --root #{current_path}"
     end
   end
 

--- a/config/deploy/templates/puma.service.erb
+++ b/config/deploy/templates/puma.service.erb
@@ -26,10 +26,9 @@ Restart=on-failure
 <%="StandardOutput=append:#{fetch(:puma_access_log)}" if fetch(:puma_access_log) %>
 <%="StandardError=append:#{fetch(:puma_error_log)}" if fetch(:puma_error_log) %>
 SyslogIdentifier=<%= fetch(:puma_service_unit_name) %>
-# Puma master + 3 workers start at ~260 MB each, capped at 500 MB per worker
-# Total limit = 3 workers x 500 MB + 30 MB master = 1,530 MB
-# Consistent with Sidekiq's 2x fresh-start ratio
-MemoryMax=1500M
+# Puma master + 3 workers start at ~260 MB each, capped at 550 MB per worker
+# Total limit = 3 workers x 550 MB + 30 MB master = 1,680 MB
+MemoryMax=1680M
 TimeoutStopSec=300
 [Install]
 WantedBy=<%=(fetch(:puma_systemctl_user) == :system) ? "multi-user.target" : "default.target"%>

--- a/config/deploy/templates/puma.service.erb
+++ b/config/deploy/templates/puma.service.erb
@@ -1,0 +1,35 @@
+# Based on capistrano3-puma-6.0.0.beta.1/lib/capistrano/templates/puma.service.erb
+# This file tells systemd how to run Puma as a 24/7 long-running daemon.
+#
+# Use `journalctl -u <%= fetch(:puma_service_unit_name) %> -rn 100` to view the last 100 lines of log output.
+#
+[Unit]
+Description=Puma HTTP Server for <%= "#{fetch(:application)} (#{fetch(:stage)})" %>
+<%= "Requires=#{fetch(:puma_service_unit_name)}.socket" if fetch(:puma_enable_socket_service) %>
+After=syslog.target network.target
+[Service]
+Type=<%= service_unit_type %>
+WatchdogSec=10
+<%="User=#{puma_user(@role)}" if fetch(:puma_systemctl_user) == :system %>
+WorkingDirectory=<%= current_path %>
+ExecStart=<%= expanded_bundle_command %> exec puma -e <%= fetch(:puma_env) %>
+ExecReload=/bin/kill -USR1 $MAINPID
+<%- Array(fetch(:puma_service_unit_env_files)).each do |file| %>
+<%="EnvironmentFile=#{file}" -%>
+<% end -%>
+<% Array(fetch(:puma_service_unit_env_vars)).each do |environment_variable| %>
+<%="Environment=\"#{environment_variable}\"" -%>
+<% end -%>
+# if we crash, restart
+RestartSec=1
+Restart=on-failure
+<%="StandardOutput=append:#{fetch(:puma_access_log)}" if fetch(:puma_access_log) %>
+<%="StandardError=append:#{fetch(:puma_error_log)}" if fetch(:puma_error_log) %>
+SyslogIdentifier=<%= fetch(:puma_service_unit_name) %>
+# Puma master + 3 workers start at ~260 MB each, capped at 500 MB per worker
+# Total limit = 3 workers x 500 MB + 30 MB master = 1,530 MB
+# Consistent with Sidekiq's 2x fresh-start ratio
+MemoryMax=1500M
+TimeoutStopSec=300
+[Install]
+WantedBy=<%=(fetch(:puma_systemctl_user) == :system) ? "multi-user.target" : "default.target"%>

--- a/config/foreman/systemd/process.service.erb
+++ b/config/foreman/systemd/process.service.erb
@@ -1,0 +1,24 @@
+# Based on foreman-0.88.1/data/export/systemd/process.service.erb
+[Unit]
+PartOf=<%= app %>.target
+StopWhenUnneeded=yes
+
+[Service]
+User=<%= user %>
+WorkingDirectory=<%= engine.root %>
+Environment=PORT=<%= port %>
+Environment=PS=<%= process_name %>
+<% engine.env.each_pair do |var,env| -%>
+Environment="<%= var %>=<%= env %>"
+<% end -%>
+ExecStart=/bin/bash -lc 'exec -a "<%= app %>-<%= process_name %>" <%= process.command %>'
+Restart=always
+RestartSec=14s
+StandardInput=null
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=%n
+KillMode=mixed
+TimeoutStopSec=<%= engine.options[:timeout] %>
+# Limit memory usage to 500MB - it normally starts around 250M and slowly climbs from there
+MemoryMax=500M

--- a/config/foreman/systemd/process.service.erb
+++ b/config/foreman/systemd/process.service.erb
@@ -20,5 +20,5 @@ StandardError=syslog
 SyslogIdentifier=%n
 KillMode=mixed
 TimeoutStopSec=<%= engine.options[:timeout] %>
-# Limit memory usage to 500MB - it normally starts around 250M and slowly climbs from there
-MemoryMax=500M
+# Limit memory usage to 700MB - it normally starts around 250M and slowly climbs from there
+MemoryMax=700M


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/planningalerts/issues/2057

## What does this do?

* configures systemd to monitor memory usage and signal service to restart if it exceeds
  * 700MB for the one sidekiq process
  * 1680MB for the 3 puma workers and 1 master process group
  * Extends timeout from signal to gracefully restart to 300 seconds before systemd terminates service
* Drops sidekiq from 5 to 3 threads to reduce memory usage

Builds on the following (which must be merged first):
* https://github.com/openaustralia/planningalerts/pull/2062

## Why was this needed?

NewRelic was alerting on over memory usage as memory leaks where slowly but surely accumulating. This makes systemd restart puma and/or sidekiq when they exceed the allocation.

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)

This has dropped memory usage significantly on both servers.

This is working, with NewRelic reporting 68.9% for the top usage. 

PA1 has:
```
$ uptime
 11:09:49 up 6 days,  4:16,  1 user,  load average: 0.39, 0.33, 0.28

deploy@ip-172-31-18-88:~$ free -m
               total        used        free      shared  buff/cache   available
Mem:            3836        2437         249           2        1149        1134
Swap:            511         227         284

deploy@ip-172-31-18-88:~$ ps auxf | (head -1 ; egrep '[s]idek|[p]uma')
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
deploy       435  2.9 18.0 2010120 709228 ?      Ssl  Jun04 265:17 sidekiq 7.3.0 production [0 of 3 busy]
deploy   2072097  0.0  0.4 691908 16320 ?        Ssl  Jun09   0:41  \_ puma 6.4.2 (tcp://0.0.0.0:8000) [20260428064149]
deploy   2072343  5.8  9.8 1835052 385296 ?      Sl   Jun09  75:10      \_ puma: cluster worker 0: 2072097 [20260428064149]
deploy   2072345  4.6 10.2 1824604 401152 ?      Sl   Jun09  59:24      \_ puma: cluster worker 1: 2072097 [20260428064149]
deploy   2072351  5.0 19.6 2289896 772960 ?      Sl   Jun09  64:34      \_ puma: cluster worker 2: 2072097 [20260428064149]
```

PA2 - note one worker has a lot more RSS than the others - puma is restarted when the total exceeds the limit...
```
deploy@ip-172-31-18-88:~$ uptime
 13:34:26 up 6 days,  6:40,  2 users,  load average: 0.35, 0.38, 0.42

deploy@ip-172-31-18-88:~$  free -m
               total        used        free      shared  buff/cache   available
Mem:            3836        2439         337           2        1059        1132
Swap:            511         250         261

deploy@ip-172-31-18-88:~$ ps auxf | (head -1 ; egrep '[s]idek|[p]uma')
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
deploy       435  2.9 18.1 2010120 711804 ?      Ssl  Jun04 271:10 sidekiq 7.3.0 production [0 of 3 busy]
deploy   2072097  0.0  0.4 691908 16320 ?        Ssl  Jun09   0:46  \_ puma 6.4.2 (tcp://0.0.0.0:8000) [20260428064149]
deploy   2072343  6.1  9.9 1835116 390144 ?      Sl   Jun09  87:39      \_ puma: cluster worker 0: 2072097 [20260428064149]
deploy   2072345  5.1 10.4 1826588 412156 ?      Sl   Jun09  72:37      \_ puma: cluster worker 1: 2072097 [20260428064149]
deploy   2072351  5.5 19.4 2291368 765124 ?      Sl   Jun09  78:26      \_ puma: cluster worker 2: 2072097 [20260428064149]
```
