### PR TITLE
Drop the dead team from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,8 @@
-# This file is used to define code owners for this repository.
-# See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+# Code owners for this repository.
+#
+# @openaustralia/team-planningalerts has maintain access here, so GitHub can
+# actually require its review. @openaustralia/code-reviewers used to be listed
+# alongside it, but that team holds access to no repository at all, so GitHub
+# silently skipped it.
 
-* @openaustralia/code-reviewers @openaustralia/team-planningalerts
+* @openaustralia/team-planningalerts


### PR DESCRIPTION
## Description

Removes one dead team from `.github/CODEOWNERS`:

```diff
-* @openaustralia/code-reviewers @openaustralia/team-planningalerts
+* @openaustralia/team-planningalerts
```

Also replaces the file's comment header to record why. **No change to who can approve pull requests here.**

## Motivation and Context

Part of openaustralia/oaf-internal#324 (audit check REPO-18).

The file named two owners. `@openaustralia/code-reviewers` holds access to **zero repositories** in the organisation, and GitHub silently skips a code-owner entry whose team lacks write access, so only `@openaustralia/team-planningalerts` was ever doing anything.

```
$ gh api repos/openaustralia/planningalerts/teams --jq '.[]|"\(.slug)=\(.permission)"'
team-planningalerts=maintain
```

`code-reviewers` does not appear. So this removes a misleading entry rather than changing behaviour: `team-planningalerts` has `maintain` and remains the owner. Confirmed live on this pull request, where GitHub automatically requested `team-planningalerts` and nothing else.

Keeping the dead entry is worse than cosmetic, because it reads as though a second group of reviewers is required when none is.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

The full CI suite ran on this pull request and passed: `test`, `type_check`, `lint`, SonarCloud and Socket Security. The change touches no application code, so nothing was run locally.

The behavioural check that matters is the reviewer request on this pull request itself:

```
$ gh api repos/openaustralia/planningalerts/pulls/2135 --jq '[.requested_teams[].slug]'
["team-planningalerts"]
```

That is the team being kept, which confirms it resolves correctly and that removing the other entry costs nothing.

## Screenshots (if appropriate):

Not applicable.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

Assisted-by: Claude Code/claude-opus-5

Reviewed by @benrfairless before opening. Supersedes #2133, which GitHub closed automatically when the branch was renamed to follow the Conventional Branch convention in CONTRIBUTING.md.
