### PR TITLE
Configure the installed engineering skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,3 +366,24 @@ Nothing checks these for you, so keep them consistent by hand:
   it is a deliberate content decision, not a tidy-up.
 - Do not invent variations on the names of OAF's other services. They are Right
   to Know, They Vote for You, OpenAustralia.org.au and morph.io.
+
+## Agent skills
+
+Configuration the installed engineering skills read before they act. Edit the
+files under `docs/agents/` directly rather than re-running the setup skill.
+
+### Issue tracker
+
+Issues live in GitHub Issues on `openaustralia/planningalerts`, worked through
+the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical triage roles use their own names as label strings. See
+`docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` and `docs/adr/` at the repository root. Neither
+exists yet, and that is fine. They are created lazily when a term or a decision
+actually gets resolved, not upfront. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists. It points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`**: read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that is a signal. Either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders), but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,47 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues on
+[`openaustralia/planningalerts`](https://github.com/openaustralia/planningalerts).
+Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v`; `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either. Resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies**, the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only, the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me`, the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds `docs/agents/` with the three configuration files the installed
engineering skills read before they act, and a `## Agent skills` section in
`AGENTS.md` pointing at them.

- `docs/agents/issue-tracker.md` records that issues live in GitHub Issues on
  this repository and are worked through the `gh` CLI. Pull requests are
  deliberately left out as a request surface, so dependabot and external PRs
  do not land in the triage queue.
- `docs/agents/triage-labels.md` maps the five canonical triage roles to label
  strings. All five use their own names.
- `docs/agents/domain.md` records a single-context layout, so `CONTEXT.md` and
  `docs/adr/` at the repository root. Neither exists yet. They are meant to be
  created lazily when a term or a decision actually gets resolved, not upfront,
  so this change does not create them.

Two judgement calls worth a reviewer's attention:

1. **Labels.** `wontfix` already existed and is untouched. `needs-triage`,
   `needs-info`, `ready-for-agent` and `ready-for-human` have been created on
   the repository so the labels and this file agree. Nothing was renamed: none
   of the existing 33 labels mapped to a triage state, and `Research`,
   `Support` and `High priority` are topic and priority labels that would lose
   their meaning if repurposed.

2. **`docs/` alongside the existing `doc/`.** The repository already has `doc/`
   (singular) for `principles.md`, `visual-design.md` and the data policies.
   The consumer skills read the literal path `docs/agents/`, so putting these
   anywhere else would stop them finding the files. The duplication is
   deliberate rather than an oversight.

The upstream seed templates use em dashes throughout, which the house style
does not, so they have been rewritten with hyphens, commas and full stops.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Without these files each skill guesses at the tracker, invents its own label
vocabulary, and looks for domain docs in whatever layout it assumes. That
produces issues in the wrong place and labels that quietly diverge from the
ones the repository actually uses.

This is stacked on #2149, because the `## Agent skills` section has to live in
`AGENTS.md` and that file does not exist on `main` yet. It should be reviewed
and merged after #2149.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
- [ ] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

This change is documentation only and touches no application code, so there is
nothing for the suite to exercise. What was verified instead:

- The four new labels were created and read back from the GitHub API, and all
  33 pre-existing labels were listed and checked for a triage-role match before
  concluding that no rename applied.
- Every file referenced from the `## Agent skills` section exists at the path
  given.
- The written files were grepped for em dashes, returning none.

The three boxes are left unticked on purpose. There is no affected area to
check manually, the suite was not run locally for a docs-only change, and the
checks need to be confirmed green before this comes out of draft.

## Screenshots (if appropriate):

N/A

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## AI assistance

Written with AI assistance, disclosed per the org
[CONTRIBUTING guide](https://github.com/openaustralia/.github/blob/main/.github/CONTRIBUTING.md).
The commit carries an `Assisted-by: Claude Code:claude-opus-5` trailer.

The agent ran the setup skill, read the seed templates, checked the repository
labels, and drafted the files. The human made the calls on the issue tracker,
the label strategy and where the branch should sit, and gave the DCO sign-off.
