### PR TITLE
Remove stale TODOs from controllers and services

### DIFF
--- a/app/controllers/alerts/registrations_controller.rb
+++ b/app/controllers/alerts/registrations_controller.rb
@@ -12,7 +12,6 @@ module Alerts
       end
     end
 
-    # TODO: Make link in email point to the right place
     sig { void }
     def create
       super do

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -15,7 +15,6 @@ class ApplicationsController < ApplicationController
 
     description = +"Most recent applications"
     if authority_id
-      # TODO: Handle the situation where the authority name isn't found
       authority = Authority.find_short_name_encoded!(authority_id)
       description << " from #{authority.full_name_and_state}"
       apps = authority.applications

--- a/app/services/process_alert_and_record_stats_service.rb
+++ b/app/services/process_alert_and_record_stats_service.rb
@@ -24,7 +24,6 @@ class ProcessAlertAndRecordStatsService
     return if no_emails.zero?
 
     # Update statistics
-    # TODO: Figure out the impact on caching updating this so regularly now
     Stat.increment_emails_sent(no_emails)
     Stat.increment_applications_sent(no_applications)
     # TODO: Rename EmailBatch as we're not using batches anymore


### PR DESCRIPTION
## Description

Removes 3 controller/service TODO comments whose work has verifiably already been done. Comment-only change; no behaviour affected.

| TODO removed | Why it's stale |
|---|---|
| `app/controllers/alerts/registrations_controller.rb:15` — "Make link in email point to the right place" | Fixed the same day the TODO was added: 83171c4c8 added `after_confirmation_path_for` (users/confirmations_controller.rb), redirecting confirmed users with alerts to `alerts_path` |
| `app/controllers/applications_controller.rb:18` — "Handle the situation where the authority name isn't found" | Handled: `Authority.find_short_name_encoded!` raises `ActiveRecord::RecordNotFound`, which renders the styled 404 page for this HTML controller |
| `app/services/process_alert_and_record_stats_service.rb:27` — "Figure out the impact on caching updating this so regularly" | Moot: `Stat.emails_sent` / `Stat.applications_sent` have no readers anywhere in app/lib/config (only their own specs) — no cached page displays these stats |

## Motivation and Context

Part of a repo-wide TODO audit: all 279 `TODO`/`FIXME` comments in the codebase were classified against the current code and the issue tracker. This is one of four PRs (#2152, #2153, #2154, #2156) removing the 19 verifiably-stale TODOs; the still-relevant ones are grouped into tracking issues #2157–#2168 (plus bugs #2169, #2170). Stale TODOs are noise that misleads readers about outstanding work — each removal above documents the evidence that the work is already done.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

This is a comment-only change (deleting 3 Ruby comment lines); it produces no change to rendered output or behaviour, so the CI suite (tests, lint, type_check) is the relevant verification.

## Screenshots (if appropriate):

Not applicable — comment-only change.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

None of the above apply: this only deletes stale comments from the source.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
