### PR TITLE
Fix spelling and grammar in user-visible text

### DIFF
--- a/app/views/alerts/edit.html.erb
+++ b/app/views/alerts/edit.html.erb
@@ -38,4 +38,4 @@
 <%# TODO: #1768 Show an error of some sort if the last delivery was not successful %>
 <%= pa_button_to "Delete this alert", @alert,
                  method: :delete, type: :secondary, icon: :trash, form_class: "mt-8",
-                 confirm: "Are you sure you want to unsubscribe for email alerts for #{@alert.address}?" %>
+                 confirm: "Are you sure you want to unsubscribe from email alerts for #{@alert.address}?" %>

--- a/app/views/application/_maintenance.html.erb
+++ b/app/views/application/_maintenance.html.erb
@@ -1,7 +1,7 @@
 <%# TODO: Do a proper design for this maintenance banner. Just taken the welcome banner as a starting point %>
 <% if Flipper.enabled?(:maintenance_mode) %>
   <div class="flex items-start gap-5 p-8 mt-8 text-xl text-white rounded-lg bg-lavender">
-    We're doing some maintenance on Planning Alerts. Is is currently in read-only mode which means you can still browse the site
+    We're doing some maintenance on Planning Alerts. It is currently in read-only mode which means you can still browse the site
     but you won't be able to make any changes for the time being. Please try again later.
   </div>
 <% end %>

--- a/app/views/documentation/_faq_commenting_address.html.erb
+++ b/app/views/documentation/_faq_commenting_address.html.erb
@@ -3,7 +3,7 @@
   To maintain your privacy online we do <b>not</b> display your address on the site.
 </p>
 <p>
-  We do this because the vast majority of planning authorities ask for peoples' addresses to be
+  We do this because the vast majority of planning authorities ask for people's addresses to be
   included in comments on
   applications. There are a variety of reasons for this. Some councils will reply via letter even when
   the comment comes in via email. Also, the council may choose to take comments seriously only if they

--- a/app/views/documentation/about.html.erb
+++ b/app/views/documentation/about.html.erb
@@ -13,7 +13,7 @@
   Planning Alerts is a free Australian service which searches as many planning authority websites as it can find and emails
   you details of applications near you. The aim of this to enable shared scrutiny of what is being built (and
   <%= pa_link_to "knocked down", "https://www.flickr.com/photos/kentjohnson/3634555801/", title: "Carlton and United Brewery Site, Broadway Sydney" %>)
-  in peoples' communities.
+  in people's communities.
 </p>
 
 <p class="mt-6 text-xl text-navy">

--- a/app/views/documentation/api_developer.html.erb
+++ b/app/views/documentation/api_developer.html.erb
@@ -54,7 +54,7 @@
       <%= render HeadingComponent.new(tag: :h3).with_content("Single Location by longitude/latitude") %>
       <p class="mt-4 text-xl text-navy">
         Return applications near a given longitude/latitude. The area included is a circle with a radius of the given size (in metres)
-        with the longitude/latitude at its center. Suggested sizes are 400, 800 or 4000 metres.
+        with the longitude/latitude at its centre. Suggested sizes are 400, 800 or 4000 metres.
       </p>
       <code class="block my-8 text-xl break-all text-navy">
         <%= api_example_latlong_url_html(format: "json", key: api_key) %>

--- a/app/views/documentation/api_howto.html.erb
+++ b/app/views/documentation/api_howto.html.erb
@@ -38,7 +38,7 @@
       <p>Lots of people!</p>
       <p class="mt-6">
         Real estate developers and agents, construction companies, urban planners, architects,
-        local government and municipalities, property management firms, community advocacy groups, environmental and heritage organizations,
+        local government and municipalities, property management firms, community advocacy groups, environmental and heritage organisations,
         academics,
         legal firms, conveyancers, utility companies, insurance companies, researchers, tech startups and app developers are interested in this data.
       </p>

--- a/app/views/documentation/get_involved.html.erb
+++ b/app/views/documentation/get_involved.html.erb
@@ -30,7 +30,7 @@
         for your local planning authority.
         Using our
         <%= pa_link_to "morph.io", "https://morph.io/" %>
-        scraping platform you can write it in any one of your favorite languages: Ruby, Python, JavaScript, Perl or PHP.
+        scraping platform you can write it in any one of your favourite languages: Ruby, Python, JavaScript, Perl or PHP.
       </p>
       <p>
         <%= pa_link_to "Read our step-by-step instructions", how_to_write_a_scraper_path %>

--- a/app/views/documentation/how_to_write_a_scraper.html.erb
+++ b/app/views/documentation/how_to_write_a_scraper.html.erb
@@ -117,7 +117,7 @@
               <td>
                 A URL that provides more information about the planning application.
                 This should be a persistent URL that preferably is specific to this particular application. In many cases councils force
