### PR TITLE
Load the Sentry browser loader from the EU region

### DIFF
--- a/app/views/application/_sentry.html.erb
+++ b/app/views/application/_sentry.html.erb
@@ -14,5 +14,5 @@
       });
     };
   </script>
-  <%= javascript_include_tag "https://js.sentry-cdn.com/d56690508e2b07f38f9b78ae4228f42f.min.js", crossorigin: "anonymous" %>
+  <%= javascript_include_tag "https://js-de.sentry-cdn.com/d56690508e2b07f38f9b78ae4228f42f.min.js", crossorigin: "anonymous" %>
 <% end %>


### PR DESCRIPTION
## Description

Loads the Sentry browser loader script from `js-de.sentry-cdn.com` instead of
`js.sentry-cdn.com` in `app/views/application/_sentry.html.erb`. One line, no
key change.

## Motivation and Context

The `oaf-org-au` Sentry org is on Sentry's EU region (`de.sentry.io`), so the
loader script has to come from the region-specific host. For an EU key,
`js.sentry-cdn.com` returns a stub whose every method is a `console.warn`:

```
$ curl -s https://js.sentry-cdn.com/<key>.min.js | head -c 120
function _sentry_noopWarning() {
  console.warn("The Sentry loader you are trying to use isn't working anymore, check your configuration.");

$ curl -s https://js-de.sentry-cdn.com/<key>.min.js | head -c 120
!function(n,e,r,t,o,i,a,c,s){for(var u=s,f=0;f<document.scripts.length;f++)if(document.scripts[f].src.indexOf(i)>-1)
```

So browser error monitoring and session replay have been silently disabled
since the loader was added in #2142 on 2026-08-11. Both hosts return HTTP 200,
and the only symptom is a single console warning, which is why nothing
surfaced. Sentry showed zero browser events, which reads as "no frontend
errors happened" rather than "monitoring is broken".

The existing key resolves to the real minified loader on the DE host, so no
new key or DSN is needed.

No issue was filed for this, so the branch name has no issue number.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
- [ ] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

None of the three are ticked yet, deliberately:

- The partial is wrapped in `if Rails.env.production?`, so the change does not
  render in development or test and cannot be exercised locally. The real
  check is browser events arriving in the `planning-alerts` Sentry project
  after deploy.
- What has been verified is the host itself, with the two `curl` calls above
  against the actual production key.
- `bin/erblint app/views/application/_sentry.html.erb` passes. The full
  `bin/rake`, `ci:type` and `ci:lint` gates have not been run locally yet; a
  port clash on 15432 is blocking `docker compose up` on this machine. Holding
  in draft until all three have run.

## Screenshots (if appropriate):

n/a

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

Assisted by AI: written with Claude Code (`claude-opus-5`). A human reviewed
the change, made the DCO sign-off and is accountable for it.
