### PR TITLE
Document application council_reference and info_url size limits

### DIFF
--- a/app/views/documentation/how_to_write_a_scraper.html.erb
+++ b/app/views/documentation/how_to_write_a_scraper.html.erb
@@ -90,7 +90,9 @@
               <td>council_reference</td>
               <td>TA/00323/2012</td>
               <td>
-                The ID that the council has given the planning application. This also must be the unique key for this data set.
+                The ID that the council has given the planning application.
+                This also must be the unique key for this data set.
+                Maximum 50 characters.
               </td>
             </tr>
             <tr>
@@ -118,6 +120,7 @@
                 users to click through a license to access planning application. In this case be careful about what URL you provide.
                 Test clicking the link in a browser that hasn't established a session with the council's site to ensure users of Planning Alerts
                 will be able to click the link and not be presented with an error.
+                Maximum 1024 characters.
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
## Description

Adds the max size fields can be in https://www.planningalerts.org.au/how_to_write_a_scraper

## Motivation and Context

Scraper exceeded undocumented limit, see:
* https://github.com/planningalerts-scrapers/issues/issues/1262

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

- **Other**: documentation

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
