### PR TITLE
Frame Planning Alerts as a library collection in site copy

### DIFF
--- a/app/views/alert_mailer/alert.html.erb
+++ b/app/views/alert_mailer/alert.html.erb
@@ -216,14 +216,14 @@
                   </p>
                   <p>
                     <strong>Planning Alerts</strong>
-                    is a free service where anyone can find out what is being built and knocked down in their area.
+                    is a searchable collection of Australian local government planning applications, where anyone can find out what is being built and knocked down in their area.
                   </p>
                   <p>
-                    The service
-                    is run by the independent charity
+                    The collection
+                    is part of the
                     <a href="https://www.oaf.org.au?utm_medium=email&utm_source=footer&utm_campaign=pa" class="hover-text-fuchsia-darker focus-bg-sun-yellow" style="font-weight: 700; color: #CA3F94; text-decoration-line: underline">
                       OpenAustralia Foundation
-                    </a>.
+                    </a>, an independent charity.
                   </p>
                   <p>
                     <a href="<%= documentation_contact_url(utm_medium: 'email', utm_source: 'footer') %>" class="hover-text-fuchsia-darker focus-bg-sun-yellow" style="font-weight: 700; color: #CA3F94; text-decoration-line: underline;">

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -4,8 +4,11 @@
     <div class="grid grid-cols-12 gap-6 gap-y-8 md:gap-4">
       <div class="col-span-12 md:col-span-5">
         <div class="space-y-2">
-          <p>Find out what is being built and knocked down in your community and have your say.</p>
-          <p>A free Australian service run for the benefit of the general public.</p>
+          <p>
+            A searchable collection of Australian local government planning applications. Find out what is being
+            built and knocked down in your community and have your say.
+          </p>
+          <p>A free service run for the benefit of the general public, part of the OpenAustralia Foundation collection.</p>
         </div>
       </div>
 

--- a/app/views/applications/_no_applications_help.html.erb
+++ b/app/views/applications/_no_applications_help.html.erb
@@ -1,8 +1,8 @@
 <p class="mt-8">
-  We are a free service brought to you by the charity the
-  <%= pa_link_to "OpenAustralia Foundation", "https://www.oaf.org.au" %>.
-  Donations and other kinds of support allow us to add more local authorities,
-  including yours!
+  We are a free service, part of the
+  <%= pa_link_to "OpenAustralia Foundation", "https://www.oaf.org.au" %>
+  collection. The foundation is an independent charity, and donations and other kinds
+  of support allow us to add more local authorities, including yours!
 </p>
 <p class="mt-6">
   Check out our <%= pa_link_to "get involved", get_involved_path %> section for

--- a/app/views/authorities/show.html.erb
+++ b/app/views/authorities/show.html.erb
@@ -156,10 +156,10 @@
   <section class="mt-16">
     <%= render HeadingComponent.new(tag: :h2).with_content("You can help!") %>
     <p class="mt-8 text-xl text-navy">
-      We are a free service brought to you by the charity the
-      <%= pa_link_to "OpenAustralia Foundation", "https://www.oaf.org.au" %>.
-      Donations and other kinds of support allow us to add more local authorities,
-      including this one.
+      We are a free service, part of the
+      <%= pa_link_to "OpenAustralia Foundation", "https://www.oaf.org.au" %>
+      collection. The foundation is an independent charity, and donations and other kinds
+      of support allow us to add more local authorities, including this one.
     </p>
     <p class="mt-6 text-xl text-navy">
       Check out our <%= pa_link_to "get involved", get_involved_path %> section.

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -105,14 +105,14 @@
             </p>
             <p>
               <strong>Planning Alerts</strong>
-              is a free service where anyone can find out what is being built and knocked down in their area.
+              is a searchable collection of Australian local government planning applications, where anyone can find out what is being built and knocked down in their area.
             </p>
             <p>
-              The service
-              is run by the independent charity
+              The collection
+              is part of the
               <a href="https://www.oaf.org.au?utm_medium=email&utm_source=footer&utm_campaign=pa" class="hover-text-fuchsia-darker focus-bg-sun-yellow" style="font-weight: 700; color: #CA3F94; text-decoration-line: underline">
                 OpenAustralia Foundation
