### PR TITLE
Add fallback for authority map load failure

### DIFF
--- a/app/components/authority_map_component.html.erb
+++ b/app/components/authority_map_component.html.erb
@@ -1,0 +1,7 @@
+<%= tag.div class: "w-full my-8 h-80 bg-google-maps-green",
+            "x-data" => "{ mapFailed: false }",
+            "x-init" => "initialiseAuthorityMap($el, #{map_params_json}).catch(() => mapFailed = true)" do %>
+  <div x-show="mapFailed" x-cloak class="flex h-full w-full items-center justify-center p-8 text-center text-xl text-navy">
+    <p>We couldn't load the map. <%= helpers.pa_link_to "View this area on Google Maps", google_maps_url %></p>
+  </div>
+<% end %>

--- a/app/components/authority_map_component.rb
+++ b/app/components/authority_map_component.rb
@@ -1,0 +1,32 @@
+# typed: strict
+# frozen_string_literal: true
+
+class AuthorityMapComponent < ViewComponent::Base
+  extend T::Sig
+
+  sig { params(authority: Authority).void }
+  def initialize(authority:)
+    super()
+    @authority = authority
+  end
+
+  # Used as a fallback when the map javascript can't be loaded, for example
+  # because a content blocker is blocking maps.googleapis.com. An authority is
+  # a boundary rather than a point, so search Google Maps by name instead of
+  # linking to a lat/lng.
+  sig { returns(String) }
+  def google_maps_url
+    "https://www.google.com/maps/search/?api=1&query=#{CGI.escape(@authority.full_name)}"
+  end
+
+  # TODO: #2164 Probably want to precompute the bounding box when the boundary data is loaded instead
+  sig { returns(String) }
+  def map_params_json
+    bb = RGeo::Cartesian::BoundingBox.create_from_geometry(@authority.boundary)
+    {
+      json: helpers.boundary_authority_url(@authority.short_name_encoded, format: :json),
+      sw: { lng: bb.min_x, lat: bb.min_y },
+      ne: { lng: bb.max_x, lat: bb.max_y }
+    }.to_json
+  end
+end

--- a/app/components/authority_map_component.rb
+++ b/app/components/authority_map_component.rb
@@ -22,11 +22,11 @@ class AuthorityMapComponent < ViewComponent::Base
   # TODO: #2164 Probably want to precompute the bounding box when the boundary data is loaded instead
   sig { returns(String) }
   def map_params_json
-    bb = RGeo::Cartesian::BoundingBox.create_from_geometry(@authority.boundary)
+    bounding_box = RGeo::Cartesian::BoundingBox.create_from_geometry(@authority.boundary)
     {
       json: helpers.boundary_authority_url(@authority.short_name_encoded, format: :json),
-      sw: { lng: bb.min_x, lat: bb.min_y },
-      ne: { lng: bb.max_x, lat: bb.max_y }
+      sw: { lng: bounding_box.min_x, lat: bounding_box.min_y },
+      ne: { lng: bounding_box.max_x, lat: bounding_box.max_y }
     }.to_json
   end
 end

--- a/app/views/authorities/show.html.erb
+++ b/app/views/authorities/show.html.erb
@@ -8,11 +8,7 @@
 
 <%# calling Authority#boundary is slow so putting it after the feature flag check %>
 <% if Flipper.enabled?(:show_authority_map, current_user) && @authority.boundary %>
-  <%# TODO: #2164 Probably want to precompute the bounding box when the boundary data is loaded instead %>
-  <div class="w-full my-8 h-80 bg-google-maps-green"
-       x-init="initialiseAuthorityMap($el, <%= bb = RGeo::Cartesian::BoundingBox.create_from_geometry(@authority.boundary)
-                                               { json: boundary_authority_url(format: :json), sw: { lng: bb.min_x, lat: bb.min_y }, ne: { lng: bb.max_x, lat: bb.max_y } }.to_json %>).catch(() => {})">
-  </div>
+  <%= render AuthorityMapComponent.new(authority: @authority) %>
 <% end %>
 
 <% if @authority.population_2021 %>

--- a/spec/components/authority_map_component_spec.rb
+++ b/spec/components/authority_map_component_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails_helper"
+
+RSpec.describe AuthorityMapComponent, type: :component do
+  before do
+    factory = RGeo::Geographic.spherical_factory(srid: 4326)
+    ring = factory.linear_ring(
+      [
+        factory.point(150.0, -34.0),
+        factory.point(151.0, -34.0),
+        factory.point(151.0, -33.0),
+        factory.point(150.0, -33.0),
+        factory.point(150.0, -34.0)
+      ]
+    )
+    boundary = factory.multi_polygon([factory.polygon(ring)])
+    authority = build(:authority, full_name: "Byron Shire Council", short_name: "Byron", boundary:)
+    render_inline(described_class.new(authority:))
+  end
+
+  it "initialises the map with the authority boundary" do
+    expect(page).to have_css("div[x-init*='initialiseAuthorityMap']")
+  end
+
+  it "explains when the map can't be loaded" do
+    expect(page).to have_text("We couldn't load the map")
+  end
+
+  it "includes a fallback link to the authority on Google Maps" do
+    expect(page).to have_link("View this area on Google Maps", href: "https://www.google.com/maps/search/?api=1&query=Byron+Shire+Council")
+  end
+
+  it "keeps the fallback hidden unless the map fails to load" do
+    expect(page).to have_css("[x-cloak][x-show='mapFailed']")
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Extracts the inline Google Maps div on the authority page into a new `AuthorityMapComponent`, following the pattern `MapComponent`, `StreetviewComponent` and `MapWithRadiusComponent` set in #2189. The map previously swallowed load failures with `.catch(() => {})`, leaving an unexplained blank green box when a content blocker or flaky connection cut off `maps.googleapis.com`. It now shows "We couldn't load the map" with a link to a Google Maps search for the authority's name - a name search rather than a lat/lng because an authority is a boundary, not a point.

Behaviour is otherwise preserved: same classes, same bounding box computation (the #2164 TODO about precomputing it is carried over), same boundary GeoJSON URL and `sw`/`ne` params. The only mechanical difference is that the component passes `short_name_encoded` to `boundary_authority_url` explicitly, since components don't inherit request params; the generated URL is identical.

Deliberately untouched: the admin geocoding comparison map (`geocode_queries/show.html.erb`) keeps its quiet catch, since the page's tabular data still renders and the audience is staff.

## Motivation and Context

Part of #2185. Real people, mostly on Mobile Safari, hit Google Maps load failures we cannot prevent (content blockers, Lockdown Mode, flaky mobile connections). The application and alert pages got fallbacks in #2189; the authority page was the remaining public page that left a silent blank space.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

New `spec/components/authority_map_component_spec.rb` (written first, TDD) covering the map initialisation, fallback text, fallback link href, and that the fallback stays hidden behind `x-cloak`/`x-show`. Full local run of `bin/rake`, `bin/rake ci:type` and `bin/rake ci:lint` via Docker Compose: 704 examples, 0 failures; Sorbet, tapioca verify, RuboCop, erblint and Brakeman all clean.

## Screenshots (if appropriate):

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

This change was made with AI assistance (OpenCode, model `anthropic.claude-fable-5`), as disclosed in the commit trailers.
