### PR TITLE
Remove stale TODO questions from specs

### DIFF
--- a/spec/controllers/applications_controller_spec.rb
+++ b/spec/controllers/applications_controller_spec.rb
@@ -35,8 +35,6 @@ describe ApplicationsController do
 
       allow(application).to receive_messages(location: nil, find_all_nearest_or_recent: [])
 
-      # TODO: Can this line be removed? It seems to be a duplicate of
-      # expectation on final line.
       allow(Application).to receive(:find).with("1").and_return(application)
 
       get :show, params: { id: 1 }

--- a/spec/features/authorities_spec.rb
+++ b/spec/features/authorities_spec.rb
@@ -36,7 +36,6 @@ describe "Authorities" do
       sign_in create(:confirmed_user, name: "Jane Ng")
       authority = create(:authority, full_name: "Byron Shire Council", morph_name: "planningalerts-scrapers/byron")
       # We need it to have at least one application so it's not "broken"
-      # TODO: I suspect we'll need to lock down the date of the application so that percy snapshots are consistent
       create(:geocoded_application, authority:, council_reference: "1", date_scraped: Date.new(2020, 1, 1))
       create(:geocoded_application, authority:, council_reference: "2", date_scraped: Date.new(2020, 1, 8))
       create(:geocoded_application, authority:, council_reference: "3", date_scraped: Date.new(2020, 1, 15))
@@ -83,7 +82,6 @@ describe "Authorities" do
       sign_in create(:confirmed_user, name: "Jane Ng")
       authority = create(:authority, full_name: "Byron Shire Council", morph_name: "planningalerts-scrapers/byron")
       # We need it to have at least one application so it's not "broken"
-      # TODO: I suspect we'll need to lock down the date of the application so that percy snapshots are consistent
       create(:geocoded_application, authority:, council_reference: "1", date_scraped: Date.new(2020, 1, 1))
       create(:geocoded_application, authority:, council_reference: "2", date_scraped: Date.new(2020, 1, 8))
       create(:geocoded_application, authority:, council_reference: "3", date_scraped: Date.new(2020, 1, 15))

--- a/spec/features/search_for_applications_spec.rb
+++ b/spec/features/search_for_applications_spec.rb
@@ -149,7 +149,6 @@ describe "Searching for development application near an address" do
     before do
       sign_in user
       Flipper.enable :full_text_search
-      # TODO: Would it be better to only enable the feature temporarily?
       visit search_applications_path
     end
 


### PR DESCRIPTION
## Description

Removes 4 spec TODO comments that are questions the current code already answers. Comment-only change; no behaviour affected.

| TODO removed | Why it's stale |
|---|---|
| `spec/controllers/applications_controller_spec.rb:38–39` — "Can this line be removed? It seems to be a duplicate of expectation on final line" | No, it can't: the `allow(Application).to receive(:find)` stub is what returns the instance carrying the `location: nil` stubs. The final line is an `expect(...)` assertion, not a stub — they're different things |
| `spec/features/search_for_applications_spec.rb:152` — "Would it be better to only enable the feature temporarily?" | Already effectively temporary: `spec_helper.rb` deletes `tmp/flipper.pstore` before every example, so `Flipper.enable` can't leak between examples |
| `spec/features/authorities_spec.rb:39` and `:86` — "I suspect we'll need to lock down the date of the application so that percy snapshots are consistent" | Already done in both blocks: fixed `date_scraped` values (2020-01-01/08/15) plus `Timecop.freeze` around each `visit` |

## Motivation and Context

Part of a repo-wide TODO audit: all 279 `TODO`/`FIXME` comments in the codebase were classified against the current code and the issue tracker. This is one of four PRs (#2152, #2153, #2154, #2156) removing the 19 verifiably-stale TODOs; the still-relevant ones are grouped into tracking issues #2157–#2168 (plus bugs #2169, #2170). Stale TODOs are noise that misleads readers about outstanding work — each removal above documents the evidence that the work is already done.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

This is a comment-only change (deleting 5 Ruby comment lines); it produces no change to rendered output or behaviour, so the CI suite (tests, lint, type_check) is the relevant verification.

## Screenshots (if appropriate):

Not applicable — comment-only change.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

None of the above apply: this only deletes stale comments from the source.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
