### PR TITLE
Add ability to hide an application without deleting it

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -121,9 +121,10 @@ class ApiController < ApplicationController
 
     # Limiting number of records that are returned
     applications = apps.limit(Application.max_per_page_all_api).to_a
-    last = applications.last
-    last = Application.visible.order(:id).last if last.nil?
-    max_id = last.id if last
+    # When there's nothing new to return we leave the cursor where the client
+    # left it. Falling back to the last visible application would move the
+    # cursor backwards whenever the most recent applications are hidden.
+    max_id = applications.last&.id || params[:since_id]&.to_i
 
     respond_to do |format|
       format.json do

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -33,13 +33,13 @@ class ApiController < ApplicationController
 
     # TODO: Handle the situation where the authority name isn't found
     authority = Authority.find_short_name_encoded!(params_authority_id)
-    apps = authority.applications.order(first_date_scraped: :desc)
+    apps = authority.applications.visible.order(first_date_scraped: :desc)
     api_render_apps(apps, "Recent applications from #{authority.full_name_and_state}")
   end
 
   sig { void }
   def suburb_postcode
-    apps = Application.order(first_date_scraped: :desc)
+    apps = Application.visible.order(first_date_scraped: :desc)
     descriptions = []
     if params[:suburb]
       descriptions << params[:suburb]
@@ -74,7 +74,7 @@ class ApiController < ApplicationController
     location = Location.new(lat: params_lat.to_f, lng: params_lng.to_f)
     location_text = location.to_s
     point = RGeo::Geographic.spherical_factory.point(location.lng, location.lat)
-    applications = Application.where("ST_DWithin(lonlat, ?, ?)", point.to_s, radius)
+    applications = Application.visible.where("ST_DWithin(lonlat, ?, ?)", point.to_s, radius)
     applications = applications.reorder(first_date_scraped: :desc)
     api_render_apps(
       applications,
@@ -89,7 +89,7 @@ class ApiController < ApplicationController
     lat1 = params[:top_right_lat]
     lng1 = params[:top_right_lng]
     api_render_apps(
-      Application.order(first_date_scraped: :desc).where(lat: lat0..lat1, lng: lng0..lng1),
+      Application.visible.order(first_date_scraped: :desc).where(lat: lat0..lat1, lng: lng0..lng1),
       "Recent applications in the area (#{lat0},#{lng0}) (#{lat1},#{lng1})"
     )
   end
@@ -105,7 +105,7 @@ class ApiController < ApplicationController
     end
 
     if date
-      api_render_apps(Application.order(date_scraped: :desc).where(date_scraped: date.beginning_of_day...date.end_of_day), "All applications collected on #{date}")
+      api_render_apps(Application.visible.order(date_scraped: :desc).where(date_scraped: date.beginning_of_day...date.end_of_day), "All applications collected on #{date}")
     else
       render_error("invalid date_scraped", :bad_request)
     end
@@ -116,13 +116,13 @@ class ApiController < ApplicationController
   sig { void }
   def all
     # TODO: Check that params page and v aren't being used
-    apps = Application.includes(:authority).order(:id)
+    apps = Application.visible.includes(:authority).order(:id)
     apps = apps.where("id > ?", params[:since_id]) if params[:since_id]
 
     # Limiting number of records that are returned
     applications = apps.limit(Application.max_per_page_all_api).to_a
     last = applications.last
-    last = Application.order(:id).last if last.nil?
+    last = Application.visible.order(:id).last if last.nil?
     max_id = last.id if last
 
     respond_to do |format|

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -124,7 +124,10 @@ class ApiController < ApplicationController
     # When there's nothing new to return we leave the cursor where the client
     # left it. Falling back to the last visible application would move the
     # cursor backwards whenever the most recent applications are hidden.
-    max_id = applications.last&.id || params[:since_id]&.to_i
+    # If there's no cursor at all (initial request with nothing visible)
+    # return 0, which is equivalent to no since_id, so that clients always
+    # get an integer they can feed back.
+    max_id = applications.last&.id || params[:since_id]&.to_i || 0
 
     respond_to do |format|
       format.json do

--- a/app/controllers/application_versions_controller.rb
+++ b/app/controllers/application_versions_controller.rb
@@ -8,7 +8,11 @@ class ApplicationVersionsController < ApplicationController
 
   sig { void }
   def index
-    @application = T.let(Application.find(T.cast(params[:application_id], String)), T.nilable(Application))
+    application = Application.find(T.cast(params[:application_id], String))
+    @application = T.let(application, T.nilable(Application))
+    return unless application.hidden? && !current_user&.has_role?(:admin)
+
+    render "applications/hidden", status: :forbidden
   end
 
   private

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -18,10 +18,10 @@ class ApplicationsController < ApplicationController
       # TODO: Handle the situation where the authority name isn't found
       authority = Authority.find_short_name_encoded!(authority_id)
       description << " from #{authority.full_name_and_state}"
-      apps = authority.applications
+      apps = authority.applications.visible
     else
       description << " across Australia"
-      apps = Application
+      apps = Application.visible
     end
     apps = apps.order("first_date_scraped DESC").where("first_date_scraped > ?", Application.nearby_and_recent_max_age_months.months.ago)
 
@@ -84,7 +84,8 @@ class ApplicationsController < ApplicationController
       @alert = Alert.new(address: @q, user: User.new, radius_meters: Alert::DEFAULT_RADIUS)
       @other_addresses = T.must(result.rest).map(&:full_address)
       point = RGeo::Geographic.spherical_factory.point(top.lng, top.lat)
-      @applications = Application.select("*", "ST_Distance(lonlat, '#{point}')/1000 AS distance")
+      @applications = Application.visible
+                                 .select("*", "ST_Distance(lonlat, '#{point}')/1000 AS distance")
                                  .where("ST_DWithin(lonlat, ?, ?)", point.to_s, radius)
                                  .order(:distance)
 
@@ -117,6 +118,9 @@ class ApplicationsController < ApplicationController
   def show
     application = Application.find(T.cast(params[:id], String))
     @application = T.let(application, T.nilable(Application))
+    render_hidden_page_if_necessary(application)
+    return if performed?
+
     @comments = T.let(application.comments.published.order(:published_at), T.untyped)
     # If this user has already written a comment that hasn't been published
     # then prepopulate the form so that they can edit their comment before it's finally sent
@@ -144,9 +148,20 @@ class ApplicationsController < ApplicationController
   def external
     application = Application.find(T.cast(params[:id], String))
     @application = T.let(application, T.nilable(Application))
+    render_hidden_page_if_necessary(application)
   end
 
   private
+
+  # If the application is hidden and the current user isn't an admin, renders
+  # a page explaining why the application can't be shown
+  sig { params(application: Application).void }
+  def render_hidden_page_if_necessary(application)
+    return unless application.hidden?
+    return if current_user&.has_role?(:admin)
+
+    render "hidden", status: :forbidden
+  end
 
   sig { void }
   def check_application_redirect

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -24,7 +24,7 @@ class CommentsController < ApplicationController
     end
     @description = T.let(description, T.nilable(String))
 
-    @comments = T.let(comments_to_display.published.includes(application: :authority).order("published_at DESC").page(params[:page]), T.untyped)
+    @comments = T.let(comments_to_display.published.joins(:application).merge(Application.visible).includes(application: :authority).order("published_at DESC").page(params[:page]), T.untyped)
   end
 
   sig { void }
@@ -38,6 +38,11 @@ class CommentsController < ApplicationController
   def create
     application = Application.find(T.cast(params[:application_id], String))
     @application = T.let(application, T.nilable(Application))
+
+    if application.hidden? && !current_user&.has_role?(:admin)
+      render "applications/hidden", status: :forbidden
+      return
+    end
 
     params_comment = T.cast(params[:comment], ActionController::Parameters)
 

--- a/app/dashboards/application_dashboard.rb
+++ b/app/dashboards/application_dashboard.rb
@@ -25,6 +25,8 @@ class ApplicationDashboard < Administrate::BaseDashboard
     first_date_scraped: Field::DateTime,
     date_scraped: Field::DateTime,
     description: Field::Text,
+    hidden: YesNoBooleanField,
+    hidden_reason: Field::Text,
     info_url: Field::String.with_options(searchable: false),
     lat: Field::Number.with_options(decimals: 2),
     lng: Field::Number.with_options(decimals: 2),
@@ -68,21 +70,19 @@ class ApplicationDashboard < Administrate::BaseDashboard
     on_notice_from
     on_notice_to
     no_alerted
+    hidden
+    hidden_reason
     comments
   ].freeze, T::Array[Symbol])
 
   # FORM_ATTRIBUTES
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
-  FORM_ATTRIBUTES = T.let(%i[
-    authority
-    comments
-    versions
-    current_version
-    council_reference
-    no_alerted
-    visible_comments_count
-  ].freeze, T::Array[Symbol])
+  FORM_ATTRIBUTES = T.let(
+    {
+      "Moderate application" => %i[hidden hidden_reason]
+    }.freeze, T::Hash[String, T::Array[Symbol]]
+  )
 
   # COLLECTION_FILTERS
   # a hash that defines filters that can be used while searching via the search
