### PR TITLE
Remove stale TODOs from migration and initializer

### DIFF
--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -2,7 +2,6 @@
 # TODO: Store this in a more sensibly named/namespaced variable
 
 ENV["ELASTICSEARCH_URL"] = Rails.configuration.x.elasticsearch_url
-# TODO: With the line above can I get rid of the stuff below?
 ElasticSearchClient = if Rails.configuration.x.elasticsearch_url.present?
                         Elasticsearch::Client.new url: Rails.configuration.x.elasticsearch_url
                       end

--- a/db/migrate/20230206002921_add_first_date_scraped_to_applications.rb
+++ b/db/migrate/20230206002921_add_first_date_scraped_to_applications.rb
@@ -1,6 +1,5 @@
 class AddFirstDateScrapedToApplications < ActiveRecord::Migration[7.0]
   def change
-    # TODO: make this null: false in a later migration once data is loaded
     add_column :applications, :first_date_scraped, :timestamp
   end
 end


### PR DESCRIPTION
## Description

Removes 2 config/db TODO comments that are verifiably resolved. Comment-only change; no behaviour affected.

| TODO removed | Why it's stale |
|---|---|
| `db/migrate/20230206002921_add_first_date_scraped_to_applications.rb:3` — "make this null: false in a later migration once data is loaded" | Done two days later: `20230208012842_make_first_date_scraped_not_null.rb` exists and `db/schema.rb:151` shows `first_date_scraped ... null: false` |
| `config/initializers/elasticsearch.rb:5` — "With the line above can I get rid of the stuff below?" | The question is answered: no. `ElasticSearchClient` is still used directly by `LogApiCallService` and `ElasticsearchSnapshotJob` |

Note: the other TODO in `elasticsearch.rb` (line 2, "store this in a more sensibly named/namespaced variable") is still relevant and is deliberately left in place — it is tracked in #2164.

## Motivation and Context

Part of a repo-wide TODO audit: all 279 `TODO`/`FIXME` comments in the codebase were classified against the current code and the issue tracker. This is one of four PRs (#2152, #2153, #2154, #2156) removing the 19 verifiably-stale TODOs; the still-relevant ones are grouped into tracking issues #2157–#2168 (plus bugs #2169, #2170). Stale TODOs are noise that misleads readers about outstanding work — each removal above documents the evidence that the work is already done.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

This is a comment-only change (deleting 2 Ruby comment lines); it produces no change to rendered output or behaviour, so the CI suite (tests, lint, type_check) is the relevant verification.

## Screenshots (if appropriate):

Not applicable — comment-only change.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

None of the above apply: this only deletes stale comments from the source.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
