### PR TITLE
Show a fallback when Google Maps fails to load

### DIFF
--- a/app/components/map_component.html.erb
+++ b/app/components/map_component.html.erb
@@ -1,4 +1,8 @@
 <%= tag.div class: "bg-google-maps-green w-full h-full",
-            "x-init" => "initialiseBasicMapWithMarker($el, #{{ lat: @lat, lng: @lng, address: @address, zoom: @zoom }.to_json})" do %>
+            "x-data" => "{ mapFailed: false }",
+            "x-init" => "initialiseBasicMapWithMarker($el, #{{ lat: @lat, lng: @lng, address: @address, zoom: @zoom }.to_json}).catch(() => mapFailed = true)" do %>
+  <div x-show="mapFailed" x-cloak class="flex h-full w-full items-center justify-center p-8 text-center text-xl text-navy">
+    <p>We couldn't load the map. <%= helpers.pa_link_to "View this location on Google Maps", google_maps_url %></p>
+  </div>
   <noscript><%= content %></noscript>
 <% end %>

--- a/app/components/map_component.rb
+++ b/app/components/map_component.rb
@@ -12,4 +12,11 @@ class MapComponent < ViewComponent::Base
     @address = address
     @zoom = zoom
   end
+
+  # Used as a fallback when the map javascript can't be loaded, for example
+  # because a content blocker is blocking maps.googleapis.com
+  sig { returns(String) }
+  def google_maps_url
+    "https://www.google.com/maps/search/?api=1&query=#{CGI.escape("#{@lat},#{@lng}")}"
+  end
 end

--- a/app/components/map_with_radius_component.html.erb
+++ b/app/components/map_with_radius_component.html.erb
@@ -1,5 +1,8 @@
 <%= tag.div class: "h-full w-full bg-google-maps-green",
-            "x-data" => "{ circle: null }",
-            "x-init" => "circle = await initialiseAlertMap($el, { lat: #{j(@lat)}, lng: #{j(@lng)}, address: '#{j(@address)}', zoom: #{j(@zoom)}, radius_meters: #{j(@radius_meters)}}); $watch('#{j(@radius_meters)}', value => circle.setRadius(value))" do %>
+            "x-data" => "{ circle: null, mapFailed: false }",
+            "x-init" => "circle = await initialiseAlertMap($el, { lat: #{j(@lat)}, lng: #{j(@lng)}, address: '#{j(@address)}', zoom: #{j(@zoom)}, radius_meters: #{j(@radius_meters)}}).catch(() => { mapFailed = true; return null }); $watch('#{j(@radius_meters)}', value => circle && circle.setRadius(value))" do %>
+  <div x-show="mapFailed" x-cloak class="flex h-full w-full items-center justify-center p-8 text-center text-xl text-navy">
+    <p>We couldn't load the map. <%= helpers.pa_link_to "View this location on Google Maps", google_maps_url %></p>
+  </div>
   <noscript><%= content %></noscript>
 <% end %>

--- a/app/components/map_with_radius_component.rb
+++ b/app/components/map_with_radius_component.rb
@@ -14,4 +14,11 @@ class MapWithRadiusComponent < ViewComponent::Base
     @radius_meters = radius_meters
     @zoom = zoom
   end
+
+  # Used as a fallback when the map javascript can't be loaded, for example
+  # because a content blocker is blocking maps.googleapis.com
+  sig { returns(String) }
+  def google_maps_url
+    "https://www.google.com/maps/search/?api=1&query=#{CGI.escape("#{@lat},#{@lng}")}"
+  end
 end

--- a/app/components/streetview_component.html.erb
+++ b/app/components/streetview_component.html.erb
@@ -1,6 +1,10 @@
 <%# To use this component create a parent div with the required height and width otherwise
 nothing will be shown %>
 <%= tag.div class: "w-full h-full",
-            "x-init" => "initialisePano($el, #{{ lat: @lat, lng: @lng, address: @address }.to_json})" do %>
+            "x-data" => "{ mapFailed: false }",
+            "x-init" => "initialisePano($el, #{{ lat: @lat, lng: @lng, address: @address }.to_json}).catch(() => mapFailed = true)" do %>
+  <div x-show="mapFailed" x-cloak class="flex h-full w-full items-center justify-center bg-light-grey p-8 text-center text-xl text-navy">
+    <p>We couldn't load the streetview. <%= helpers.pa_link_to "View the streetview on Google Maps", google_maps_url %></p>
+  </div>
   <noscript><%= content %></noscript>
 <% end %>