@@ -94,7 +94,10 @@ class ApplicationDashboard < Administrate::BaseDashboard
   #   COLLECTION_FILTERS = {
   #     open: ->(resources) { resources.where(open: true) }
   #   }.freeze
-  COLLECTION_FILTERS = T.let({}.freeze, T::Hash[Symbol, T.untyped])
+  COLLECTION_FILTERS = T.let({
+    visible: ->(resources) { resources.visible },
+    hidden: ->(resources) { resources.where(hidden: true) }
+  }.freeze, T::Hash[Symbol, T.untyped])
 
   # Overwrite this method to customize how applications are displayed
   # across all pages of the admin dashboard.

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -104,7 +104,7 @@ class Alert < ApplicationRecord
   sig { returns(T.untyped) }
   def recent_new_applications
     point = RGeo::Geographic.spherical_factory.point(lng, lat)
-    result = Application.where("ST_DWithin(lonlat, ?, ?)", point.to_s, radius_meters)
+    result = Application.visible.where("ST_DWithin(lonlat, ?, ?)", point.to_s, radius_meters)
     result.where("first_date_scraped > ?", cutoff_time)
           .reorder("first_date_scraped DESC")
   end
@@ -113,7 +113,7 @@ class Alert < ApplicationRecord
   sig { returns(T.untyped) }
   def applications_with_new_comments
     point = RGeo::Geographic.spherical_factory.point(lng, lat)
-    result = Application.where("ST_DWithin(lonlat, ?, ?)", point.to_s, radius_meters)
+    result = Application.visible.where("ST_DWithin(lonlat, ?, ?)", point.to_s, radius_meters)
     result.reorder(first_date_scraped: :desc)
           .joins(:comments)
           .where("comments.published_at > ?", cutoff_time)

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -25,6 +25,7 @@ class Application < ApplicationRecord
 
   scope(:in_past_week, -> { where("first_date_scraped > ?", 7.days.ago) })
   scope(:recent, -> { where(first_date_scraped: 14.days.ago..) })
+  scope(:visible, -> { where(hidden: false) })
 
   sig { returns(T.class_of(ApplicationsPolicy)) }
   def self.policy_class
@@ -41,6 +42,13 @@ class Application < ApplicationRecord
     # We're capturing the geodata anyway via the "location" key
     r.delete(:lonlat)
     r
+  end
+
+  # Hidden applications are removed from the elasticsearch index so that they
+  # don't show up in full text search results
+  sig { returns(T::Boolean) }
+  def should_index?
+    !hidden
   end
 
   # For the benefit of kaminari. Also sets the maximum number of
@@ -102,7 +110,8 @@ class Application < ApplicationRecord
   def find_all_nearest_or_recent
     if location
       point = RGeo::Geographic.spherical_factory.point(lng, lat)
