### PR TITLE
Handle geocoding APIs returning integer for lat or lng

### DIFF
--- a/app/services/google_geocode_service.rb
+++ b/app/services/google_geocode_service.rb
@@ -63,8 +63,8 @@ class GoogleGeocodeService
       postcode = component(result, "postal_code")
 
       GeocodedLocation.new(
-        lat: result["geometry"]["location"]["lat"],
-        lng: result["geometry"]["location"]["lng"],
+        lat: result["geometry"]["location"]["lat"]&.to_f,
+        lng: result["geometry"]["location"]["lng"]&.to_f,
         suburb: (suburb["long_name"] if suburb),
         state: (state["short_name"] if state),
         postcode: (postcode["long_name"] if postcode),

--- a/app/services/mappify_geocode_service.rb
+++ b/app/services/mappify_geocode_service.rb
@@ -32,8 +32,8 @@ class MappifyGeocodeService
 
     all = data["result"].map do |a|
       GeocodedLocation.new(
-        lat: a["location"]["lat"],
-        lng: a["location"]["lon"],
+        lat: a["location"]["lat"]&.to_f,
+        lng: a["location"]["lon"]&.to_f,
         suburb: a["suburb"].titleize,
         state: a["state"],
         postcode: a["postCode"],


### PR DESCRIPTION
## Description

Handle geocoding APIs returning integer for lat or lng

Based on (rather than stack as 3 PRs depend directly on it):
* https://github.com/openaustralia/planningalerts/pull/2137

## Motivation and Context

Fixes import errors with some applications

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
Developed and tested on Ubuntu 24.04.4 LTS x86_64 with ruby installed by mise, mysql 8.0, redis 5:7.0, make 4.3

Ran api calls manually and checked results
- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