-              </a>.
+              </a>, an independent charity.
             </p>
             <p>
               <a href="<%= documentation_contact_url(utm_medium: 'email', utm_source: 'footer') %>" class="hover-text-fuchsia-darker focus-bg-sun-yellow" style="font-weight: 700; color: #CA3F94; text-decoration-line: underline;">

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -107,14 +107,14 @@
             </p>
             <p>
               <strong>Planning Alerts</strong>
-              is a free service where anyone can find out what is being built and knocked down in their area.
+              is a searchable collection of Australian local government planning applications, where anyone can find out what is being built and knocked down in their area.
             </p>
             <p>
-              The service
-              is run by the independent charity
+              The collection
+              is part of the
               <a href="https://www.oaf.org.au?utm_medium=email&utm_source=footer&utm_campaign=pa" class="hover-text-fuchsia-darker focus-bg-sun-yellow" style="font-weight: 700; color: #CA3F94; text-decoration-line: underline">
                 OpenAustralia Foundation
-              </a>.
+              </a>, an independent charity.
             </p>
             <p>
               <a href="<%= documentation_contact_url(utm_medium: 'email', utm_source: 'footer') %>" class="hover-text-fuchsia-darker focus-bg-sun-yellow" style="font-weight: 700; color: #CA3F94; text-decoration-line: underline;">

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -106,14 +106,14 @@
             </p>
             <p>
               <strong>Planning Alerts</strong>
-              is a free service where anyone can find out what is being built and knocked down in their area.
+              is a searchable collection of Australian local government planning applications, where anyone can find out what is being built and knocked down in their area.
             </p>
             <p>
-              The service
-              is run by the independent charity
+              The collection
+              is part of the
               <a href="https://www.oaf.org.au?utm_medium=email&utm_source=footer&utm_campaign=pa" class="hover-text-fuchsia-darker focus-bg-sun-yellow" style="font-weight: 700; color: #CA3F94; text-decoration-line: underline">
                 OpenAustralia Foundation
-              </a>.
+              </a>, an independent charity.
             </p>
             <p>
               <a href="<%= documentation_contact_url(utm_medium: 'email', utm_source: 'footer') %>" class="hover-text-fuchsia-darker focus-bg-sun-yellow" style="font-weight: 700; color: #CA3F94; text-decoration-line: underline;">

--- a/app/views/documentation/about.html.erb
+++ b/app/views/documentation/about.html.erb
@@ -10,16 +10,18 @@
 </p>
 
 <p class="mt-6 text-xl text-navy">