-      Application.where("ST_DWithin(lonlat, ?, ?)", point.to_s, Application.nearby_and_recent_max_distance_km * 1000)
+      Application.visible
+                 .where("ST_DWithin(lonlat, ?, ?)", point.to_s, Application.nearby_and_recent_max_distance_km * 1000)
                  .where.not(id:)
                  .where("first_date_scraped > ?", Application.nearby_and_recent_max_age_months.months.ago)
     else
@@ -112,7 +121,7 @@ class Application < ApplicationRecord
 
   sig { returns(ActiveRecord::Relation) }
   def self.trending
-    where("first_date_scraped > ?", 6.months.ago).order(visible_comments_count: :desc)
+    visible.where("first_date_scraped > ?", 6.months.ago).order(visible_comments_count: :desc)
   end
 
   sig { params(description: String).returns(String) }

--- a/app/policies/admin/applications_policy.rb
+++ b/app/policies/admin/applications_policy.rb
@@ -16,6 +16,16 @@ module Admin
     end
 
     sig { returns(T::Boolean) }
+    def edit?
+      user.has_role?(:admin)
+    end
+
+    sig { returns(T::Boolean) }
+    def update?
+      user.has_role?(:admin)
+    end
+
+    sig { returns(T::Boolean) }
     def destroy?
       user.has_role?(:admin)
     end

--- a/app/views/applications/_address_search.html.erb
+++ b/app/views/applications/_address_search.html.erb
@@ -23,7 +23,7 @@
     <div class="space-y-8">
       <ul class="space-y-8">
         <%# TODO: Probably want some ordering that shows applications from different places %>
-        <% Application.order(first_date_scraped: :desc).limit(3).each do |application| %>
+        <% Application.visible.order(first_date_scraped: :desc).limit(3).each do |application| %>
           <li class="flex items-start gap-6">
             <%= image_tag "clock.svg", class: "mt-1", alt: "" %>
             <%= render LinkBlockComponent.new(url: application_path(application)) do |c| %>

--- a/app/views/applications/hidden.html.erb
+++ b/app/views/applications/hidden.html.erb
@@ -1,0 +1,27 @@
+<% content_for :page_title, t(".page_title") %>
+
+<%= render CentreBlockWithImageComponent.new do |c| %>
+  <% c.with_heading do %>
+    <%= t(".heading") %>
+  <% end %>
+
+  <% c.with_image do %>
+    <%# TODO: Replace with a purpose-drawn hidden.svg - see the illustration brief attached to https://github.com/openaustralia/planningalerts/issues/2140 %>
+    <%= image_tag "illustration/no_results.svg", alt: "" %>
+  <% end %>
+
+  <div class="text-xl text-navy">
+    <p>
+      <%= @application.hidden_reason.presence || t(".default_reason") %>
+    </p>
+
+    <p class="mt-8">
+      <%= t(".record_kept") %>
+      <%= pa_link_to t(".contact_us"), documentation_contact_path %>.
+    </p>
+
+    <p class="mt-8">
+      <%= pa_link_to t(".go_home"), root_url %>
+    </p>
+  </div>
+<% end %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -22,6 +22,15 @@
   <%= image_tag "illustration/bottom-of-page-man.svg", alt: "" %>
 <% end %>
 
+<% if @application.hidden? %>
+  <div class="mb-8">
+    <%= render AlertComponent.new(type: :warning) do %>
+      <%= t("applications.show.hidden_admin_banner", reason: @application.hidden_reason.presence || t("applications.hidden.default_reason")) %>
+      <%= link_to t("applications.show.hidden_admin_banner_edit"), edit_admin_application_path(@application), class: "underline" %>
+    <% end %>
+  </div>
+<% end %>
+
 <%= render HeadingComponent.new(tag: :h1, extra_classes: "mb-10").with_content(@application.address) %>
 
 <%# TODO: Weird that the line below fails a test if it's just "map" rather than "applications/map" %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,13 +3,13 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "2eb65b3a9cc645431b29f91a447497fccccc438f0998b3893bf86ba16e29562e",
+      "fingerprint": "79f9eb8002c157639f8398b2c7d44b341a2fe2b7232455ad701334b563b4fdaa",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/controllers/applications_controller.rb",
-      "line": 85,
+      "line": 88,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Application.select(\"*\", \"ST_Distance(lonlat, '#{RGeo::Geographic.spherical_factory.point(GoogleGeocodeService.call(:address => T.let(T.cast(params[:q], T.nilable(String)), T.nilable(String)), :key => Rails.application.credentials.dig(:google_maps, :server_key)).top.lng, GoogleGeocodeService.call(:address => T.let(T.cast(params[:q], T.nilable(String)), T.nilable(String)), :key => Rails.application.credentials.dig(:google_maps, :server_key)).top.lat)}')/1000 AS distance\")",
+      "code": "Application.visible.select(\"*\", \"ST_Distance(lonlat, '#{RGeo::Geographic.spherical_factory.point(GoogleGeocodeService.call(:address => T.let(T.cast(params[:q], T.nilable(String)), T.nilable(String)), :key => Rails.application.credentials.dig(:google_maps, :server_key)).top.lng, GoogleGeocodeService.call(:address => T.let(T.cast(params[:q], T.nilable(String)), T.nilable(String)), :key => Rails.application.credentials.dig(:google_maps, :server_key)).top.lat)}')/1000 AS distance\")",
       "render_path": null,
       "location": {
         "type": "method",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,6 +63,16 @@ en:
       success: "API key created"
       already_have_key: "You already have an API key"
   applications:
+    hidden:
+      page_title: "Application hidden"
+      heading: "This application has been hidden"
+      default_reason: "It has been removed from public view."
+      record_kept: "The application record has not been deleted - it is just no longer shown publicly on Planning Alerts. If you have a question about this,"
+      contact_us: "please contact us"
+      go_home: "Go to our home page"
+    show:
+      hidden_admin_banner: "This application is hidden from the public. Reason: %{reason}"
+      hidden_admin_banner_edit: "Change or unhide"
     search:
       full_text_search_not_enabled: "You do not have access to full text search. It is currently only available to some users. Contact us if you would like access"
   comments:
@@ -85,6 +95,9 @@ en:
         subject: "PlanningAlerts: Activate your account"
   administrate:
     field_hints:
+      application:
+        hidden: Hide this application from all public pages, search results, the API and email alerts. It is not deleted and can be unhidden at any time.
+        hidden_reason: Published word-for-word on the public page for this application - anyone who visits can read it. Leave blank to show the default explanation ("It has been removed from public view.").
       authority:
         email: Where comments on applications are to be sent
         wikidata_id: The unique identifier on wikidata.org for this authority. Used to download boundary data.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,7 +53,7 @@ Rails.application.routes.draw do
         post :import
       end
     end
-    resources :applications, only: %i[index show destroy]
+    resources :applications, only: %i[index show edit update destroy]
     resources :api_keys, except: %i[destroy new create]
     resources :api_usages, only: :index
     resources :background_jobs, only: :index

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -19,7 +19,7 @@ SitemapGenerator::Sitemap.create do
   add faq_path, changefreq: "monthly"
   add get_involved_path, changefreq: "monthly"
 
-  ::Application.select(:id, :date_scraped).find_each do |application|
+  ::Application.visible.select(:id, :date_scraped).find_each do |application|
     add application_path(application), changefreq: "monthly", lastmod: application.date_scraped
   end
 end

--- a/db/migrate/20260817100506_add_hidden_to_applications.rb
+++ b/db/migrate/20260817100506_add_hidden_to_applications.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddHiddenToApplications < ActiveRecord::Migration[7.1]
+  def change
+    add_column :applications, :hidden, :boolean, default: false, null: false
+    add_column :applications, :hidden_reason, :text
+    add_index :applications, :hidden
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_13_095739) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_17_100506) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -164,11 +164,14 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_13_095739) do
     t.string "comment_email"
     t.string "comment_authority"
     t.geography "lonlat", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
