### PR TITLE
Remove stale TODOs from views and components

### DIFF
--- a/app/components/share_button_component.html.erb
+++ b/app/components/share_button_component.html.erb
@@ -1,5 +1,4 @@
 <%# TODO: This button needs a hover and active state %>
-<%# TODO: Use web share API (https://w3c.github.io/web-share/) to make this even more betterer on mobile %>
 <%# This is the only place that this button style is used. So, we'll just hardcode it for the time being  %>
 <%# TODO: Alignment of text and icons is not consistent when clicking button %>
 <div

--- a/app/views/api_keys/confirm.html.erb
+++ b/app/views/api_keys/confirm.html.erb
@@ -5,8 +5,6 @@
 
 <%# TODO: Extract component for grey box %>
 <div class="p-14 bg-light-grey">
-  <%# TODO: Probably don't actually want to use the word dickhead! ;-) %>
-  <%# TODO: Update the wording for all of this about it being a trial, etc.. %>
   <p class="text-2xl font-bold text-navy">
     We trust you. Don’t abuse that trust.
   </p>

--- a/app/views/application/_html_head.html.erb
+++ b/app/views/application/_html_head.html.erb
@@ -19,7 +19,6 @@
 <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<%# TODO: #1769 Only load the font weights that we're actually using so that this is faster %>
 <link href="https://fonts.googleapis.com/css2?family=Fira+Sans:wght@300;400;500;600;700&family=Merriweather:wght@700;900&display=fallback" rel="stylesheet">
 <%= javascript_include_tag "https://cdn.jsdelivr.net/npm/@floating-ui/core@1.6.1", defer: true %>
 <%= javascript_include_tag "https://cdn.jsdelivr.net/npm/@floating-ui/dom@1.6.5", defer: true %>

--- a/app/views/application/_welcome_banner.html.erb
+++ b/app/views/application/_welcome_banner.html.erb
@@ -11,7 +11,6 @@
         <%= link_to "Discover the reasons behind our redesign", "https://www.oaf.org.au/2024/06/25/introducing-the-biggest-planning-alerts-redesign-in-fourteen-years/", class: "hover:opacity-80 focus:outline-none focus:bg-sun-yellow focus:text-navy underline" %>.
       </p>
     </div>
-    <%# TODO: This button doesn't do anything without javascript, so hide it until js is running %>
     <button x-on:click="open=false; document.cookie='planningalerts_welcome=false;Path=/'"
             class="p-2 mt-8 hover:opacity-80 focus:outline-none focus:ring-sun-yellow focus:ring-4">
       <span class="sr-only">Close</span>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -71,13 +71,10 @@
         <div>Notified</div>
       </div>
     </dt>
-    <%# TODO: The link in notified text should go to the new alert sign up page %>
-    <%# TODO: Should we have the link at all now? %>
     <dd class="ml-10 md:py-1 md:border-t border-light-grey2 md:ml-0">
       <%= render "applications/notified_text", application: @application %>
     </dd>
   <% end %>
-  <%# TODO: What to do if there are 0 comments? %>
   <dt class="pt-6 font-bold md:py-1 md:pt-1">
     <div class="flex gap-4">
       <%= image_tag "comments.svg", width: 24, alt: "" %>

--- a/app/views/contact_messages/_form.html.erb
+++ b/app/views/contact_messages/_form.html.erb
@@ -38,7 +38,6 @@
   <% if current_user.nil? && Rails.application.credentials[:recaptcha] %>
     <div class="mt-8">
       <%= recaptcha_tags %>
-      <%# TODO: Make sure recaptcha errors are shown here %>
       <%= f.error :base, class: "mt-2" %>
       <%= f.hint class: "mt-2" do %>
         Or <%= pa_link_to "sign in", new_user_session_path %> to remove this annoying reCaptcha

--- a/app/views/documentation/api_howto.html.erb
+++ b/app/views/documentation/api_howto.html.erb
@@ -134,7 +134,6 @@
         <div class="text-left">
           <%= render BulletListComponent.new do |c| %>
             <%= c.with_item do %>
-              <%# TODO: Add documentation for bulk data API %>
               Access to bulk data API
             <% end %>
             <%= c.with_item do %>


### PR DESCRIPTION
## Description

Removes 10 view/component TODO comments whose work has verifiably already been done. Comment-only change; no rendered output or behaviour is affected.

| TODO removed | Why it's stale |
|---|---|
| `app/views/application/_html_head.html.erb:22` — "#1769 Only load the font weights that we're actually using" | #1769 was closed as completed (July 2024); the stylesheet link now loads exactly the weights in use (Fira Sans 300–700, Merriweather 700/900) |
| `app/views/application/_welcome_banner.html.erb:14` — "button doesn't do anything without javascript" | The partial is dead code — its render call in `layouts/application.html.erb:13` is commented out (it was the June 2024 redesign announcement) |
| `app/views/applications/show.html.erb:74–75` — "link in notified text should go to the new alert sign up page" / "Should we have the link at all now?" | `_notified_text.html.erb` no longer contains any link — the whole partial is plain text |
| `app/views/applications/show.html.erb:80` — "What to do if there are 0 comments?" | Handled: `_comments_text.html.erb` renders a "Be the first to comment" link for the zero case |
| `app/views/documentation/api_howto.html.erb:137` — "Add documentation for bulk data API" | Bulk API docs now exist in `api_developer.html.erb:127–162` (heading, description, example URL) |
| `app/views/contact_messages/_form.html.erb:41` — "Make sure recaptcha errors are shown here" | Verified end-to-end: `verify_recaptcha(model:)` adds `:base` errors in the controller and the view renders `f.error :base` directly below |
| `app/views/api_keys/confirm.html.erb:8–9` — "don't use the word dickhead" / "update the wording about it being a trial" | Both done in 10ef8255e ("Updated wording on the interstitial") — the copy is now "We trust you. Don't abuse that trust." with rewritten trial/plan bullets |
| `app/components/share_button_component.html.erb:2` — "Use web share API" | Implemented: `navigator.canShare`/`navigator.share` with clipboard fallback in this same component |

## Motivation and Context

Part of a repo-wide TODO audit: all 279 `TODO`/`FIXME` comments in the codebase were classified against the current code and the issue tracker. This is one of four PRs (#2152, #2153, #2154, #2156) removing the 19 verifiably-stale TODOs; the still-relevant ones are grouped into tracking issues #2157–#2168 (plus bugs #2169, #2170). Stale TODOs are noise that misleads readers about outstanding work — each removal above documents the evidence that the work is already done.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

This is a comment-only change (deleting 10 ERB comment lines); it produces no change to rendered output or behaviour, so the CI suite (tests, lint, type_check) is the relevant verification.

## Screenshots (if appropriate):

Not applicable — comment-only change.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

None of the above apply: this only deletes stale comments from the source.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
