### PR TITLE
Support Sentry CLI v4 and v3, and skip release recording when neither is usable

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,17 +184,21 @@ bundle exec cap --tasks
 
 ### Sentry release tracking
 
-Deploys automatically record a release and deploy in Sentry (org `oaf-org-au`, project `planning-alerts`) so issues can be tied to the deploy that introduced them. This runs via a Capistrano hook using `sentry-cli` on your machine (part of [#2049](https://github.com/openaustralia/planningalerts/issues/2049)).
+Deploys automatically record a release and deploy in Sentry (org `oaf-org-au`, project `planning-alerts`) so issues can be tied to the deploy that introduced them. This runs via a Capistrano hook using the Sentry CLI on your machine (part of [#2049](https://github.com/openaustralia/planningalerts/issues/2049)).
 
-One-time setup per deployer machine:
+The hook supports both CLI v4 (binary `sentry`) and the legacy v3 (binary `sentry-cli`), preferring v4 when both are installed. See the [v4 migration guide](https://cli.sentry.dev/migrating-from-v3/).
 
-1. Install sentry-cli: `brew install getsentry/tools/sentry-cli` on macOS, or `curl -sL https://sentry.io/get-cli/ | sh` on Linux
-2. Authenticate: run `sentry-cli login` — it opens Sentry to create a personal User Auth Token (needs the `project:releases` and `org:read` scopes) and stores it in `~/.sentryclirc`
-3. Verify: `sentry-cli info` should show you are authenticated against the `oaf-org-au` org
+One-time setup per deployer machine (v4, recommended):
+
+1. Install the CLI: `brew install getsentry/tools/sentry` on macOS, or `curl https://cli.sentry.dev/install -fsS | bash` on Linux
+2. Authenticate: run `sentry auth login` — it opens Sentry in a browser to authenticate (the token needs the `project:releases` and `org:read` scopes)
+3. Verify: `sentry info` should show you are authenticated against the `oaf-org-au` org
+
+If you still have v3 (`sentry-cli`), it keeps working: authenticate with `sentry-cli login` and verify with `sentry-cli info`.
 
 The repo's committed `.sentryclirc` supplies org/project defaults; your token stays in `~/.sentryclirc` and must never be committed.
 
-If sentry-cli is missing or unauthenticated the deploy still succeeds — the hook prints a warning and skips recording the release, so set it up before your next production deploy.
+If the Sentry CLI is missing or unauthenticated the deploy still succeeds — the hook prints a warning and skips recording the release, so set it up before your next production deploy.
 
 ## Upgrading Ruby in production
 

--- a/lib/capistrano/tasks/sentry.rake
+++ b/lib/capistrano/tasks/sentry.rake
@@ -12,7 +12,16 @@ namespace :sentry do
   desc "Record the release and deploy in Sentry"
   task :release do
     run_locally do
-      unless test("sentry-cli info")
+      # SSHKit's local backend execs commands directly rather than through a
+      # shell, so a missing binary raises Errno::ENOENT instead of making
+      # `test` return false. Treat it the same as an unauthenticated CLI.
+      sentry_cli_usable = begin
+        test("sentry-cli info")
+      rescue Errno::ENOENT
+        false
+      end
+
+      unless sentry_cli_usable
         warn <<~WARNING
           ********************************************************************
           WARNING: sentry-cli is not installed or not authenticated.

--- a/lib/capistrano/tasks/sentry.rake
+++ b/lib/capistrano/tasks/sentry.rake
@@ -5,26 +5,31 @@
 # issues can be tied to the deploy that introduced them.
 #
 # Runs locally on the deployer's machine (not the servers) because that's
-# where sentry-cli and the full git history live. Org/project defaults come
-# from the committed .sentryclirc; the auth token comes from each deployer's
-# ~/.sentryclirc — see README "Sentry release tracking".
+# where the Sentry CLI and the full git history live. Org/project defaults
+# come from the committed .sentryclirc; the auth token comes from each
+# deployer's ~/.sentryclirc — see README "Sentry release tracking".
 namespace :sentry do
   desc "Record the release and deploy in Sentry"
   task :release do
     run_locally do
+      # CLI v4 renamed the binary from sentry-cli to sentry, so support both,
+      # preferring v4 (https://cli.sentry.dev/migrating-from-v3/). A candidate
+      # only counts if it exists AND is authenticated.
+      #
       # SSHKit's local backend execs commands directly rather than through a
       # shell, so a missing binary raises Errno::ENOENT instead of making
       # `test` return false. Treat it the same as an unauthenticated CLI.
-      sentry_cli_usable = begin
-        test("sentry-cli info")
+      cli = %w[sentry sentry-cli].find do |candidate|
+        test("#{candidate} info")
       rescue Errno::ENOENT
         false
       end
 
-      unless sentry_cli_usable
+      if cli.nil?
         warn <<~WARNING
           ********************************************************************
-          WARNING: sentry-cli is not installed or not authenticated.
+          WARNING: the Sentry CLI (sentry or sentry-cli) is not installed or
+          not authenticated.
 
           This deploy was NOT recorded as a release in Sentry, so issues
           won't be linked to it. The deploy itself has still succeeded.
@@ -41,18 +46,26 @@ namespace :sentry do
       environment = fetch(:stage).to_s
 
       begin
-        execute :"sentry-cli", "releases", "new", release
         # Associating commits requires the GitHub integration to be installed in
         # Sentry. If it isn't yet, warn but still finalize and record the deploy.
-        unless test("sentry-cli releases set-commits --auto #{release}")
-          warn "WARNING: sentry-cli could not associate commits with release #{release} " \
-               "(is the GitHub integration installed in Sentry?). Continuing without commit data."
+        commit_warning = "WARNING: #{cli} could not associate commits with release #{release} " \
+                         "(is the GitHub integration installed in Sentry?). Continuing without commit data."
+        if cli == "sentry"
+          # v4 renamed command groups to singular and made the deploy
+          # environment a positional argument.
+          execute :sentry, "release", "new", release
+          warn commit_warning unless test("sentry release set-commits --auto #{release}")
+          execute :sentry, "release", "finalize", release
+          execute :sentry, "release", "deploy", release, environment
+        else
+          execute :"sentry-cli", "releases", "new", release
+          warn commit_warning unless test("sentry-cli releases set-commits --auto #{release}")
+          execute :"sentry-cli", "releases", "finalize", release
+          execute :"sentry-cli", "deploys", "new", "--release", release, "-e", environment
         end
-        execute :"sentry-cli", "releases", "finalize", release
-        execute :"sentry-cli", "deploys", "new", "--release", release, "-e", environment
       rescue StandardError => e
         # Recording the release in Sentry is best-effort; the deploy itself
-        # has already succeeded, so don't let a sentry-cli failure fail it.
+        # has already succeeded, so don't let a Sentry CLI failure fail it.
         warn "WARNING: recording release #{release} in Sentry failed (#{e.message}). " \
              "The deploy itself has still succeeded."
       end


### PR DESCRIPTION
## Description

Two changes to the `sentry:release` Capistrano hook in `lib/capistrano/tasks/sentry.rake`:

1. Rescue `Errno::ENOENT` around the CLI detection so a missing binary is treated the same as an unauthenticated one: print the existing warning, skip recording the release, and let the deploy finish successfully.
2. Support both Sentry CLI v4 (binary `sentry`) and v3 (binary `sentry-cli`), preferring v4. v4 is a ground-up rewrite ([migration guide](https://cli.sentry.dev/migrating-from-v3/)) that renames the binary, makes command groups singular (`releases` -> `release`), and replaces `deploys new --release X -e env` with positional arguments (`release deploy <version> <environment>`). The hook now detects which CLI is installed and authenticated and issues the matching command shapes.

The README "Sentry release tracking" setup instructions now recommend v4 while documenting that v3 keeps working.

## Motivation and Context

Fixes #2181.

Today's production deploy aborted with `DEPLOY FAILED` at the very last step:

```
cap aborted!
Errno::ENOENT: No such file or directory - sentry-cli (Errno::ENOENT)
lib/capistrano/tasks/sentry.rake:15
```

The guard assumed `test` returns false when the command fails. Over SSH that holds, but this task uses `run_locally`, and SSHKit's local backend execs the command directly rather than through a shell, so a missing binary raises `Errno::ENOENT` instead of returning a non-zero exit. The warn-and-skip path the task was written for never ran, and the deploy reported failure even though it had already completed.

The v4 rename is also a likely cause of the binary being missing in the first place: a deployer who installs the current CLI gets `sentry`, not `sentry-cli`, so without v4 support the hook would silently skip recording releases forever.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system

Verified the failure mode and the detection logic directly against SSHKit's local backend:

- missing binary raises `Errno::ENOENT` from `test` (reproduces the crash)
- neither CLI installed -> detection returns nil (warn and skip)
- v4 installed -> picked ahead of v3
- v3 only and unauthenticated -> nil (warn and skip)
- v3 only and working -> picked

- [x] Ran automated tests on my own system

`bundle exec rubocop lib/capistrano/tasks/sentry.rake` (no offenses) and `bundle exec srb tc` (no errors). There are no specs covering Capistrano tasks.

- [ ] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

N/A

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---

AI assistance disclosure: this change was made with the help of OpenCode running anthropic.claude-fable-5, as noted in the commit trailers.