+    t.boolean "hidden", default: false, null: false
+    t.text "hidden_reason"
     t.index ["authority_id", "council_reference"], name: "index_applications_on_authority_id_and_council_reference", unique: true
     t.index ["authority_id", "date_scraped"], name: "index_applications_on_authority_id_and_date_scraped"
     t.index ["authority_id", "first_date_scraped"], name: "index_applications_on_authority_id_and_first_date_scraped"
     t.index ["date_scraped", "lat", "lng"], name: "index_applications_on_date_scraped_and_lat_and_lng"
     t.index ["first_date_scraped", "lat", "lng"], name: "index_applications_on_first_date_scraped_and_lat_and_lng"
+    t.index ["hidden"], name: "index_applications_on_hidden"
     t.index ["lat", "lng", "date_scraped"], name: "index_applications_on_lat_and_lng_and_date_scraped"
     t.index ["lonlat"], name: "index_applications_on_lonlat", using: :gist
     t.index ["postcode"], name: "index_applications_on_postcode"

--- a/sorbet/rbi/dsl/application.rbi
+++ b/sorbet/rbi/dsl/application.rbi
@@ -567,6 +567,9 @@ class Application
     end
     def upsert_all(attributes, returning: nil, unique_by: nil); end
 
+    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+    def visible(*args, &blk); end
+
     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelationWhereChain) }
     def where(*args, &blk); end
 
@@ -982,6 +985,96 @@ class Application
 
     sig { void }
     def first_date_scraped_will_change!; end
+
+    sig { returns(T::Boolean) }
+    def hidden; end
+
+    sig { params(value: T::Boolean).returns(T::Boolean) }
+    def hidden=(value); end
+
+    sig { returns(T::Boolean) }
+    def hidden?; end
+
+    sig { returns(T.nilable(T::Boolean)) }
+    def hidden_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def hidden_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def hidden_came_from_user?; end
+
+    sig { returns(T.nilable([T::Boolean, T::Boolean])) }
+    def hidden_change; end
+
+    sig { returns(T.nilable([T::Boolean, T::Boolean])) }
+    def hidden_change_to_be_saved; end
+
+    sig { params(from: T::Boolean, to: T::Boolean).returns(T::Boolean) }
+    def hidden_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(T::Boolean)) }
+    def hidden_in_database; end
+
+    sig { returns(T.nilable([T::Boolean, T::Boolean])) }
+    def hidden_previous_change; end
+
+    sig { params(from: T::Boolean, to: T::Boolean).returns(T::Boolean) }
+    def hidden_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(T::Boolean)) }
+    def hidden_previously_was; end
+
+    sig { returns(T.nilable(::String)) }
+    def hidden_reason; end
+
+    sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+    def hidden_reason=(value); end
+
+    sig { returns(T::Boolean) }
+    def hidden_reason?; end
+
+    sig { returns(T.nilable(::String)) }
+    def hidden_reason_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def hidden_reason_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def hidden_reason_came_from_user?; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def hidden_reason_change; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def hidden_reason_change_to_be_saved; end
+
+    sig { params(from: T.nilable(::String), to: T.nilable(::String)).returns(T::Boolean) }
+    def hidden_reason_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::String)) }
+    def hidden_reason_in_database; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def hidden_reason_previous_change; end
+
+    sig { params(from: T.nilable(::String), to: T.nilable(::String)).returns(T::Boolean) }
+    def hidden_reason_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::String)) }
+    def hidden_reason_previously_was; end
+
+    sig { returns(T.nilable(::String)) }
+    def hidden_reason_was; end
+
+    sig { void }
+    def hidden_reason_will_change!; end
+
+    sig { returns(T.nilable(T::Boolean)) }
+    def hidden_was; end
+
+    sig { void }
+    def hidden_will_change!; end
 
     sig { returns(::Integer) }
     def id; end
@@ -1461,6 +1554,12 @@ class Application
     def restore_first_date_scraped!; end
 
     sig { void }
+    def restore_hidden!; end
+
+    sig { void }
+    def restore_hidden_reason!; end
+
+    sig { void }
     def restore_id!; end
 
     sig { void }
@@ -1552,6 +1651,18 @@ class Application
 
     sig { returns(T::Boolean) }
     def saved_change_to_first_date_scraped?; end
