### PR TITLE
Add bulk application deletion rake task based on prefix and authority

### DIFF
--- a/app/services/bulk_delete_applications_service.rb
+++ b/app/services/bulk_delete_applications_service.rb
@@ -60,19 +60,27 @@ class BulkDeleteApplicationsService
     skipped_comments = T.let([], T::Array[Item])
     skipped_redirect_target = T.let([], T::Array[Item])
 
-    matching_applications.find_each do |application|
+    # Fetch redirect-target IDs once to avoid N+1 queries in the loop
+    redirect_target_ids = T.let(
+      ApplicationRedirect.where(redirect_application_id: matching_applications).pluck(:redirect_application_id).to_set,
+      T::Set[Integer]
+    )
+
+    matching_applications.preload(:comments).find_each do |application|
+      comments_count = application.comments.size
+
       item = Item.new(
         id: application.id,
         council_reference: application.council_reference,
         address: application.address,
-        comments_count: application.comments.count
+        comments_count:
       )
 
-      if ApplicationRedirect.exists?(redirect_application_id: application.id)
+      if redirect_target_ids.include?(application.id)
         # Deleting these would violate a foreign key constraint on
         # application_redirects so they need to be handled manually
         skipped_redirect_target << item
-      elsif item.comments_count.positive? && !delete_comments
+      elsif comments_count.positive? && !delete_comments
         skipped_comments << item
       else
         delete(application) unless dry_run
@@ -108,7 +116,7 @@ class BulkDeleteApplicationsService
   sig { params(application: Application).void }
   def delete(application)
     Application.transaction do
-      application.comments.destroy_all if delete_comments
+      application.comments.find_each(&:destroy!) if delete_comments
       application.destroy!
     end
   end

--- a/app/services/bulk_delete_applications_service.rb
+++ b/app/services/bulk_delete_applications_service.rb
@@ -60,15 +60,21 @@ class BulkDeleteApplicationsService
     skipped_comments = T.let([], T::Array[Item])
     skipped_redirect_target = T.let([], T::Array[Item])
 
+    # Fetch these up-front to avoid running two queries per application
+    comment_counts = Comment.where(application_id: matching_applications.select(:id))
+                            .group(:application_id).count
+    redirect_target_ids = ApplicationRedirect.where(redirect_application_id: matching_applications.select(:id))
+                                             .pluck(:redirect_application_id).to_set
+
     matching_applications.find_each do |application|
       item = Item.new(
         id: application.id,
         council_reference: application.council_reference,
         address: application.address,
-        comments_count: application.comments.count
+        comments_count: comment_counts.fetch(application.id, 0)
       )
 
-      if ApplicationRedirect.exists?(redirect_application_id: application.id)
+      if redirect_target_ids.include?(application.id)
         # Deleting these would violate a foreign key constraint on
         # application_redirects so they need to be handled manually
         skipped_redirect_target << item
@@ -108,7 +114,9 @@ class BulkDeleteApplicationsService
   sig { params(application: Application).void }
   def delete(application)
     Application.transaction do
-      application.comments.destroy_all if delete_comments
+      # Destroy in batches rather than destroy_all so we don't load every
+      # comment into memory at once, while still running callbacks
+      application.comments.find_each(&:destroy!) if delete_comments
       application.destroy!
     end
   end

