### PR TITLE
Guard copy and share buttons for missing clipboard API

### DIFF
--- a/app/components/click_to_copy_component.html.erb
+++ b/app/components/click_to_copy_component.html.erb
@@ -1,15 +1,27 @@
-<div class="flex items-baseline" x-data="{ copied: false }">
+<div class="flex items-baseline" x-data="{ copied: false, failed: false }">
   <div class="px-8 py-2 text-xl select-all text-navy bg-light-grey" x-ref="value"><%= content %></div>
   <%# We only want the button to appear once javascript (and alpine) are going %>
   <%# Using invisible here so that we avoid content reflow when javascript is running %>
+  <%# The clipboard API is unavailable in some contexts (e.g. non-secure ones). %>
+  <%# Keep the button hidden there because it could never work. The value above %>
+  <%# is still selectable so people can copy it by hand. See #2186. %>
   <button class="flex items-baseline invisible gap-2 px-4 py-2 text-xl font-semibold text-white w-28 bg-warm-grey"
-          x-on:click="
-            navigator.clipboard.writeText($refs.value.innerText);
-            copied = true;
-            setTimeout(() => { copied = false }, 750)"
-          x-bind:disabled="copied"
-          x-bind:class="{ 'invisible': false }">
-    <%= image_tag "copy-to-clipboard.svg", "x-show": "!copied" %>
-    <div x-text="copied ? 'Copied' : 'Copy' ">Copy</div>
+          x-on:click="if (navigator.clipboard) {
+            try {
+              await navigator.clipboard.writeText($refs.value.innerText);
+              copied = true;
+              setTimeout(() => { copied = false }, 750);
+            } catch {
+              failed = true;
+              setTimeout(() => { failed = false }, 2000);
+            }
+          } else {
+            failed = true;
+            setTimeout(() => { failed = false }, 2000);
+          }"
+          x-bind:disabled="copied || failed"
+          x-bind:class="{ 'invisible': !navigator.clipboard }">
+    <%= image_tag "copy-to-clipboard.svg", "x-show": "!copied && !failed" %>
+    <div x-text="copied ? 'Copied' : (failed ? 'Failed' : 'Copy')">Copy</div>
   </button>
 </div>

--- a/app/components/share_button_component.html.erb
+++ b/app/components/share_button_component.html.erb
@@ -1,11 +1,14 @@
 <%# TODO: #2158 This button needs a hover and active state %>
 <%# This is the only place that this button style is used. So, we'll just hardcode it for the time being  %>
 <%# TODO: #2158 Alignment of text and icons is not consistent when clicking button %>
+<%# Stay hidden where the button could never work: it needs the Web Share API %>
+<%# or the clipboard API, and some contexts (e.g. non-secure ones) have neither. See #2186. %>
 <div
   class="invisible"
-  x-bind:class="{'invisible': false}"
+  x-bind:class="{'invisible': !(navigator.canShare || navigator.clipboard)}"
   x-data="{
     copied: false,
+    failed: false,
     shareData: {url: '<%= j(url_with_tracking) %>', title: '<%= j(@title) %>'}
   }">
   <button class="inline-block px-10 py-3 text-xl font-semibold border-2 sm:py-4"
@@ -20,19 +23,25 @@
               console.log('Web share error', err);
             }
           } else {
-            navigator.clipboard.writeText('<%= url_with_tracking %>');
-            copied = true;
-            setTimeout(() => { copied = false }, 2000);
+            try {
+              await navigator.clipboard.writeText(shareData.url);
+              copied = true;
+              setTimeout(() => { copied = false }, 2000);
+            } catch {
+              failed = true;
+              setTimeout(() => { failed = false }, 2000);
+            }
           }">
     <%# Giving this a constant height to avoid any content shifts when button is clicked %>
     <div class="flex items-baseline justify-center h-8 gap-4">
       <div>
-        <div x-show="!copied" class="size-5"><%= render IconComponent.new(name: :share) %></div>
+        <div x-show="!copied && !failed" class="size-5"><%= render IconComponent.new(name: :share) %></div>
         <div x-show="copied" class="size-5"><%= render IconComponent.new(name: :tick) %></div>
       </div>
       <div>
-        <div x-show="!copied"><%= content %></div>
+        <div x-show="!copied && !failed"><%= content %></div>
         <div x-show="copied">Link copied</div>
+        <div x-show="failed">Couldn't copy link</div>
       </div>
     </div>
   </button>