+
+    sig { returns(T.nilable([T::Boolean, T::Boolean])) }
+    def saved_change_to_hidden; end
+
+    sig { returns(T::Boolean) }
+    def saved_change_to_hidden?; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def saved_change_to_hidden_reason; end
+
+    sig { returns(T::Boolean) }
+    def saved_change_to_hidden_reason?; end
 
     sig { returns(T.nilable([::Integer, ::Integer])) }
     def saved_change_to_id; end
@@ -1794,6 +1905,12 @@ class Application
     def will_save_change_to_first_date_scraped?; end
 
     sig { returns(T::Boolean) }
+    def will_save_change_to_hidden?; end
+
+    sig { returns(T::Boolean) }
+    def will_save_change_to_hidden_reason?; end
+
+    sig { returns(T::Boolean) }
     def will_save_change_to_id?; end
 
     sig { returns(T::Boolean) }
@@ -1965,6 +2082,9 @@ class Application
 
     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
     def unscope(*args, &blk); end
+
+    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+    def visible(*args, &blk); end
 
     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelationWhereChain) }
     def where(*args, &blk); end

--- a/sorbet/rbi/dsl/generated_path_helpers_module.rbi
+++ b/sorbet/rbi/dsl/generated_path_helpers_module.rbi
@@ -208,6 +208,9 @@ module GeneratedPathHelpersModule
   def edit_admin_api_key_path(*args); end
 
   sig { params(args: T.untyped).returns(String) }
+  def edit_admin_application_path(*args); end
+
+  sig { params(args: T.untyped).returns(String) }
   def edit_admin_authority_path(*args); end
 
   sig { params(args: T.untyped).returns(String) }

--- a/sorbet/rbi/dsl/generated_url_helpers_module.rbi
+++ b/sorbet/rbi/dsl/generated_url_helpers_module.rbi
@@ -208,6 +208,9 @@ module GeneratedUrlHelpersModule
   def edit_admin_api_key_url(*args); end
 
   sig { params(args: T.untyped).returns(String) }
+  def edit_admin_application_url(*args); end
+
+  sig { params(args: T.untyped).returns(String) }
   def edit_admin_authority_url(*args); end
 
   sig { params(args: T.untyped).returns(String) }

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -161,6 +161,20 @@ describe ApiController do
           }]
         )
       end
+
+      it "does not move the cursor backwards when all the applications after since_id are hidden" do
+        key.update(bulk: true)
+        create(:geocoded_application, id: 10, date_scraped: Time.utc(2001, 1, 1))
+        create(:geocoded_application, :hidden, id: 20, date_scraped: Time.utc(2001, 1, 2))
+
+        get :all, params: { key: key.value, since_id: 20, format: "js" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include(
+          "application_count" => 0,
+          "max_id" => 20
+        )
+      end
     end
   end
 

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -175,6 +175,19 @@ describe ApiController do
           "max_id" => 20
         )
       end