--- a/app/services/bulk_delete_applications_service.rb
+++ b/app/services/bulk_delete_applications_service.rb
@@ -1,0 +1,115 @@
+# typed: strict
+# frozen_string_literal: true
+
+# Bulk deletes applications for an authority whose council_reference starts
+# with the given prefix. Used by the planningalerts:bulk_delete_applications
+# rake task. See https://github.com/openaustralia/planningalerts/issues/2155
+class BulkDeleteApplicationsService
+  extend T::Sig
+
+  # A summary of an application that the service acted on (or would act on)
+  class Item < T::Struct
+    const :id, Integer
+    const :council_reference, String
+    const :address, String
+    const :comments_count, Integer
+  end
+
+  class Result < T::Struct
+    const :dry_run, T::Boolean
+    # Applications that were deleted (or would be deleted in a dry run)
+    const :deleted, T::Array[Item]
+    # Applications skipped because they have comments (and delete_comments was not set)
+    const :skipped_comments, T::Array[Item]
+    # Applications skipped because they are the target of an application redirect
+    const :skipped_redirect_target, T::Array[Item]
+  end
+
+  sig do
+    params(
+      authority: Authority,
+      council_reference_prefix: String,
+      dry_run: T::Boolean,
+      delete_comments: T::Boolean
+    ).returns(Result)
+  end
+  def self.call(authority:, council_reference_prefix:, dry_run:, delete_comments: false)
+    new(authority:, council_reference_prefix:, dry_run:, delete_comments:).call
+  end
+
+  sig do
+    params(
+      authority: Authority,
+      council_reference_prefix: String,
+      dry_run: T::Boolean,
+      delete_comments: T::Boolean
+    ).void
+  end
+  def initialize(authority:, council_reference_prefix:, dry_run:, delete_comments:)
+    @authority = authority
+    @council_reference_prefix = council_reference_prefix
+    @dry_run = dry_run
+    @delete_comments = delete_comments
+  end
+
+  sig { returns(Result) }
+  def call
+    raise ArgumentError, "council_reference_prefix can't be blank" if council_reference_prefix.blank?
+
+    deleted = T.let([], T::Array[Item])
+    skipped_comments = T.let([], T::Array[Item])
+    skipped_redirect_target = T.let([], T::Array[Item])
+
+    matching_applications.find_each do |application|
+      item = Item.new(
+        id: application.id,
+        council_reference: application.council_reference,
+        address: application.address,
+        comments_count: application.comments.count
+      )
+
+      if ApplicationRedirect.exists?(redirect_application_id: application.id)
+        # Deleting these would violate a foreign key constraint on
+        # application_redirects so they need to be handled manually
+        skipped_redirect_target << item
+      elsif item.comments_count.positive? && !delete_comments
+        skipped_comments << item
+      else
+        delete(application) unless dry_run
+        deleted << item
+      end
+    end
+
+    Result.new(dry_run:, deleted:, skipped_comments:, skipped_redirect_target:)
+  end
+
+  private
+
+  sig { returns(Authority) }
+  attr_reader :authority
+
+  sig { returns(String) }
+  attr_reader :council_reference_prefix
+
+  sig { returns(T::Boolean) }
+  attr_reader :dry_run
+
+  sig { returns(T::Boolean) }
+  attr_reader :delete_comments
+
+  sig { returns(ActiveRecord::Relation) }
+  def matching_applications
+    authority.applications.where(
+      "council_reference LIKE ?",
+      "#{Application.sanitize_sql_like(council_reference_prefix)}%"
+    )
+  end
+
+  sig { params(application: Application).void }
+  def delete(application)
+    Application.transaction do
+      application.comments.destroy_all if delete_comments
+      application.destroy!
+    end
+  end
+end

--- a/lib/tasks/planningalerts.rake
+++ b/lib/tasks/planningalerts.rake
@@ -72,6 +72,63 @@ namespace :planningalerts do
     end
   end
 