-  Planning Alerts is a free Australian service which searches as many planning authority websites as it can find and emails
-  you details of applications near you. The aim of this to enable shared scrutiny of what is being built (and
+  Planning Alerts is a free independent Australian library service collecting information from as many planning
+  authority websites as possible. The collection can be searched, and library members receive emails with details
+  of applications near them. This service enables shared scrutiny of what is being built (and
   <%= pa_link_to "knocked down", "https://www.flickr.com/photos/kentjohnson/3634555801/", title: "Carlton and United Brewery Site, Broadway Sydney" %>)
   in people's communities.
 </p>
 
 <p class="mt-6 text-xl text-navy">
-  Planning Alerts is brought to you by the charity the
-  <%= pa_link_to "OpenAustralia Foundation", "https://www.oaf.org.au/" %>.
-  It was created by Matthew Landauer and Katherine Szuminska.
+  Planning Alerts is part of the
+  <%= pa_link_to "OpenAustralia Foundation", "https://www.oaf.org.au/" %>
+  collection. The foundation is a registered charity and was founded in 2007 by Matthew Landauer and
+  Katherine Szuminska.
 </p>
 
 <section id="contributors" class="pt-12">

--- a/app/views/documentation/faqs/_where_does_data_come_from.html.erb
+++ b/app/views/documentation/faqs/_where_does_data_come_from.html.erb
@@ -2,5 +2,5 @@
   Where does the data come from?
 </dt>
 <dd>
-  We search as many planning authority websites as we can find and forward the data on to you.
+  The collection is gathered from as many planning authority websites as we can find, and then we forward the data on to you.
 </dd>

--- a/app/views/home/_banner.html.erb
+++ b/app/views/home/_banner.html.erb
@@ -1,8 +1,14 @@
 <div class="flex flex-col items-center mb-6 sm:mb-12 lg:flex-row lg:gap-7">
-  <%# This is using a different style than the standard Heading component %>
-  <%= render HeadingComponent.new(tag: :h1, size: "3xl", extra_classes: "sm:text-4xl leading-tight leading-snug sm:leading-snug") do %>
-    Find out for free what is being built and knocked down in your area, anywhere in Australia.
-  <% end %>
+  <div>
+    <%# This is using a different style than the standard Heading component %>
+    <%= render HeadingComponent.new(tag: :h1, size: "3xl", extra_classes: "sm:text-4xl leading-tight leading-snug sm:leading-snug") do %>
+      What is being built and knocked down in your area?<br>
+      Find out here, for free.
+    <% end %>
+    <p class="mt-4 text-xl text-navy">
+      A searchable collection of Australian local government planning applications.
+    </p>
+  </div>
   <div class="mt-9 lg:mt-0 justify-self-end shrink-0">
     <%= image_tag "illustration/banner.svg", alt: "", size: "465x340" %>
   </div>

--- a/app/views/reply_to_no_reply_mailer/reply.html.erb
+++ b/app/views/reply_to_no_reply_mailer/reply.html.erb
@@ -480,7 +480,7 @@
                           <tr>
                             <td>
                               <p class="sub">
-                                <%= link_to "Planningalerts.org.au", root_url %> is a free service brought to you by the charity the OpenAustralia Foundation.
+                                <%= link_to "Planningalerts.org.au", root_url %> is a free searchable collection of planning applications from the OpenAustralia Foundation, an independent charity.
                               </p>
 
                               <p class="sub">

--- a/app/views/users/activation_mailer/notify.html.erb
+++ b/app/views/users/activation_mailer/notify.html.erb
@@ -105,14 +105,14 @@
             </p>
             <p>
               <strong>Planning Alerts</strong>
-              is a free service where anyone can find out what is being built and knocked down in their area.
+              is a searchable collection of Australian local government planning applications, where anyone can find out what is being built and knocked down in their area.
             </p>
             <p>
-              The service
-              is run by the independent charity
+              The collection
+              is part of the
               <a href="https://www.oaf.org.au?utm_medium=email&utm_source=footer&utm_campaign=pa" class="hover-text-fuchsia-darker focus-bg-sun-yellow" style="font-weight: 700; color: #CA3F94; text-decoration-line: underline">
                 OpenAustralia Foundation
-              </a>.
+              </a>, an independent charity.
             </p>
             <p>
               <a href="<%= documentation_contact_url(utm_medium: 'email', utm_source: 'footer') %>" class="hover-text-fuchsia-darker focus-bg-sun-yellow" style="font-weight: 700; color: #CA3F94; text-decoration-line: underline;">

--- a/config/application.rb
+++ b/config/application.rb
@@ -84,8 +84,8 @@ module PlanningalertsApp
     # in practise to change much
 
     config.planningalerts_meta_description =
-      "A free service which searches Australian planning authority websites " \
-      "and emails you details of applications near you"
+      "A searchable collection of Australian local government planning applications. " \
+      "Find out for free what is being built and knocked down in your area."
 
     # Values used in the API examples
     config.planningalerts_api_example_address = "24 Bruce Road Glenbrook, NSW 2773"

--- a/maizzle/src/components/footer-text.html
+++ b/maizzle/src/components/footer-text.html
@@ -3,14 +3,14 @@
 </p>
 <p>
   <strong>Planning Alerts</strong>
-  is a free service where anyone can find out what is being built and knocked down in their area.
+  is a searchable collection of Australian local government planning applications, where anyone can find out what is being built and knocked down in their area.
 </p>
 <p>
-  The service
-  is run by the independent charity
+  The collection
+  is part of the
   <a href="https://www.oaf.org.au?utm_medium=email&utm_source=footer&utm_campaign=pa" class="font-bold underline text-fuchsia hover:text-fuchsia-darker focus:bg-sun-yellow">
     OpenAustralia Foundation
-  </a>.
+  </a>, an independent charity.
 </p>
 <p>
   <a href="<%= documentation_contact_url(utm_medium: 'email', utm_source: 'footer') %>" class="font-bold underline text-fuchsia hover:text-fuchsia-darker focus:bg-sun-yellow">

--- a/spec/features/documentation_pages_spec.rb
+++ b/spec/features/documentation_pages_spec.rb
@@ -10,7 +10,7 @@ describe "Browsing basic documentation pages" do
   describe "about page" do
     it "has an about page" do
       visit about_path
-      expect(page).to have_content "The aim of this to enable shared scrutiny of what is being built"
+      expect(page).to have_content "This service enables shared scrutiny of what is being built"
     end
 
     describe "in the new design" do

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -7,6 +7,11 @@ describe "Home page" do
   # See https://github.com/heartcombo/devise#controller-tests
   include Devise::Test::IntegrationHelpers
 
+  it "shows what the service is" do
+    visit root_path
+    expect(page).to have_content "What is being built and knocked down in your area?"
+  end
+
   describe "accessibility tests", :js do
     before do
       sign_in create(:confirmed_user, name: "Jane Ng")


### PR DESCRIPTION
## Description

Reframes Planning Alerts as a library collection in the site copy.

**The four items decided in #2123**

- **Home hero** (`app/views/home/_banner.html.erb`) now leads with "What is being built and knocked down in your area? Find out here, for free.", with a smaller line beneath describing the service as a searchable collection. The h1 and that paragraph are wrapped in a div so the illustration stays in the right-hand column.
- **About page** (`app/views/documentation/about.html.erb`) describes Planning Alerts as a free independent Australian library service, and attributes it to the OpenAustralia Foundation collection rather than "brought to you by the charity". The Flickr link on "knocked down" and the link on the foundation name are preserved.
- **Help page** (`app/views/documentation/faqs/_where_does_data_come_from.html.erb`) now refers to the collection.

**Adjacent copy brought into line**

The site meta description (`config/application.rb`), the footer tagline (`app/views/application/_footer.html.erb`), the two "You can help!" paragraphs (`app/views/applications/_no_applications_help.html.erb`, `app/views/authorities/show.html.erb`) and the email footers. That wording is not decided in the issue, so it's the part most worth a close read.

**Email footers**

`maizzle/src/components/footer-text.html` is the source of truth, and the five generated mailer templates are hand-synced with it rather than rebuilt. `maizzle/package.json` pins `@maizzle/framework` to `latest`, so a rebuild would have rewritten the inlined CSS across all five files and buried the copy change. Each generated file has an 8-line diff, all copy.

`app/views/comment_mailer/_footer.html.erb` is deliberately left alone. It goes to planning authorities rather than the public and sits directly above a privacy notice they rely on.

**Two deviations from the issue text**

- The issue writes "peoples' communities"; this keeps the existing and correct "people's".
- The About assertion in `spec/features/documentation_pages_spec.rb` had to change, because the sentence it matched on is one of the ones being replaced.

## Motivation and Context

We're reviewing copy across our services. For Planning Alerts the aim is to frame the service more clearly as a library collection and to reduce the overlap in positioning between our services.

The adjacent copy is included because the old "free service which searches ... and emails you details of applications near you" and "brought to you by the charity" wording was duplicated in several other places. Leaving it would have left the site contradicting its own new positioning, and any future email copy change would have hit the same problem.

Closes #2123

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

Notes on the above:

- Not checked manually in a browser. The environment this was developed in has no working browser for the app, so the layout change to the hero (the new wrapper div and the forced line break) has not been eyeballed at mobile, `sm` and `lg` widths. Worth a look before merging.
- Locally: Rubocop clean across 243 files, `erblint --lint-all` clean across 189, and the non-JS specs pass (69 feature and request examples, plus 38 mailer and view examples). That includes the updated About assertion and a new home page example guarding the hero headline. The `:js` examples could not run locally because the suite uses `:selenium_headless`, which needs Firefox.
- On CI: `test`, `lint` and `type_check` all pass, so the `:js` examples including the axe accessibility checks did run and are green. Note the separate SonarCloud quality gate fails on duplication, which is the five generated mailer templates being duplicates of each other by construction. See the comment below for the detail and options.

## Screenshots (if appropriate):

None attached, for the browser reason above. The Percy snapshots are the visual record here, and every one of them will show a diff because the footer appears on every page: Home, About, API, API developer, Get Involved, Lobby your council, 404 and 500. They need approving rather than reading as regressions. If that's unwelcome, the footer change is the one to split out.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

None of these quite fit. This is a user-facing content and copy change with no change in behaviour.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhTGGgGCFUSLKdvGztwvfo