### PR TITLE
Drop the dead team from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,8 @@
-# This file is used to define code owners for this repository.
-# See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+# Code owners for this repository.
+#
+# @openaustralia/team-planningalerts has maintain access here, so GitHub can
+# actually require its review. @openaustralia/code-reviewers used to be listed
+# alongside it, but that team holds access to no repository at all, so GitHub
+# silently skipped it.
 
-* @openaustralia/code-reviewers @openaustralia/team-planningalerts
+* @openaustralia/team-planningalerts


### PR DESCRIPTION
## Description

Removes `@openaustralia/code-reviewers` from `.github/CODEOWNERS`, leaving `@openaustralia/team-planningalerts` as the sole owner of `*`, and rewrites the file's comment to explain why only one team is listed.

No change in who can approve. `team-planningalerts` has `maintain` on this repository and was already the only entry GitHub honoured.

## Motivation and Context

Part of openaustralia/oaf-internal#324.

CODEOWNERS named two teams, but `@openaustralia/code-reviewers` has write access to zero repositories. GitHub silently skips a code-owner entry whose team lacks write access on the repository, so that half of the line never had any effect. Keeping it in the file suggested a review requirement that did not exist.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

Code-owner resolution is only observable through GitHub itself, so that is where I checked it: `orgs/openaustralia/teams/code-reviewers/repos` returns 0 repositories, and `repos/openaustralia/planningalerts/teams` lists `team-planningalerts` with `maintain`. No test in the suite exercises `.github/CODEOWNERS`. All Actions checks are green (`test`, `lint`, `type_check`, SonarCloud, Socket Security, Seer Code Review).

## Screenshots (if appropriate):

None. There is no user-facing surface to this change.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

Repository configuration rather than application code, but it fixes a broken entry rather than adding anything.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<sub>Drafted with AI assistance (Claude Opus 5).</sub>