+  # Dry run by default. Pass "execute" as the third argument to actually
+  # delete and "delete_comments" as the fourth argument to also delete any
+  # comments on matching applications (otherwise applications with comments
+  # are skipped). For example:
+  #   rake planningalerts:bulk_delete_applications[123,PA1]                          # dry run
+  #   rake planningalerts:bulk_delete_applications[123,PA1,execute]                  # delete
+  #   rake planningalerts:bulk_delete_applications[123,PA1,execute,delete_comments]  # delete incl. comments
+  desc "Bulk delete applications for an authority matching a council_reference prefix (dry run by default)"
+  task :bulk_delete_applications, %i[authority_id prefix mode option] => :environment do |_task, args|
+    authority = Authority.find(args.authority_id)
+    prefix = args.prefix.to_s
+    raise "prefix can't be blank" if prefix.blank?
+    raise "Unknown mode: #{args.mode}. Did you mean execute?" unless args.mode.nil? || args.mode == "execute"
+    raise "Unknown option: #{args.option}. Did you mean delete_comments?" unless args.option.nil? || args.option == "delete_comments"
+
+    dry_run = args.mode != "execute"
+    delete_comments = args.option == "delete_comments"
+
+    result = BulkDeleteApplicationsService.call(
+      authority:,
+      council_reference_prefix: prefix,
+      dry_run:,
+      delete_comments:
+    )
+
+    puts "#{'DRY RUN - nothing was changed - ' if dry_run}#{authority.full_name} - " \
+         "applications with council_reference starting with #{prefix.inspect}"
+    puts
+
+    describe = ->(item) { "  #{item.council_reference} (id #{item.id}) - #{item.address}" }
+
+    puts "#{dry_run ? 'Would delete' : 'Deleted'} #{result.deleted.count} application(s):"
+    result.deleted.each do |item|
+      puts describe.call(item) + (item.comments_count.positive? ? " - including #{item.comments_count} comment(s)" : "")
+    end
+
+    if result.skipped_comments.any?
+      puts
+      puts "Skipped #{result.skipped_comments.count} application(s) because they have comments " \
+           "(pass delete_comments to delete them too):"
+      result.skipped_comments.each { |item| puts describe.call(item) + " - #{item.comments_count} comment(s)" }
+    end
+
+    if result.skipped_redirect_target.any?
+      puts
+      puts "Skipped #{result.skipped_redirect_target.count} application(s) because they are the target " \
+           "of an application redirect. These need to be handled manually:"
+      result.skipped_redirect_target.each { |item| puts describe.call(item) }
+    end
+
+    if dry_run
+      puts
+      puts "This was a dry run. To actually delete run the task again with execute, e.g."
+      puts "  rake planningalerts:bulk_delete_applications[#{authority.id},#{prefix},execute]"
+    end
+  end
+
   namespace :emergency do
     desc "Regenerates all the counter caches in case they got out of synch"
     task fixup_counter_caches: :environment do

--- a/spec/services/bulk_delete_applications_service_spec.rb
+++ b/spec/services/bulk_delete_applications_service_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe BulkDeleteApplicationsService do
+  let(:authority) { create(:authority) }
+
+  def call(prefix: "PA1", dry_run: true, delete_comments: false)
+    described_class.call(
+      authority:,
+      council_reference_prefix: prefix,
+      dry_run:,
+      delete_comments:
+    )
+  end
+
+  describe ".call" do
+    it "raises when the prefix is blank" do
+      expect { call(prefix: "") }.to raise_error(ArgumentError)
+    end
+
+    context "with applications from different authorities and references" do
+      let!(:matching) { create(:geocoded_application, authority:, council_reference: "PA123") }
+      let!(:other_reference) { create(:geocoded_application, authority:, council_reference: "PA456") }
+      let!(:other_authority) { create(:geocoded_application, council_reference: "PA124") }
+
+      it "only matches applications for the given authority with the given prefix" do
+        result = call
+        expect(result.deleted.map(&:id)).to eq [matching.id]
+        expect(result.skipped_comments).to be_empty
+        expect(result.skipped_redirect_target).to be_empty
+      end
+
+      it "does not delete anything in a dry run" do
+        expect { call }.not_to change(Application, :count)
+      end
+
+      it "deletes only the matching application when executing" do
+        expect { call(dry_run: false) }.to change(Application, :count).by(-1)
+        expect(Application.exists?(matching.id)).to be false
+        expect(Application.exists?(other_reference.id)).to be true
+        expect(Application.exists?(other_authority.id)).to be true
+      end
+
+      it "deletes the application versions too" do
+        expect { call(dry_run: false) }.to change(ApplicationVersion, :count).by(-1)
+      end
+
+      it "does not treat SQL wildcards in the prefix as wildcards" do
+        result = call(prefix: "PA%")
+        expect(result.deleted).to be_empty
+      end
+    end
+
+    context "with an application that has comments" do
+      let!(:application) { create(:geocoded_application, authority:, council_reference: "PA123") }
+      let!(:comment) { create(:published_comment, application:) }
+
+      it "skips it and reports it by default" do
+        result = call(dry_run: false)
+        expect(result.deleted).to be_empty
+        expect(result.skipped_comments.map(&:id)).to eq [application.id]
+        expect(result.skipped_comments.first.comments_count).to eq 1
+        expect(Application.exists?(application.id)).to be true
+      end
+
+      it "deletes it along with its comments when delete_comments is set" do
+        result = call(dry_run: false, delete_comments: true)
+        expect(result.deleted.map(&:id)).to eq [application.id]
+        expect(Application.exists?(application.id)).to be false
+        expect(Comment.exists?(comment.id)).to be false
+      end
+
+      it "reports it as deleted in a dry run with delete_comments but changes nothing" do
+        result = nil
+        expect { result = call(delete_comments: true) }.not_to change(Comment, :count)
+        expect(result.deleted.map(&:id)).to eq [application.id]
+      end
+    end
+
+    context "with an application that is the target of a redirect" do
+      let!(:application) { create(:geocoded_application, authority:, council_reference: "PA123") }
+
+      before do
+        create(:application_redirect, application_id: application.id + 1000, redirect_application: application)
+      end
+
+      it "skips it and reports it" do
+        result = call(dry_run: false)
+        expect(result.deleted).to be_empty
+        expect(result.skipped_redirect_target.map(&:id)).to eq [application.id]
+        expect(Application.exists?(application.id)).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a `planningalerts:bulk_delete_applications` rake task for bulk deleting applications for a given authority whose `council_reference` starts with a given prefix, backed by a new `BulkDeleteApplicationsService`.