+
+      it "returns max_id 0 rather than null when there is no since_id and nothing is visible" do
+        key.update(bulk: true)
+        create(:geocoded_application, :hidden, id: 10, date_scraped: Time.utc(2001, 1, 1))
+
+        get :all, params: { key: key.value, format: "js" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include(
+          "application_count" => 0,
+          "max_id" => 0
+        )
+      end
     end
   end
 

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -182,7 +182,9 @@ describe ApiController do
       scope2 = Application.none
       scope3 = Application.none
       scope4 = Application.none
-      allow(Application).to receive(:order).and_return(scope1)
+      visible_scope = Application.none
+      allow(Application).to receive(:visible).and_return(visible_scope)
+      allow(visible_scope).to receive(:order).and_return(scope1)
       allow(scope1).to receive(:where).with(postcode: "2780").and_return(scope2)
       allow(scope2).to receive(:includes).and_return(scope3)
       allow(scope3).to receive(:page).with(nil).and_return(scope4)
@@ -201,7 +203,9 @@ describe ApiController do
       scope3 = Application.none
       scope4 = Application.none
       allow(result).to receive(:total_pages).and_return(5)
-      allow(Application).to receive(:order).and_return(scope1)
+      visible_scope = Application.none
+      allow(Application).to receive(:visible).and_return(visible_scope)
+      allow(visible_scope).to receive(:order).and_return(scope1)
       allow(scope1).to receive(:where).and_return(scope2)
       allow(scope2).to receive(:includes).and_return(scope3)
       allow(scope3).to receive(:page).and_return(scope4)
@@ -239,7 +243,9 @@ describe ApiController do
       scope3 = Application.none
       scope4 = Application.none
       allow(result).to receive(:total_pages).and_return(5)
-      allow(Application).to receive(:order).and_return(scope1)
+      visible_scope = Application.none
+      allow(Application).to receive(:visible).and_return(visible_scope)
+      allow(visible_scope).to receive(:order).and_return(scope1)
       allow(scope1).to receive(:where).and_return(scope2)
       allow(scope2).to receive(:includes).and_return(scope3)
       allow(scope3).to receive(:page).and_return(scope4)
@@ -279,7 +285,9 @@ describe ApiController do
       scope3 = Application.none
       scope4 = Application.none
       allow(result).to receive(:total_pages).and_return(5)
-      allow(Application).to receive(:order).and_return(scope1)
+      visible_scope = Application.none
+      allow(Application).to receive(:visible).and_return(visible_scope)
+      allow(visible_scope).to receive(:order).and_return(scope1)
       allow(scope1).to receive(:where).and_return(scope2)
       allow(scope2).to receive(:includes).and_return(scope3)
       allow(scope3).to receive(:page).and_return(scope4)
@@ -319,7 +327,9 @@ describe ApiController do
       scope2 = Application.none
       scope3 = Application.none
       scope4 = Application.none
-      allow(Application).to receive(:order).and_return(scope1)
+      visible_scope = Application.none
+      allow(Application).to receive(:visible).and_return(visible_scope)
+      allow(visible_scope).to receive(:order).and_return(scope1)
       allow(scope1).to receive(:where).with(suburb: "Katoomba").and_return(scope2)
       allow(scope2).to receive(:includes).and_return(scope3)
       allow(scope3).to receive(:page).with(nil).and_return(scope4)
@@ -337,7 +347,9 @@ describe ApiController do
         scope3 = Application.none
         scope4 = Application.none
         scope5 = Application.none
-        allow(Application).to receive(:order).and_return(scope1)
+        visible_scope = Application.none
+        allow(Application).to receive(:visible).and_return(visible_scope)
+        allow(visible_scope).to receive(:order).and_return(scope1)
         allow(scope1).to receive(:where).with(suburb: "Katoomba").and_return(scope2)
         allow(scope2).to receive(:where).with(state: "NSW").and_return(scope3)
         allow(scope3).to receive(:includes).and_return(scope4)
@@ -358,7 +370,9 @@ describe ApiController do
         scope4 = Application.none
         scope5 = Application.none
         scope6 = Application.none
-        allow(Application).to receive(:order).and_return(scope1)
+        visible_scope = Application.none
+        allow(Application).to receive(:visible).and_return(visible_scope)
+        allow(visible_scope).to receive(:order).and_return(scope1)
         allow(scope1).to receive(:where).with(suburb: "Katoomba").and_return(scope2)
         allow(scope2).to receive(:where).with(state: "NSW").and_return(scope3)
         allow(scope3).to receive(:where).with(postcode: "2780").and_return(scope4)
@@ -383,7 +397,9 @@ describe ApiController do
       scope3 = Application.none
       scope4 = Application.none
 
-      allow(Application).to receive(:where).and_return(scope1)
+      visible_scope = Application.none
+      allow(Application).to receive(:visible).and_return(visible_scope)
+      allow(visible_scope).to receive(:where).and_return(scope1)
       allow(scope1).to receive(:reorder).and_return(scope2)
       allow(scope2).to receive(:includes).and_return(scope3)
       allow(scope3).to receive(:page).and_return(scope4)
@@ -462,7 +478,9 @@ describe ApiController do
       scope2 = Application.none
       scope3 = Application.none
       scope4 = Application.none
-      allow(Application).to receive(:order).and_return(scope1)
+      visible_scope = Application.none
+      allow(Application).to receive(:visible).and_return(visible_scope)
+      allow(visible_scope).to receive(:order).and_return(scope1)
       allow(scope1).to receive(:where).with(lat: "1.0".."3.0", lng: "2.0".."4.0").and_return(scope2)
       allow(scope2).to receive(:includes).and_return(scope3)
       allow(scope3).to receive(:page).with(nil).and_return(scope4)
@@ -539,6 +557,61 @@ describe ApiController do
 
         it { expect(page).not_to be_successful }
         it { expect(page.body).to eq '{"error":"invalid date_scraped"}' }
+      end
+    end
+  end
+
+  describe "hidden applications" do
+    let(:authority) { create(:authority, full_name: "Acme Local Planning Authority", short_name: "acme") }
+    let!(:visible_application) do
+      create(:geocoded_application, id: 1, authority:, council_reference: "V1", date_scraped: Time.utc(2015, 5, 6, 12, 0, 0))
+    end
+    let!(:hidden_application) do
+      create(:geocoded_application, :hidden, id: 2, authority:, council_reference: "H1", date_scraped: Time.utc(2015, 5, 6, 12, 0, 0))
+    end
+
+    def returned_ids
+      response.parsed_body.map { |a| a["application"]["id"] }
+    end
+
+    it "is not included in the authority endpoint" do
+      get :authority, params: { key: key.value, format: "js", authority_id: "acme" }
+      expect(returned_ids).to eq [visible_application.id]
+      expect(returned_ids).not_to include(hidden_application.id)
+    end
+
+    it "is not included in the suburb_postcode endpoint" do
+      get :suburb_postcode, params: { key: key.value, format: "js", suburb: "Sydney" }
+      expect(returned_ids).to eq [visible_application.id]
+      expect(returned_ids).not_to include(hidden_application.id)
+    end
+
+    it "is not included in the point endpoint" do
+      get :point, params: { key: key.value, format: "js", lat: 1.0, lng: 2.0, radius: 1000 }
+      expect(returned_ids).to eq [visible_application.id]
+      expect(returned_ids).not_to include(hidden_application.id)
+    end
+
+    it "is not included in the area endpoint" do
+      get :area, params: { key: key.value, format: "js", bottom_left_lat: 0.0, bottom_left_lng: 1.0, top_right_lat: 2.0, top_right_lng: 3.0 }
+      expect(returned_ids).to eq [visible_application.id]
+      expect(returned_ids).not_to include(hidden_application.id)
+    end
+
+    context "with a bulk api key" do
+      let(:key) { create(:api_key, bulk: true) }
+
+      it "is not included in the date_scraped endpoint" do
+        get :date_scraped, params: { key: key.value, format: "js", date_scraped: "2015-05-06" }
+        expect(returned_ids).to eq [visible_application.id]
+        expect(returned_ids).not_to include(hidden_application.id)
+      end
+
+      it "is not included in the all endpoint" do
+        get :all, params: { key: key.value, format: "js" }
+        expect(response.parsed_body["application_count"]).to eq 1
+        expect(response.parsed_body["applications"].map { |a| a["application"]["id"] }).to eq [visible_application.id]
+        expect(response.parsed_body["applications"].map { |a| a["application"]["id"] }).not_to include(hidden_application.id)
       end
     end
   end

--- a/spec/controllers/applications_controller_spec.rb
+++ b/spec/controllers/applications_controller_spec.rb
@@ -101,6 +101,39 @@ describe ApplicationsController do
     end
   end
 
+  describe "#external" do
+    context "when the application is hidden" do
+      let!(:application) { create(:geocoded_application, :hidden, id: 1) }
+
+      it "returns 403 forbidden and renders the hidden page for anonymous users" do
+        get :external, params: { id: application.id }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response).to render_template("hidden")
+      end
+
+      it "returns 403 forbidden for signed in users that are not admins" do
+        sign_in create(:confirmed_user)
+
+        get :external, params: { id: application.id }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response).to render_template("hidden")
+      end
+
+      it "returns 200 and renders the normal page for admins" do
+        admin = create(:confirmed_user)
+        admin.add_role(:admin)
+        sign_in admin
+
+        get :external, params: { id: application.id }
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template("external")
+      end
+    end
+  end
+
   describe "#address" do
     before { allow(GoogleGeocodeService).to receive(:call).and_return(GeocoderResults.new([], nil)) }
 