--- a/app/components/streetview_component.rb
+++ b/app/components/streetview_component.rb
@@ -12,4 +12,11 @@ class StreetviewComponent < ViewComponent::Base
     @lng = lng
     @address = address
   end
+
+  # Used as a fallback when the streetview javascript can't be loaded, for
+  # example because a content blocker is blocking maps.googleapis.com
+  sig { returns(String) }
+  def google_maps_url
+    "https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=#{CGI.escape("#{@lat},#{@lng}")}"
+  end
 end

--- a/app/lib/form_builders/tailwind.rb
+++ b/app/lib/form_builders/tailwind.rb
@@ -81,8 +81,13 @@ module FormBuilders
       options = {
         placeholder: "e.g. 1 Sowerby St, Goulburn, NSW 2580",
         "x-data" => "{ async initAutocomplete() {
-                         const { Autocomplete } = await google.maps.importLibrary('places');
-                         new Autocomplete($el, {componentRestrictions: {country: 'au'}, types: ['address']})}
+                         try {
+                           const { Autocomplete } = await google.maps.importLibrary('places');
+                           new Autocomplete($el, {componentRestrictions: {country: 'au'}, types: ['address']})
+                         } catch {
+                           // If autocomplete can't load (e.g. a content blocker is
+                           // blocking maps.googleapis.com) the plain text field still works
+                         }}
                      }",
         "x-init" => "initAutocomplete()"
       }.merge(options)

--- a/app/views/applications/_address_search_form.html.erb
+++ b/app/views/applications/_address_search_form.html.erb
@@ -32,8 +32,13 @@
                             required: "required",
                             autofocus:,
                             "x-data" => "{ async initAutocomplete() {
-                                            const { Autocomplete } = await google.maps.importLibrary('places');
-                                            new Autocomplete($el, {componentRestrictions: {country: 'au'}, types: ['address']})}
+                                            try {
+                                              const { Autocomplete } = await google.maps.importLibrary('places');
+                                              new Autocomplete($el, {componentRestrictions: {country: 'au'}, types: ['address']})
+                                            } catch {
+                                              // If autocomplete can't load (e.g. a content blocker is
+                                              // blocking maps.googleapis.com) the plain text field still works
+                                            }}
                                         }",
                             "x-init" => "initAutocomplete()",
                             "x-model.fill" => "address" %>

--- a/app/views/authorities/show.html.erb
+++ b/app/views/authorities/show.html.erb
@@ -11,7 +11,7 @@
   <%# TODO: #2164 Probably want to precompute the bounding box when the boundary data is loaded instead %>
   <div class="w-full my-8 h-80 bg-google-maps-green"
        x-init="initialiseAuthorityMap($el, <%= bb = RGeo::Cartesian::BoundingBox.create_from_geometry(@authority.boundary)
-                                               { json: boundary_authority_url(format: :json), sw: { lng: bb.min_x, lat: bb.min_y }, ne: { lng: bb.max_x, lat: bb.max_y } }.to_json %>)">
+                                               { json: boundary_authority_url(format: :json), sw: { lng: bb.min_x, lat: bb.min_y }, ne: { lng: bb.max_x, lat: bb.max_y } }.to_json %>).catch(() => {})">
   </div>
 <% end %>
 

--- a/app/views/geocode_queries/show.html.erb
+++ b/app/views/geocode_queries/show.html.erb
@@ -28,5 +28,5 @@
           lng: @geocode_query.result("mappify").lng,
           html: render("geocode_results/result", result: @geocode_query.result("mappify"))
         }
-      }, "x-init" => "initialiseGeocodingMap($el)" %>
+      }, "x-init" => "initialiseGeocodingMap($el).catch(() => {})" %>
 </div>

--- a/spec/components/map_component_spec.rb
+++ b/spec/components/map_component_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails_helper"
+
+RSpec.describe MapComponent, type: :component do
+  before do
+    render_inline(described_class.new(lat: -33.916812, lng: 151.027302, address: "24 Bruce Road Glenbrook, NSW 2773", zoom: 16))
+  end
+
+  it "explains when the map can't be loaded" do
+    expect(page).to have_text("We couldn't load the map")
+  end
+
+  it "includes a fallback link to the location on Google Maps" do
+    expect(page).to have_link("View this location on Google Maps", href: "https://www.google.com/maps/search/?api=1&query=-33.916812%2C151.027302")
+  end
+
+  it "keeps the fallback hidden unless the map fails to load" do
+    expect(page).to have_css("[x-cloak][x-show='mapFailed']")
+  end
+end