--- a/spec/features/copy_and_share_buttons_spec.rb
+++ b/spec/features/copy_and_share_buttons_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Copy and share buttons" do
+  # Note that headless Firefox (the javascript driver) has no Web Share API,
+  # so the share button specs exercise the clipboard fallback branch, which is
+  # the same branch people hit in the wild when navigator.share is unavailable.
+  let(:application) { create(:geocoded_application, council_reference: "005") }
+
+  describe "copy button on the external link page" do
+    before do
+      visit external_application_path(application)
+    end
+
+    it "copies the reference and confirms it", :js do
+      click_on "Copy"
+
+      expect(page).to have_content("Copied")
+    end
+
+    it "tells the person when copying fails", :js do
+      page.execute_script(<<~JS)
+        Object.defineProperty(navigator, "clipboard", {
+          value: { writeText: () => Promise.reject(new Error("denied")) }
+        });
+      JS
+      click_on "Copy"
+
+      expect(page).to have_content("Failed")
+    end
+
+    it "tells the person rather than throwing when the clipboard API is unavailable", :js do
+      page.execute_script('Object.defineProperty(navigator, "clipboard", { value: undefined });')
+      click_on "Copy"
+
+      expect(page).to have_content("Failed")
+    end
+  end
+
+  describe "share button on the application page" do
+    before do
+      visit application_path(application)
+    end
+
+    it "copies the link and confirms it", :js do
+      click_on "Share this application"
+
+      expect(page).to have_content("Link copied")
+    end
+
+    it "tells the person when copying the link fails", :js do
+      page.execute_script(<<~JS)
+        Object.defineProperty(navigator, "clipboard", {
+          value: { writeText: () => Promise.reject(new Error("denied")) }
+        });
+      JS
+      click_on "Share this application"
+
+      expect(page).to have_content("Couldn't copy link")
+    end
+
+    it "tells the person rather than throwing when the clipboard API is unavailable", :js do
+      page.execute_script('Object.defineProperty(navigator, "clipboard", { value: undefined });')
+      click_on "Share this application"
+
+      expect(page).to have_content("Couldn't copy link")
+    end
+  end
+end


### PR DESCRIPTION
## Description

Two Alpine.js click handlers called `navigator.clipboard.writeText` without checking that `navigator.clipboard` exists:

- `app/components/share_button_component.html.erb` (the clipboard fallback branch, used when the Web Share API is unavailable)
- `app/components/click_to_copy_component.html.erb`

Where the async clipboard API is undefined (non-secure contexts, some in-app browsers, older Firefox) the call threw a `TypeError` before `copied = true` ran, so the button gave no feedback at all and looked dead.

This change:

- Keeps both buttons hidden where they could never work. They already render `invisible` and are only revealed once Alpine boots, so the reveal binding now also checks for the needed APIs (`navigator.clipboard`, or for the share button `navigator.canShare || navigator.clipboard`). The click-to-copy value remains `select-all` so people can still copy it by hand.
- Awaits the `writeText` promise inside `try/catch`. A rejected or throwing write now shows a brief failure state ("Failed" / "Couldn't copy link") instead of falsely confirming the copy.
- Uses `shareData.url` for the clipboard write in the share button rather than duplicating the raw (unescaped) URL interpolation.

One subtlety worth knowing for review: Alpine only wraps an inline handler as statements (in an async IIFE) when the expression starts with `if (`, so both handlers are structured that way. A handler starting with `try {` compiles to invalid JavaScript and fails silently.

## Motivation and Context

Fixes #2186
Fixes [PLANNING-ALERTS-H](https://oaf-org-au.sentry.io/issues/PLANNING-ALERTS-H) (2 events, 1 person, Firefox, on an application's external link page)

The people most likely to need the share button's clipboard fallback (no Web Share API) were exactly the ones hitting the crash.

## How Has This Been Tested?

Written test-first: the new feature spec was added and confirmed failing (4 of 6 examples) before the components were touched.

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

New feature spec `spec/features/copy_and_share_buttons_spec.rb` (headless Firefox, which has no Web Share API, so the share button specs exercise the same clipboard fallback branch people hit in the wild) covers, for each button:

- happy path: click copies and confirms ("Copied" / "Link copied")
- `writeText` rejects: failure state shown
- `navigator.clipboard` undefined at click time: failure state shown, no `TypeError`

All three CI gates pass locally via Docker Compose: `bin/rake` (647 examples, 0 failures), `bin/rake ci:type`, `bin/rake ci:lint`.

## Screenshots (if appropriate):

Captured from the feature spec run (headless Firefox). The states of each button:

| Normal | Copied | Failed |
|---|---|---|
| Copy button | "Copied" | "Failed" |
| Share this application | tick + "Link copied" | "Couldn't copy link" |

(Screenshot files attached in a comment below, as they can't be uploaded via `gh` directly.)

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

This pull request was prepared with AI assistance (OpenCode, model `anthropic.claude-fable-5`).