Usage:

```
rake planningalerts:bulk_delete_applications[AUTHORITY_ID,PREFIX]                          # dry run (default)
rake planningalerts:bulk_delete_applications[AUTHORITY_ID,PREFIX,execute]                  # actually delete
rake planningalerts:bulk_delete_applications[AUTHORITY_ID,PREFIX,execute,delete_comments]  # also delete comments
```

Behaviour:

* **Dry run by default** — the task prints a full report of what would be deleted without changing anything. Deletion only happens when the literal word `execute` is passed.
* **Applications with comments are skipped and reported** by default (they can't be destroyed anyway because of `dependent: :restrict_with_exception`). Passing `delete_comments` deletes the comments (and their associated reports) along with the application.
* **Applications that are the target of an `ApplicationRedirect` are always skipped and reported**, since deleting them would violate the foreign key constraint on `application_redirects`. These need manual handling.
* Application versions are cleaned up via the existing `dependent: :destroy` association, and searchkick de-indexes via its destroy callbacks.
* SQL wildcards in the prefix are escaped, so `PA1` matches only references literally starting with `PA1`.

## Motivation and Context

We have a business need to remove a significant number of applications whose references start with `PA1`, `PA2`, `PA3` from a specific authority. Doing this manually would take days.

The issue expressed a preference to hide rather than delete once #2140 lands, but #2140 hasn't landed yet and there is currently no hide mechanism on applications, so this implements deletion as specified. If/when #2140 lands, the service is a single obvious place to switch from destroy to hide.

Resolves #2155

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

* New service spec (`spec/services/bulk_delete_applications_service_spec.rb`, 10 examples) covering prefix/authority scoping, dry run, execute, comment skipping/deletion, redirect-target skipping and wildcard escaping
* Full `spec/services` + `spec/models` suite green (247 examples, 0 failures) in the Docker Compose dev environment
* `bin/srb tc` and `bin/rubocop` clean
* Smoke-tested the rake task end-to-end (dry run then execute) against a scratch database

## Screenshots (if appropriate):

Dry run output:

```
DRY RUN - nothing was changed - Smoke Test Council - applications with council_reference starting with "PA1"

Would delete 2 application(s):
  PA100 (id 41) - 1 Test St
  PA101 (id 42) - 1 Test St

This was a dry run. To actually delete run the task again with execute, e.g.
  rake planningalerts:bulk_delete_applications[36,PA1,execute]
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
