### PR TITLE
Remove misleading request count from API trial box

### DIFF
--- a/app/views/documentation/api_howto.html.erb
+++ b/app/views/documentation/api_howto.html.erb
@@ -180,7 +180,7 @@
         requests a day (returning up to a total of
         <%= number_with_delimiter(ApiKey.default_daily_limit_trial * Application.max_per_page) %>
         applications per day) for
-        <%= pluralize(ApiKey.default_trial_duration_days, "day") %>. (<%= number_with_delimiter(ApiKey.default_trial_duration_days) %> requests)
+        <%= pluralize(ApiKey.default_trial_duration_days, "day") %>.
       </p>
       <%= image_tag "illustration/key.svg", alt: "", size: "237x155", class: "my-8" %>
       <% if current_user %>

--- a/spec/features/documentation_pages_spec.rb
+++ b/spec/features/documentation_pages_spec.rb
@@ -83,6 +83,12 @@ describe "Browsing basic documentation pages" do
       end
     end
 
+    it "describes the trial limits without a contradictory request count" do
+      # The view breaks this sentence across several lines, so normalise whitespace
+      expect(page).to have_content("Enjoy up to 10 requests a day", normalize_ws: true)
+      expect(page).to have_no_content("(14 requests)", normalize_ws: true)
+    end
+
     # rubocop:disable RSpec/NoExpectationExample
     it "renders a snapshot for a visual diff", :js do
       page.percy_snapshot("API")


### PR DESCRIPTION
## Description

Removes the trailing "(14 requests)" from the "Instant access 14 day trial" box on the API page, in `app/views/documentation/api_howto.html.erb`. That figure rendered `ApiKey.default_trial_duration_days`, which is the trial length in days, dressed up as a request count.

The box now reads:

> Enjoy up to 10 requests a day (returning up to a total of 1,000 applications per day) for 14 days.

Also adds a spec to `spec/features/documentation_pages_spec.rb` asserting the sentence is there and "(14 requests)" isn't, so the wording can't regress quietly. It passes `normalize_ws: true` because the view breaks that sentence across several lines and Capybara's rack_test driver keeps the newlines in page text.

The Community and Standard plan cards higher up the same file keep their parentheticals. There the headline figure is applications, so converting to requests adds something.

## Motivation and Context

Fixes #2122.

Nothing in the system caps a trial key at 14 requests. `ApiKey.default_daily_limit_trial` is 10 a day, enforced by the Rack::Attack throttle, across the 14 days `ApiKeysController` sets on the key. So the parenthetical was both wrong and a contradiction of the sentence it sat inside: anyone reading carefully got two different numbers for the same limit.

It looks like it was copied from the plan cards, where the same pattern is correct, with the wrong constant dropped in. `app/views/api_keys/_create_key_box.html.erb` already describes this trial correctly, so this brings the two descriptions into line.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

The first two aren't ticked, and I'd rather say so than tick them. The change was written in a container with no working app environment (no Docker daemon, and the `pg` gem wouldn't build), so the suite couldn't be started and the page couldn't be loaded.

Verification rests on the Actions run for this PR, where `lint`, `type_check` and `test` have all passed.

Worth a second pair of eyes on the new spec in particular, since it has only ever run in CI.

## Screenshots (if appropriate):

Text-only change.

Before: `... for 14 days. (14 requests)`
After: `... for 14 days.`

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

The change is itself a wording fix on a documentation page, and nothing else documents the trial limits, so there's no further documentation to update.