### PR TITLE
Filter Google Maps chunk noise from Sentry

### DIFF
--- a/app/views/application/_sentry.html.erb
+++ b/app/views/application/_sentry.html.erb
@@ -16,6 +16,12 @@
         // link scanners rather than by our own code. We cannot fix any of these
         // and they drown out real problems. Anything our own JavaScript causes
         // belongs in a fix, not in this list.
+        //
+        // Google Maps noise is filtered here by message, deliberately not by a
+        // denyUrls entry for maps.googleapis.com, which would also hide errors
+        // caused by our own misuse of the Maps API. Don't be tempted to add
+        // WebKit's generic "Load failed" either: it is the message for any
+        // failed fetch, including our own boundary GeoJSON requests.
         ignoreErrors: [
           // Microsoft Outlook and Office scanning links in our alert emails
           "Object Not Found Matching Id",
@@ -26,7 +32,15 @@
           // Accessibility and screen reader extensions reading their own state
           "isHighContrast",
           // iOS in-app browsers and extensions expecting their native bridge
-          "window.webkit.messageHandlers"
+          "window.webkit.messageHandlers",
+          // Chunk failures inside Google Maps' own loader ("onion", "map",
+          // "util" and friends): the main script arrived but a content blocker
+          // or flaky connection cut off an internal module. Our importLibrary
+          // calls already catch these and show people a fallback (#2185)
+          /^Could not load "\w+"\.$/,
+          // Google Maps Street View calling HTMLDialogElement.close() on
+          // browsers without <dialog> support (#2185)
+          "this.dj.close is not a function"
         ],
         denyUrls: [
           /^chrome-extension:\/\//i,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds two entries to the browser Sentry `ignoreErrors` list in `_sentry.html.erb`:

- `/^Could not load "\w+"\.$/` - chunk failures inside Google Maps' own loader ("onion", "map", "util", "streetview", "marker"): the main script arrived but a content blocker or flaky connection cut off an internal module. These reject promises created inside Google's code that we can never attach a handler to; our own `importLibrary` calls already catch their side of the failure and show people a fallback.
- `"this.dj.close is not a function"` - Google Maps Street View calling `HTMLDialogElement.close()` on browsers without `<dialog>` support (old Firefox/Safari).

The comment block now also records the policy behind two deliberate non-entries: no `denyUrls` for the Maps host (it would also hide errors caused by our own misuse of the Maps API), and no WebKit `"Load failed"` (that is the message for any failed fetch, including our own boundary GeoJSON requests). A caveat worth knowing: the `dj` identifier comes from Google's minifier and will rotate in a future Maps build, at which point this entry fails open - the errors reappear rather than being silently hidden, which is the right failure direction for a filter.

## Motivation and Context

Part of #2185. Since #2189 deployed, the loader-level failures ("The Google Maps JavaScript API could not load.") have stopped appearing in Sentry, but the chunk failures still account for the bulk of unresolved browser events (PLANNING-ALERTS-V, -C, -W, -A) despite there being no action available to us. Filtering them follows the approach agreed in #2187/#2188: only other people's code is filtered; anything our own JavaScript causes belongs in a fix. Once this deploys, the existing Sentry issues in this cluster will be archived.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

The partial only renders in production for non-crawler user agents, so this is not exercisable locally; the regex was checked against the exact messages recorded in Sentry. Full local run of `bin/rake`, `bin/rake ci:type` and `bin/rake ci:lint` via Docker Compose: 704 examples, 0 failures; all linters clean.

## Screenshots (if appropriate):

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

This change was made with AI assistance (OpenCode, model `anthropic.claude-fable-5`), as disclosed in the commit trailers.