--- a/spec/controllers/applications_controller_spec.rb
+++ b/spec/controllers/applications_controller_spec.rb
@@ -21,6 +21,18 @@ describe ApplicationsController do
         expect { get :index, params: { authority_id: "this_authority_does_not_exist" } }.to raise_error ActiveRecord::RecordNotFound
       end
     end
+
+    describe "hidden applications" do
+      it "does not include hidden applications" do
+        application = create(:geocoded_application)
+        hidden_application = create(:geocoded_application, :hidden)
+
+        get :index
+
+        expect(assigns[:applications]).to include(application)
+        expect(assigns[:applications]).not_to include(hidden_application)
+      end
+    end
   end
 
   describe "#show" do
@@ -56,6 +68,37 @@ describe ApplicationsController do
         expect(response).to redirect_to(id: redirect.redirect_application_id)
       end
     end
+
+    context "when the application is hidden" do
+      let!(:application) { create(:geocoded_application, :hidden, id: 1) }
+
+      it "returns 403 forbidden and renders the hidden page for anonymous users" do
+        get :show, params: { id: application.id }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response).to render_template("hidden")
+      end
+
+      it "returns 403 forbidden for signed in users that are not admins" do
+        sign_in create(:confirmed_user)
+
+        get :show, params: { id: application.id }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response).to render_template("hidden")
+      end
+
+      it "returns 200 and renders the normal page for admins" do
+        admin = create(:confirmed_user)
+        admin.add_role(:admin)
+        sign_in admin
+
+        get :show, params: { id: application.id }
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template("show")
+      end
+    end
   end
 
   describe "#address" do
@@ -69,6 +112,25 @@ describe ApplicationsController do
     it "sets the radius to the default when not supplied" do
       get :address, params: { q: "24 Bruce Road Glenbrook" }
       expect(assigns[:radius]).to eq 2000.0
+    end
+
+    context "with applications near the searched address" do
+      let(:geo_factory) { RGeo::Geographic.spherical_factory(srid: 4326) }
+      let!(:application) do
+        create(:geocoded_application, lat: -33.772607, lng: 150.624245, lonlat: geo_factory.point(150.624245, -33.772607))
+      end
+      let!(:hidden_application) do
+        create(:geocoded_application, :hidden, lat: -33.772607, lng: 150.624245, lonlat: geo_factory.point(150.624245, -33.772607))
+      end
+
+      before { mock_geocoder_valid_address_response }
+
+      it "does not include hidden applications" do
+        get :address, params: { q: "24 Bruce Road Glenbrook" }
+
+        expect(assigns[:applications]).to include(application)
+        expect(assigns[:applications]).not_to include(hidden_application)
+      end
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -20,6 +20,11 @@ FactoryBot.define do
     description { "pretty" }
     info_url { "http://foo.com" }
 
+    trait :hidden do
+      hidden { true }
+      hidden_reason { "Contains personal information" }
+    end
+
     factory :application do
       date_received { nil }
       on_notice_from { nil }

--- a/spec/features/admin_hides_application_spec.rb
+++ b/spec/features/admin_hides_application_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Hiding an application" do
+  describe "admin hides an application" do
+    before do
+      create(:geocoded_application, id: 1, council_reference: "DA/2026/1")
+    end
+
+    it "successfully" do
+      sign_in_as_admin
+
+      click_on "Applications"
+
+      click_on "Edit"
+
+      check "Hidden"
+      fill_in "Hidden reason", with: "Contains personal information"
+      click_on "Update Application"
+
+      expect(page).to have_content("Application was successfully updated")
+      expect(page).to have_content("Hidden\nyes")
+      expect(page).to have_content("Contains personal information")
+    end
+  end
+
+  describe "viewing a hidden application" do
+    context "when a reason was given" do
+      before do
+        create(:geocoded_application, :hidden, id: 1, hidden_reason: "Contains personal information")
+      end
+
+      it "shows an explanation page with the reason" do
+        visit application_path(id: 1)
+
+        expect(page.status_code).to eq 403
+        expect(page).to have_content("This application has been hidden")
+        expect(page).to have_content("Contains personal information")
+        expect(page).to have_content("The application record has not been deleted")
+      end
+    end
+
+    context "when no reason was given" do
+      before do
+        create(:geocoded_application, :hidden, id: 1, hidden_reason: nil)
+      end
+
+      it "shows an explanation page with the default reason" do
+        visit application_path(id: 1)
+
+        expect(page.status_code).to eq 403
+        expect(page).to have_content("This application has been hidden")
+        expect(page).to have_content("It has been removed from public view.")
+      end
+    end
+  end
+end

--- a/spec/features/admin_hides_application_spec.rb
+++ b/spec/features/admin_hides_application_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 describe "Hiding an application" do
+  let(:hidden_reason) { "Contains personal information" }
+
   describe "admin hides an application" do
     before do
       create(:geocoded_application, id: 1, council_reference: "DA/2026/1")
@@ -16,19 +18,19 @@ describe "Hiding an application" do
       click_on "Edit"
 
       check "Hidden"
-      fill_in "Hidden reason", with: "Contains personal information"
+      fill_in "Hidden reason", with: hidden_reason
       click_on "Update Application"
 
       expect(page).to have_content("Application was successfully updated")
       expect(page).to have_content("Hidden\nyes")
-      expect(page).to have_content("Contains personal information")
+      expect(page).to have_content(hidden_reason)
     end
   end
 
   describe "viewing a hidden application" do
     context "when a reason was given" do
       before do
-        create(:geocoded_application, :hidden, id: 1, hidden_reason: "Contains personal information")
+        create(:geocoded_application, :hidden, id: 1, hidden_reason:)
       end
 
       it "shows an explanation page with the reason" do
