### PR TITLE
Handle network errors when proxying analytics to plausible.io

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,7 +40,14 @@ class PlausibleProxy < Rack::Proxy
 
         env['content-length'] = nil
 
-        super(env)
+        begin
+          super
+        rescue Timeout::Error, SystemCallError, SocketError, OpenSSL::SSL::SSLError, EOFError => e
+          # Analytics are best-effort. If plausible.io is slow or unreachable we
+          # don't want to raise an error (and return a 500 to the user)
+          Rails.logger.warn("PlausibleProxy: #{e.class}: #{e.message}")
+          [502, {}, []]
+        end
     else
       @app.call(env)
     end

--- a/spec/requests/plausible_proxy_spec.rb
+++ b/spec/requests/plausible_proxy_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "PlausibleProxy" do
+  context "when plausible.io is unreachable" do
+    before do
+      # rack-proxy opens the connection to plausible.io lazily via
+      # Net::HTTP#start, using its own "hacked" net/http internals that
+      # WebMock can't intercept. So we have to stub at the object level.
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Net::HTTP).to receive(:start).and_raise(Net::OpenTimeout)
+      # rubocop:enable RSpec/AnyInstance
+    end
+
+    it "returns a 502 rather than raising when proxying analytics events" do
+      post "https://www.planningalerts.org.au/api/event"
+      expect(response).to have_http_status(:bad_gateway)
+    end
+
+    it "returns a 502 rather than raising when proxying the analytics script" do
+      get "https://www.planningalerts.org.au/js/script.js"
+      expect(response).to have_http_status(:bad_gateway)
+    end
+  end
+end


### PR DESCRIPTION
## Description

Rescues network-level errors (`Net::OpenTimeout`, connection refused, DNS failures, SSL errors, EOF) in the `PlausibleProxy` Rack middleware and returns a 502 for the analytics request (with a logged warning) instead of letting the exception bubble up as a 500 to the visitor.

Adds a request spec (`spec/requests/plausible_proxy_spec.rb`) covering both proxied paths (`/api/event` and `/js/script.*`).

## Motivation and Context

The `PlausibleProxy` middleware in `config/application.rb` proxies analytics requests to plausible.io synchronously via rack-proxy, which opens the upstream connection with no error handling on our side. When plausible.io was briefly unreachable on 2026-08-17, every analytics request during the blip raised an unhandled `Net::OpenTimeout` — 500s for visitors and 13 Sentry events in ~90 seconds.

Analytics are best-effort: an upstream analytics outage shouldn't error requests for visitors or page us.

Resolves #2175
Fixes [PLANNING-ALERTS-6](https://oaf-org-au.sentry.io/issues/141215382/)

Note: each hung request still holds a Puma thread for up to Net::HTTP's default 60s open timeout — rack-proxy 0.7.7 only exposes `read_timeout`, not `open_timeout`, so shortening that would need a bigger change (or replacing rack-proxy). Left out of scope here.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

The new spec reproduces the production failure by stubbing `Net::HTTP#start` to raise `Net::OpenTimeout` (rack-proxy uses its own "hacked" net/http internals, so WebMock can't intercept it). Before the fix it failed with the exact production stack trace (`config/application.rb:43:in 'perform_request'`); after the fix both examples pass. Rubocop is clean on the changed lines. The pre-existing `redirects_spec.rb` failure locally is unrelated (missing local tailwind asset build); verified it fails identically on a clean tree.

## Screenshots (if appropriate):

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