--- a/spec/components/map_with_radius_component_spec.rb
+++ b/spec/components/map_with_radius_component_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails_helper"
+
+RSpec.describe MapWithRadiusComponent, type: :component do
+  before do
+    render_inline(described_class.new(lat: -33.916812, lng: 151.027302, address: "24 Bruce Road Glenbrook, NSW 2773", radius_meters: "radius_meters", zoom: 12))
+  end
+
+  it "explains when the map can't be loaded" do
+    expect(page).to have_text("We couldn't load the map")
+  end
+
+  it "includes a fallback link to the location on Google Maps" do
+    expect(page).to have_link("View this location on Google Maps", href: "https://www.google.com/maps/search/?api=1&query=-33.916812%2C151.027302")
+  end
+
+  it "keeps the fallback hidden unless the map fails to load" do
+    expect(page).to have_css("[x-cloak][x-show='mapFailed']")
+  end
+
+  it "only updates the circle radius when the map has loaded" do
+    expect(page).to have_css("div[x-init*='circle && circle.setRadius(value)']")
+  end
+end

--- a/spec/components/streetview_component_spec.rb
+++ b/spec/components/streetview_component_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails_helper"
+
+RSpec.describe StreetviewComponent, type: :component do
+  before do
+    render_inline(described_class.new(lat: -33.916812, lng: 151.027302, address: "24 Bruce Road Glenbrook, NSW 2773"))
+  end
+
+  it "explains when the streetview can't be loaded" do
+    expect(page).to have_text("We couldn't load the streetview")
+  end
+
+  it "includes a fallback link to the streetview on Google Maps" do
+    expect(page).to have_link("View the streetview on Google Maps", href: "https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=-33.916812%2C151.027302")
+  end
+
+  it "keeps the fallback hidden unless the streetview fails to load" do
+    expect(page).to have_css("[x-cloak][x-show='mapFailed']")
+  end
+end


### PR DESCRIPTION
## Description

Sentry browser monitoring (added in #2049) showed the Google Maps javascript failing to load for some people, mostly on Mobile Safari, which is consistent with content blockers, Lockdown Mode or flaky connections cutting off `maps.googleapis.com`. When that happened the person got an unexplained blank space where the map should have been, and the unhandled promise rejection was reported to Sentry.

This catches the failure everywhere a map is initialised:

- The map and streetview on the application page and the map on the alert edit page now explain that the map couldn't be loaded and link to the location on Google Maps instead (a plain link, so it works even when the javascript API is blocked).
- The alert radius watcher only updates the circle when the map actually loaded, so it can't raise a follow-on `TypeError` (likely the source of [PLANNING-ALERTS-N](https://oaf-org-au.sentry.io/issues/PLANNING-ALERTS-N), [PLANNING-ALERTS-G](https://oaf-org-au.sentry.io/issues/PLANNING-ALERTS-G) and [PLANNING-ALERTS-E](https://oaf-org-au.sentry.io/issues/PLANNING-ALERTS-E)).
- The address autocomplete, the authority map and the admin geocoding map catch the failure quietly. The address field still works as a plain text field without autocomplete.

Part of #2185. The remaining step, once this is deployed, is archiving the Sentry issues ([PLANNING-ALERTS-8](https://oaf-org-au.sentry.io/issues/PLANNING-ALERTS-8), [PLANNING-ALERTS-7](https://oaf-org-au.sentry.io/issues/PLANNING-ALERTS-7), [PLANNING-ALERTS-A](https://oaf-org-au.sentry.io/issues/PLANNING-ALERTS-A), [PLANNING-ALERTS-C](https://oaf-org-au.sentry.io/issues/PLANNING-ALERTS-C)) so they stop competing for attention.

## Motivation and Context

Fixes the first half of #2185: the page should not leave an unexplained blank space where the map was going to be.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

Written test-first: new component specs for `MapComponent`, `StreetviewComponent` and `MapWithRadiusComponent` cover the fallback message, the Google Maps link and the fallback staying hidden until the map fails.

Verified manually by running the app locally and loading an application page in a browser with `maps.googleapis.com` blocked (simulating a content blocker): both the map and streetview slots showed the fallback message and link. Screenshot to be attached below.

All three CI gates pass locally: `bin/rake` (651 examples, 0 failures), `bin/rake ci:type`, `bin/rake ci:lint`.

## Screenshots (if appropriate):
<img width="1280" height="3383" alt="application-page-fallback-full" src="https://github.com/user-attachments/assets/b7f20607-332c-4775-ae76-e92bd4a83ebc" />

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

This change was made with AI assistance (OpenCode, model `anthropic.claude-fable-5`).