@@ -36,7 +38,7 @@ describe "Hiding an application" do
 
         expect(page.status_code).to eq 403
         expect(page).to have_content("This application has been hidden")
-        expect(page).to have_content("Contains personal information")
+        expect(page).to have_content(hidden_reason)
         expect(page).to have_content("The application record has not been deleted")
       end
     end

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -398,6 +398,19 @@ describe Alert do
         end
       end
     end
+
+    context "with a hidden application nearby" do
+      let(:radius_meters) { 2000 }
+      let(:last_sent) { nil }
+
+      before do
+        app1.update!(hidden: true)
+      end
+
+      it "does not include the hidden application" do
+        expect(alert.recent_new_applications).to contain_exactly(app2)
+      end
+    end
   end
 
   describe "#new_comments" do
@@ -496,6 +509,15 @@ describe Alert do
     context "when there is a hidden comment near by" do
       it "does not return the application it belongs to" do
         create(:published_comment, hidden: true, application: near_application)
+
+        expect(alert.applications_with_new_comments).to eq []
+      end
+    end
+
+    context "when there is a new comment near by on a hidden application" do
+      it "does not return the application it belongs to" do
+        create(:published_comment, application: near_application)
+        near_application.update!(hidden: true)
 
         expect(alert.applications_with_new_comments).to eq []
       end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -219,4 +219,41 @@ describe Application do
       expect(create(:geocoded_application).search_data).not_to have_key(:lonlat)
     end
   end
+
+  describe ".visible" do
+    it "does not include hidden applications" do
+      application = create(:application)
+      hidden_application = create(:application, :hidden)
+
+      expect(described_class.visible).to include(application)
+      expect(described_class.visible).not_to include(hidden_application)
+    end
+  end
+
+  describe "#should_index?" do
+    it "indexes a normal application" do
+      expect(build(:application_with_no_version).should_index?).to be true
+    end
+
+    it "does not index a hidden application" do
+      expect(build(:application_with_no_version, :hidden).should_index?).to be false
+    end
+  end
+
+  describe ".trending" do
+    it "does not include hidden applications" do
+      hidden_application = create(:application, :hidden)
+
+      expect(described_class.trending).not_to include(hidden_application)
+    end
+  end
+
+  describe "#find_all_nearest_or_recent" do
+    it "does not include hidden applications nearby" do
+      application = create(:geocoded_application)
+      hidden_application = create(:geocoded_application, :hidden)
+
+      expect(application.find_all_nearest_or_recent).not_to include(hidden_application)
+    end
+  end
 end

--- a/spec/views/applications/show_spec.rb
+++ b/spec/views/applications/show_spec.rb
@@ -23,7 +23,8 @@ describe "applications/show" do
       on_notice_from: nil,
       on_notice_to: nil,
       find_all_nearest_or_recent: [],
-      comments: []
+      comments: [],
+      hidden?: false
     )
   end
 


### PR DESCRIPTION
## Description

Adds a `hidden` flag (plus a free-text `hidden_reason`) to applications so an admin can remove an application from public view without deleting it. The record, its versions and its comments are all kept, and it can be unhidden at any time.

**Admin**

- New moderation-only edit form in the Administrate admin (`hidden` checkbox + `hidden_reason` text), restricted to the `admin` role
- Field hints spell out that the reason is published word-for-word on the public page
- `visible:`/`hidden:` collection filters on the admin applications index

**Public**

Hidden applications are excluded from:

- Recent applications listings (Australia-wide and per authority)
- Address search, full text search (via searchkick `should_index?`), trending and "nearby" applications
- All six API endpoints (`authority`, `suburb_postcode`, `point`, `area`, `date_scraped`, `all`) - silent omission, no tombstone
- The sitemap and the public comments listing
- Email alerts (both new applications and new comments on a hidden application)

The public application page returns **403 Forbidden** with an explanation page showing the admin-entered reason, or a default ("It has been removed from public view.") when none was given. Admins visiting the same URL get the normal page (200) with a warning banner linking to the moderation form. The same guard covers the external redirect page, version history and comment creation.

Implementation notes:

- The explanation page reuses `no_results.svg` as an interim illustration with a `TODO`; a purpose-drawn `hidden.svg` has been briefed separately for the design system
- The `brakeman.ignore` fingerprint for the pre-existing SQL injection warning in `ApplicationsController#address` was regenerated because the flagged expression now includes the `visible` scope
- Existing API controller specs that mocked query chains were updated to stub through the new scope

## Motivation and Context

At the moment the only way to remove an application from public view is to delete it outright, which permanently loses the data. That's not appropriate when a record just needs to be hidden (e.g. published in error, or containing personal information) rather than removed.

Resolves #2140

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

Local run (macOS, postgres + elasticsearch via Docker Compose):

- `bundle exec rspec --tag "~js"`: 560 examples, 0 failures (the `:js` accessibility specs need headless Firefox which wasn't available locally; they run in CI)
- `bundle exec rubocop`, `bin/erblint --lint-all`, `bin/brakeman -q -w2`, `bin/srb tc`, `bin/tapioca dsl --verify` + `check-shims`: all clean

Manual testing of the admin flow is still to be done before this leaves draft; CI `test` job is running at time of writing (`lint` and `type_check` have passed).

## Screenshots (if appropriate):

<img width="1280" height="716" alt="admin-moderation-form" src="https://github.com/user-attachments/assets/2c2da2bb-a56e-4ee2-8099-aa9712c88c88" />
<img width="1280" height="1215" alt="admin-show-hidden-fields" src="https://github.com/user-attachments/assets/23e909ee-74cb-49e5-8637-887d300a7b10" />
<img width="1280" height="577" alt="admin-view-hidden-banner" src="https://github.com/user-attachments/assets/a5b349b5-c4fd-4aa0-af6d-d96b063593a8" />
<img width="1280" height="1817" alt="public-403-hidden-page" src="https://github.com/user-attachments/assets/da8b44d7-849a-41ed-b877-6fc1f2fde80b" />



## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.