### PR TITLE
Fix/remove unused flipper feature correct test of maintenance_mode flipper

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,7 +33,7 @@ class ApplicationController < ActionController::Base
   def check_for_write_during_maintenance_mode(error)
     # Checking for postgres responses that we don't have permission which means
     # we're trying to do a write operation when we're only allowed to do read operations.
-    raise error unless Flipper.enabled?(:maintance_mode) && error.message.match?(/PG::InsufficientPrivilege/)
+    raise error unless Flipper.enabled?(:maintenance_mode) && error.message.match?(/PG::InsufficientPrivilege/)
 
     Rails.logger.warn "Write attempted during maintenance mode: #{error}"
 

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -8,7 +8,6 @@ Flipper::UI.configure do |config|
   config.descriptions_source = lambda do |_keys|
     # This should be a complete list of all features being currently used in the codebase
     {
-      "disable_streetview_in_emails" => "Disables Google streetview in email. Do this to save money",
       "disable_streetview_in_app" => "Disable Google streetview in the main application. Do this to save money",
       "extra_options_on_address_search" => "Add extra options to filter by time/space when searching address",
       "show_authority_map" => "Show boundary of authority on a map",


### PR DESCRIPTION
## Description

* Removes unused `disable_streetview_in_emails` flipper feature
* Corrects usage of `maintenance_mode` flipper (misspelt as `maintenance_mode`)
## Motivation and Context

Found whilst flipper researching:
* https://github.com/openaustralia/oaf-internal/issues/237

## How Has This Been Tested?

`bundle exec rake` passes

## Screenshots (if appropriate):

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
