### PR TITLE
Handle Pundit authorization errors gracefully

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,8 +26,14 @@ class ApplicationController < ActionController::Base
   default_form_builder FormBuilders::Tailwind
 
   rescue_from ActiveRecord::StatementInvalid, with: :check_for_write_during_maintenance_mode
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   private
+
+  sig { params(_error: Pundit::NotAuthorizedError).void }
+  def user_not_authorized(_error)
+    redirect_back fallback_location: root_path, alert: t("pundit.not_authorized")
+  end
 
   sig { params(error: StandardError).void }
   def check_for_write_during_maintenance_mode(error)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,8 @@ en:
               taken_activation: "You already have an account with that email address. Please activate your account."
               already_activated: "Account with that email address has already been activated"
               not_found: "We don't recognise that email address. Is there another one you might have used?"
+  pundit:
+    not_authorized: "You are not allowed to do that"
   errors:
     messages:
       not_a_date: "is not a date"

--- a/spec/controllers/alerts_controller_spec.rb
+++ b/spec/controllers/alerts_controller_spec.rb
@@ -7,6 +7,32 @@ describe AlertsController do
     request.env["HTTPS"] = "on"
   end
 
+  describe "#edit" do
+    let(:user) { create(:confirmed_user) }
+
+    before do
+      sign_in user
+    end
+
+    it "redirects back to the alerts page when the alert has been unsubscribed" do
+      alert = create(:unsubscribed_alert, user:)
+
+      get :edit, params: { id: alert.id }
+
+      expect(response).to redirect_to(root_path)
+      expect(flash[:alert]).to eq("You are not allowed to do that")
+    end
+
+    it "redirects back to the alerts page when the alert belongs to another user" do
+      alert = create(:alert)
+
+      get :edit, params: { id: alert.id }
+
+      expect(response).to redirect_to(root_path)
+      expect(flash[:alert]).to eq("You are not allowed to do that")
+    end
+  end
+
   describe "#unsubscribe" do
     it "marks the alert as unsubscribed" do
       alert = create(:alert)


### PR DESCRIPTION
## Description

Rescue `Pundit::NotAuthorizedError` in `ApplicationController` and redirect back (falling back to the home page) with a flash message, instead of letting the error bubble up as a 500 error page. Adds a `pundit.not_authorized` locale string and controller specs covering both failure modes on `AlertsController#edit`.

## Motivation and Context

Sentry reported an unhandled `Pundit::NotAuthorizedError` from `AlertsController#edit` in production. `AlertPolicy#update?` (which `edit?` delegates to) returns `false` when an alert belongs to another user **or has been unsubscribed** — so a user who unsubscribes via the one-click email link and then revisits the edit page from a stale tab or bookmark gets a 500 error. There was no `rescue_from` for Pundit, so any authorisation failure anywhere in the app produced a 500 rather than a graceful response.

Fixes PLANNING-ALERTS-5
Resolves #2150

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
  - New specs reproduce both failure modes (unsubscribed alert, another user's alert) and fail without the fix
  - `bundle exec rspec spec/controllers spec/policies` — 116 examples, 0 failures (via `docker compose run web`)
  - `bundle exec srb tc` — no errors
  - `bundle exec rubocop` on changed files — no offenses
- [x] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

N/A

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

AI disclosure: this change was produced with the assistance of OpenCode using the model anthropic.claude-fable-5 (see `Assisted-by` commit trailer), and has been reviewed before submission.