-                users to click through a license to access planning application. In this case be careful about what URL you provide.
+                users to click through a licence to access a planning application. In this case be careful about what URL you provide.
                 Test clicking the link in a browser that hasn't established a session with the council's site to ensure users of Planning Alerts
                 will be able to click the link and not be presented with an error.
                 Maximum 1024 characters.
@@ -221,7 +221,7 @@
       wording or corrects a mistake) your scraper should get the most up to date information.
     </p>
     <p>
-      For that reason, it's good practise for your scraper to look back a reasonable amount of
+      For that reason, it's good practice for your scraper to look back a reasonable amount of
       time (one month is good) in which you scrape all applications that might have changed in that
       time. That way you're most likely to catch any changes. Often it's not possible to simply
       get a list of applications that recently changed. Instead you have to scrape say a list

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,7 +50,7 @@ en:
               taken: "You already have an account with that email address. Please sign into your account."
               taken_activation: "You already have an account with that email address. Please activate your account."
               already_activated: "Account with that email address has already been activated"
-              not_found: "We don't know recognise that email address. Is there another one you might have used?"
+              not_found: "We don't recognise that email address. Is there another one you might have used?"
   errors:
     messages:
       not_a_date: "is not a date"

--- a/spec/features/activate_account_spec.rb
+++ b/spec/features/activate_account_spec.rb
@@ -99,7 +99,7 @@ describe "Activate account" do
       fill_in "Email", with: "matthew@oaf.org.au"
       click_on "Send me an email"
 
-      expect(page).to have_content "We don't know recognise that email address"
+      expect(page).to have_content "We don't recognise that email address"
     end
   end
 


### PR DESCRIPTION
## Description

Eleven single-line prose corrections to user-visible text, grouped as in #2103.

**Live UI messages** (the two the public actually hits)

- `config/locales/en.yml` — the sign-in / activation error read "We don't **know recognise** that email address". Dropped the stray "know".
- `app/views/application/_maintenance.html.erb` — the maintenance banner read "**Is is** currently in read-only mode" → "**It is**".

**American spellings Australianised**

- `documentation/get_involved.html.erb` — favorite → favourite
- `documentation/api_howto.html.erb` — organizations → organisations
- `documentation/api_developer.html.erb` — center → centre
- `documentation/how_to_write_a_scraper.html.erb` — "click through a **license**" → **licence** (noun), and added the missing article: "access **a** planning application"
- `documentation/how_to_write_a_scraper.html.erb` — "good **practise**" → **practice** (noun)

**Grammar**

- `documentation/about.html.erb` — peoples' communities → people's communities
- `documentation/_faq_commenting_address.html.erb` — peoples' addresses → people's addresses. This partial renders in two places (the FAQ page and the comment form info popup), so the one fix covers both.
- `alerts/edit.html.erb` — the delete-alert confirm dialog: "unsubscribe **for** email alerts for…" → "unsubscribe **from**".

**One spec updated:** `spec/features/activate_account_spec.rb` asserted on the buggy sign-in error string, so it changes in the same commit.

### Noticed but deliberately left out of scope

- `reply_to_no_reply_mailer/reply.html.erb` — "a crazy **amount of** people" is strictly "number of people", but that email's tone is deliberately warm and casual, and the stricter form stiffens it. Left as-is.
- `config/application.rb` — "in practise" in a code comment. Not user-visible; keeping this change focused on the prose people read.
- `how_to_write_a_scraper.html.erb` — "planningalerts-scrapers organization" is a GitHub org proper noun, not a spelling error.

## Motivation and Context

Resolves #2103.

Australian English is our standard, and two of these are errors the public hits directly: the sign-in error is ungrammatical, and the maintenance banner opens with "Is is". The rest are on the documentation pages people read when getting involved or writing a scraper.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system — reviewed the diff line by line; every change is a single in-place prose substitution with no reflowing or whitespace change.
- [x] Ran automated tests on my own system — `docker compose run --rm web bin/rspec spec/features/activate_account_spec.rb` (covers the changed sign-in error string) and `docker compose run --rm web bin/rake ci:lint` (rubocop + erb_lint + brakeman). `ci:type` is unaffected; no signatures change.
- [x] Confirmed it passed the GitHub actions tests — all 7 checks green (`test`, `type_check`, `lint`, SonarCloud ×2, Socket Security ×2)

**Expected Percy diffs.** Percy snapshots cover pages touched here — About, API, API developer, Get Involved, Activate account, and the comment form via Application / Comment preview. The visual diffs are prose-only and expected; nothing about layout or styling changed.

## Screenshots (if appropriate):

N/A — text-only changes, quoted in full above.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

Drafted with AI assistance (Claude Code, model Opus 5). I reviewed every change against the source before submitting and I'm happy to explain any of them.

Assisted-by: Claude Code/claude-opus-5
