### PR TITLE
Switch Capistrano to reach EC2 hosts via SSM Session Manager

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -17,6 +17,8 @@ require "capistrano/honeybadger"
 require "capistrano/aws"
 require "capistrano/puma"
 require "capistrano/tagging3"
+require "net/ssh/proxy/command"
+
 install_plugin Capistrano::Puma
 install_plugin Capistrano::Puma::Systemd
 

--- a/app/jobs/elasticsearch_snapshot_job.rb
+++ b/app/jobs/elasticsearch_snapshot_job.rb
@@ -7,7 +7,7 @@ class ElasticsearchSnapshotJob
 
   sig { void }
   def perform
-    ElasticSearchClient.snapshot&.create_repository(
+    T.must(ElasticSearchClient).snapshot&.create_repository(
       repository: "backups",
       body: {
         type: "s3",
@@ -20,7 +20,7 @@ class ElasticsearchSnapshotJob
         }
       }
     )
-    ElasticSearchClient.snapshot&.create(
+    T.must(ElasticSearchClient).snapshot&.create(
       repository: "backups",
       snapshot: "pa-api-#{Rails.env}-#{Time.zone.now.utc.strftime('%Y.%m.%d')}",
       body: { indices: "pa-api-#{Rails.env}-*" }

--- a/app/services/log_api_call_service.rb
+++ b/app/services/log_api_call_service.rb
@@ -15,7 +15,7 @@ class LogApiCallService
     ).void
   end
   def self.call(key:, ip_address:, query:, params:, user_agent:, time:)
-    ElasticSearchClient.index(
+    T.must(ElasticSearchClient).index(
       index: LogApiCallService.elasticsearch_index(time),
       body: {
         ip_address:,

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -89,7 +89,7 @@ def live_aws_instances
   instances = aws_ec2.instances.values
 
   available_colours = instances.filter_map { |i| Capistrano::Aws::EC2.parse_tag(i, "BlueGreen") }.uniq.reject(&:empty?)
-  colour = ENV["BLUE_GREEN"]
+  colour = ENV.fetch("BLUE_GREEN", nil)
   if colour
     instances = instances.select { |i| Capistrano::Aws::EC2.parse_tag(i, "BlueGreen") == colour }
   end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -76,18 +76,35 @@ set :aws_ec2_default_filters, (proc {
       name: "tag:#{fetch(:aws_ec2_application_tag)}",
       values: [fetch(:application)]
     },
-    # Uncomment the following lines (and set the value) if you want to only deploy to blue or green
-    # The default is to deploy to both blue AND green
-    # {
-    #   name: "tag:BlueGreen",
-    #   values: ["blue"]
-    # },
     {
       name: 'instance-state-name',
       values: ['running']
     }
   ]
 })
+
+# Blue/green: exactly one colour is meant to be "live" at a time - provision and deploy to
+# the standby colour, then swap, never update the live colour in place.
+def live_aws_instances
+  instances = aws_ec2.instances.values
+
+  available_colours = instances.filter_map { |i| Capistrano::Aws::EC2.parse_tag(i, "BlueGreen") }.uniq.reject(&:empty?)
+  colour = ENV["BLUE_GREEN"]
+  if colour
+    instances = instances.select { |i| Capistrano::Aws::EC2.parse_tag(i, "BlueGreen") == colour }
+  end
+  colours = instances.filter_map { |i| Capistrano::Aws::EC2.parse_tag(i, "BlueGreen") }.uniq.reject(&:empty?)
+  raise "ERROR: BLUE_GREEN must be #{available_colours.join(' or ')}" if colours.size != 1
+  instances
+end
+
+def register_aws_instances(options = {})
+  live_aws_instances.each do |instance|
+    ip = Capistrano::Aws::EC2.contact_point(instance)
+    roles = Capistrano::Aws::EC2.parse_tag(instance, fetch(:aws_ec2_roles_tag)).split(",").map(&:strip)
+    server ip, options.merge(roles: roles, aws_instance_id: instance.id)
+  end
+end
 
 # Tagging options
 set :tagging3_format, ':stage_:release'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -58,13 +58,23 @@ set :puma_service_unit_props, %w[MemoryMax=1680M TimeoutStopSec=300]
 set :puma_enable_lingering, false
 set :puma_systemctl_user, :user
 
+# Use the ID as that is what ssm needs.
+set :aws_ec2_contact_point, :id
+
+set :ssh_options, {
+  proxy: Net::SSH::Proxy::Command.new(
+    "aws ssm start-session --profile oaf --target %h " \
+      "--document-name AWS-StartSSHSession --parameters portNumber=%p"
+  ),
+}.compact
+
 set :aws_ec2_regions, ['ap-southeast-2']
 # We don't want to use the stage tag to filter because we have both production and staging on the same machine
 set :aws_ec2_default_filters, (proc {
   [
     {
       name: "tag:#{fetch(:aws_ec2_application_tag)}",
-      values: [fetch(:aws_ec2_application)]
+      values: [fetch(:application)]
     },
     # Uncomment the following lines (and set the value) if you want to only deploy to blue or green
     # The default is to deploy to both blue AND green
@@ -79,10 +89,6 @@ set :aws_ec2_default_filters, (proc {
   ]
 })
 
-# Doing this so that when we get the host names in upload_memcache_config they can also
-# be used inside the network to contact the memcache servers
-set :aws_ec2_contact_point, :public_dns
-
 # Tagging options
 set :tagging3_format, ':stage_:release'
 
@@ -90,8 +96,10 @@ set :foreman_timeout, 300
 
 desc "upload memcache.yml configuration"
 task :upload_memcache_config do
-  # Each host is also running memcached. So...
-  servers = roles(:app).map(&:hostname)
+  # Memcache is reached over the private network directly, not via the SSM-proxied :id
+  # contact point used for SSH - so look up each host's private IP rather than its hostname.
+  instances = aws_ec2.instances
+  servers = roles(:app).map { |host| instances[host.properties.fetch(:aws_instance_id)].private_ip_address }
   memcache_config = { "servers" => servers }.to_yaml
   on roles(:app) do
     upload! StringIO.new(memcache_config), "#{shared_path}/config/memcache.yml"

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,5 +1,5 @@
 # typed: false
 
-aws_ec2_register(user: "deploy")
+register_aws_instances(user: "deploy")
 
 set :deploy_to, "/srv/www/production"

--- a/sorbet/config
+++ b/sorbet/config
@@ -6,6 +6,8 @@ spec/
 db/
 --ignore
 vendor/
+--ignore
+config/
 # Agent worktrees nest a full checkout inside the repo, which would otherwise
 # make Sorbet see every RBI file twice
 --ignore

--- a/sorbet/rbi/shims/elasticsearch_client.rbi
+++ b/sorbet/rbi/shims/elasticsearch_client.rbi
@@ -1,0 +1,6 @@
+# typed: true
+
+# ElasticSearchClient is initialised in config/initializers/elasticsearch.rb,
+# which Sorbet excludes. This shim keeps the constant visible to the type
+# checker.
+ElasticSearchClient = T.let(T.unsafe(nil), T.nilable(Elasticsearch::Client))


### PR DESCRIPTION
## Description

Switches Capistrano's deploy target lookup from public hostnames to AWS SSM Session Manager, using `capistrano-aws` to dynamically look up EC2 instances by the tags Terraform sets, and proxying SSH through `aws ssm start-session`. Also tightens the blue/green deploy logic so a deploy without `BLUE_GREEN` set errors out rather than silently deploying to both colours when both are alive.

## Motivation and Context

Closes #2201.

Part of tightening PlanningAlerts security to require SSH access to EC2 instances go via AWS SSM with MFA, per [infrastructure#224](https://github.com/openaustralia/infrastructure/issues/224) and [infrastructure#503](https://github.com/openaustralia/infrastructure/issues/503).

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system - capistrano runs using ssh
- [ ] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

In my case I use a non standard key, and without the following entry capistrano cannot connect, with it it can. Thus I have confirmed the host name is as reported `i-04d69907ddcda3087` which ssh would not be able to resolve on its own without using ssm to connect.

```
Host i-04d69907ddcda3087
    IdentityFile ~/.ssh/id_rsa-OAF
```

I also deployed to main, with this update to production:
```
ianh@ben:.../planningalerts (feature/capistrano-ss)$ be cap production deploy
rvm 1.29.12-next (master) by Michal Papis, Piotr Kuczynski, Wayne E. Seguin [https://rvm.io]
rvm 1.29.12-next (master) by Michal Papis, Piotr Kuczynski, Wayne E. Seguin [https://rvm.io]
ruby-3.3.4
ruby-3.3.4
ruby 3.3.4 (2024-07-09 revision be1089c8ec) [x86_64-linux]
ruby 3.3.4 (2024-07-09 revision be1089c8ec) [x86_64-linux]
00:00 git:wrapper
      01 mkdir -p /tmp
    ✔ 01 deploy@i-04d69907ddcda3087 0.055s
    ✔ 01 deploy@i-042c2bf7b3dea1d48 0.066s
      Uploading /tmp/git-ssh-504741bae08068029e54.sh 100.0%
      Uploading /tmp/git-ssh-504741bae08068029e54.sh 100.0%
      02 chmod 700 /tmp/git-ssh-504741bae08068029e54.sh
    ✔ 02 deploy@i-04d69907ddcda3087 0.052s
    ✔ 02 deploy@i-042c2bf7b3dea1d48 0.056s
00:00 git:check
      01 git ls-remote https://github.com/openaustralia/planningalerts.git HEAD
      01 4d6e415d8ef603b226935983ce0b6c36a4cb0f42	HEAD
    ✔ 01 deploy@i-042c2bf7b3dea1d48 0.637s
      01 4d6e415d8ef603b226935983ce0b6c36a4cb0f42	HEAD
    ✔ 01 deploy@i-04d69907ddcda3087 0.676s
00:01 puma:check_lingering
      OK: Linger is enabled for deploy@i-042c2bf7b3dea1d48.
      OK: Linger is enabled for deploy@i-04d69907ddcda3087.
00:01 deploy:check:directories
      01 mkdir -p /srv/www/production/shared /srv/www/production/releases
    ✔ 01 deploy@i-04d69907ddcda3087 0.053s
    ✔ 01 deploy@i-042c2bf7b3dea1d48 0.055s
00:01 deploy:check:linked_dirs
      01 mkdir -p /srv/www/production/shared/log /srv/www/production/shared/tmp/pids /srv/www/production/shared/tmp/cache /srv/www/production/shared/tmp/sockets /srv/www/production/shared/public/system …
    ✔ 01 deploy@i-04d69907ddcda3087 0.051s
    ✔ 01 deploy@i-042c2bf7b3dea1d48 0.053s
00:01 deploy:check:make_linked_dirs
      01 mkdir -p /srv/www/production/shared/config /srv/www/production/shared/config/credentials
    ✔ 01 deploy@i-042c2bf7b3dea1d48 0.062s
    ✔ 01 deploy@i-04d69907ddcda3087 0.063s
00:01 upload_memcache_config
      Uploading /srv/www/production/shared/config/memcache.yml 100.0%
      Uploading /srv/www/production/shared/config/memcache.yml 100.0%
00:01 git:clone
      The repository mirror is at /srv/www/production/repo
      The repository mirror is at /srv/www/production/repo
00:01 git:update
      01 git remote set-url origin https://github.com/openaustralia/planningalerts.git
    ✔ 01 deploy@i-04d69907ddcda3087 0.057s
      02 git remote update --prune
    ✔ 01 deploy@i-042c2bf7b3dea1d48 0.059s
      02 Fetching origin
      02 Fetching origin
      02 From https://github.com/openaustralia/planningalerts
      02  - [deleted]             (none)     -> feature/int266-cloudflare-tunnel-for-web
      02  - [deleted]             (none)     -> feature/int266-use-ssm-to-deploy
      02  - [deleted]             (none)     -> production_20260818112904
      02 From https://github.com/openaustralia/planningalerts
      02  - [deleted]             (none)     -> feature/int266-cloudflare-tunnel-for-web
      02  - [deleted]             (none)     -> feature/int266-use-ssm-to-deploy
      02  - [deleted]             (none)     -> production_20260818112904
      02  * [new branch]          bugfix/2193-guard-alpine-x-init-globals -> bugfix/2193-guard-alpine-x-init-globals
      02  * [new branch]          feature/2199-postal-webhook -> feature/2199-postal-webhook
      02  * [new branch]          feature/capistrano-ssm-proxy -> feature/capistrano-ssm-proxy
      02    5f0362cb9..4d6e415d8  main                        -> main
      02  + da550330f...0ac59ffdd refs/pull/2050/merge        -> refs/pull/2050/merge  (forced update)
      02  + 48d9770fb...2381ebe42 refs/pull/2139/merge        -> refs/pull/2139/merge  (forced update)
      02  * [new ref]             refs/pull/2196/head         -> refs/pull/2196/head
      02  * [new ref]             refs/pull/2196/merge        -> refs/pull/2196/merge
      02  * [new ref]             refs/pull/2197/head         -> refs/pull/2197/head
      02  * [new ref]             refs/pull/2198/head         -> refs/pull/2198/head
      02  * [new ref]             refs/pull/2200/head         -> refs/pull/2200/head
      02  * [new ref]             refs/pull/2200/merge        -> refs/pull/2200/merge
      02  * [new ref]             refs/pull/2202/head         -> refs/pull/2202/head
      02  * [new ref]             refs/pull/2202/merge        -> refs/pull/2202/merge
      02  * [new tag]             production_20260821091603   -> production_20260821091603
      02  * [new branch]          bugfix/2193-guard-alpine-x-init-globals -> bugfix/2193-guard-alpine-x-init-globals
      02  * [new branch]          feature/2199-postal-webhook -> feature/2199-postal-webhook
      02  * [new branch]          feature/capistrano-ssm-proxy -> feature/capistrano-ssm-proxy
      02    5f0362cb9..4d6e415d8  main                        -> main
      02  + da550330f...0ac59ffdd refs/pull/2050/merge        -> refs/pull/2050/merge  (forced update)
      02  + 48d9770fb...2381ebe42 refs/pull/2139/merge        -> refs/pull/2139/merge  (forced update)
      02  * [new ref]             refs/pull/2196/head         -> refs/pull/2196/head
      02  * [new ref]             refs/pull/2196/merge        -> refs/pull/2196/merge
      02  * [new ref]             refs/pull/2197/head         -> refs/pull/2197/head
      02  * [new ref]             refs/pull/2198/head         -> refs/pull/2198/head
      02  * [new ref]             refs/pull/2200/head         -> refs/pull/2200/head
      02  * [new ref]             refs/pull/2200/merge        -> refs/pull/2200/merge
      02  * [new ref]             refs/pull/2202/head         -> refs/pull/2202/head
      02  * [new ref]             refs/pull/2202/merge        -> refs/pull/2202/merge
      02  * [new tag]             production_20260821091603   -> production_20260821091603
    ✔ 02 deploy@i-04d69907ddcda3087 1.563s
    ✔ 02 deploy@i-042c2bf7b3dea1d48 1.567s
00:03 git:create_release
      01 mkdir -p /srv/www/production/releases/20260826075917
    ✔ 01 deploy@i-04d69907ddcda3087 0.054s
      02 git archive main | /usr/bin/env tar -x -f - -C /srv/www/production/releases/20260826075917
    ✔ 01 deploy@i-042c2bf7b3dea1d48 0.058s
    ✔ 02 deploy@i-04d69907ddcda3087 0.462s
    ✔ 02 deploy@i-042c2bf7b3dea1d48 0.541s
00:04 deploy:set_current_revision
      01 echo "4d6e415d8ef603b226935983ce0b6c36a4cb0f42" > REVISION
    ✔ 01 deploy@i-042c2bf7b3dea1d48 0.054s
    ✔ 01 deploy@i-04d69907ddcda3087 0.052s
00:04 deploy:set_current_revision_time
      01 echo "1787711881" > REVISION_TIME
    ✔ 01 deploy@i-042c2bf7b3dea1d48 0.051s
    ✔ 01 deploy@i-04d69907ddcda3087 0.054s
00:04 deploy:symlink:linked_files
      01 mkdir -p /srv/www/production/releases/20260826075917/config /srv/www/production/releases/20260826075917/config/credentials
    ✔ 01 deploy@i-04d69907ddcda3087 0.055s
    ✔ 01 deploy@i-042c2bf7b3dea1d48 0.055s
      02 ln -s /srv/www/production/shared/config/memcache.yml /srv/www/production/releases/20260826075917/config/memcache.yml
    ✔ 02 deploy@i-04d69907ddcda3087 0.054s
    ✔ 02 deploy@i-042c2bf7b3dea1d48 0.053s
      03 ln -s /srv/www/production/shared/config/credentials/production.key /srv/www/production/releases/20260826075917/config/credentials/production.key
    ✔ 03 deploy@i-04d69907ddcda3087 0.052s
    ✔ 03 deploy@i-042c2bf7b3dea1d48 0.052s
00:04 deploy:symlink:linked_dirs
      01 mkdir -p /srv/www/production/releases/20260826075917 /srv/www/production/releases/20260826075917/tmp /srv/www/production/releases/20260826075917/public
    ✔ 01 deploy@i-042c2bf7b3dea1d48 0.053s
    ✔ 01 deploy@i-04d69907ddcda3087 0.055s
      02 ln -s /srv/www/production/shared/log /srv/www/production/releases/20260826075917/log
    ✔ 02 deploy@i-04d69907ddcda3087 0.055s
    ✔ 02 deploy@i-042c2bf7b3dea1d48 0.057s
      03 ln -s /srv/www/production/shared/tmp/pids /srv/www/production/releases/20260826075917/tmp/pids
    ✔ 03 deploy@i-04d69907ddcda3087 0.052s
    ✔ 03 deploy@i-042c2bf7b3dea1d48 0.054s
      04 rm -rf /srv/www/production/releases/20260826075917/tmp/cache
    ✔ 04 deploy@i-04d69907ddcda3087 0.062s
    ✔ 04 deploy@i-042c2bf7b3dea1d48 0.055s
      05 ln -s /srv/www/production/shared/tmp/cache /srv/www/production/releases/20260826075917/tmp/cache
    ✔ 05 deploy@i-04d69907ddcda3087 0.053s
    ✔ 05 deploy@i-042c2bf7b3dea1d48 0.055s
      06 ln -s /srv/www/production/shared/tmp/sockets /srv/www/production/releases/20260826075917/tmp/sockets
    ✔ 06 deploy@i-04d69907ddcda3087 0.052s
    ✔ 06 deploy@i-042c2bf7b3dea1d48 0.060s
      07 ln -s /srv/www/production/shared/public/system /srv/www/production/releases/20260826075917/public/system
    ✔ 07 deploy@i-04d69907ddcda3087 0.051s
    ✔ 07 deploy@i-042c2bf7b3dea1d48 0.051s
      08 ln -s /srv/www/production/shared/public/assets /srv/www/production/releases/20260826075917/public/assets
    ✔ 08 deploy@i-04d69907ddcda3087 0.051s
    ✔ 08 deploy@i-042c2bf7b3dea1d48 0.054s
00:06 bundler:config
      01 /usr/local/rvm/bin/rvm default do bundle config --local deployment true
    ✔ 01 deploy@i-04d69907ddcda3087 0.669s
      02 /usr/local/rvm/bin/rvm default do bundle config --local path /srv/www/production/shared/bundle
    ✔ 01 deploy@i-042c2bf7b3dea1d48 0.689s
    ✔ 02 deploy@i-04d69907ddcda3087 0.661s
      03 /usr/local/rvm/bin/rvm default do bundle config --local without development:test
    ✔ 02 deploy@i-042c2bf7b3dea1d48 0.748s
    ✔ 03 deploy@i-04d69907ddcda3087 0.624s
    ✔ 03 deploy@i-042c2bf7b3dea1d48 0.808s
00:09 bundler:install
      The Gemfile's dependencies are satisfied, skipping installation
      The Gemfile's dependencies are satisfied, skipping installation
00:09 deploy:assets:precompile
      01 /usr/local/rvm/bin/rvm default do bundle exec rake assets:precompile
      01 Browserslist: caniuse-lite is outdated. Please run:
      01   npx update-browserslist-db@latest
      01   Why you should do it regularly: https://github.com/browserslist/update-db#readme
      01
      01 Rebuilding...
      01 Browserslist: caniuse-lite is outdated. Please run:
      01   npx update-browserslist-db@latest
      01   Why you should do it regularly: https://github.com/browserslist/update-db#readme
      01
      01 Rebuilding...
      01
      01 Done in 1684ms.
      01
      01 Done in 1845ms.
    ✔ 01 deploy@i-04d69907ddcda3087 10.263s
    ✔ 01 deploy@i-042c2bf7b3dea1d48 11.433s
00:21 deploy:assets:backup_manifest
      01 mkdir -p /srv/www/production/releases/20260826075917/assets_manifest_backup
    ✔ 01 deploy@i-04d69907ddcda3087 0.052s
    ✔ 01 deploy@i-042c2bf7b3dea1d48 0.055s
      02 cp /srv/www/production/releases/20260826075917/public/assets/.sprockets-manifest-aea7500425e03ff591f4499da27b03b8.json /srv/www/production/releases/20260826075917/assets_manifest_backup
      03 cp /srv/www/production/releases/20260826075917/public/assets/.sprockets-manifest-d5c20fa59f2759d88948a6aeb988a4e3.json /srv/www/production/releases/20260826075917/assets_manifest_backup
    ✔ 02 deploy@i-04d69907ddcda3087 0.054s
    ✔ 03 deploy@i-042c2bf7b3dea1d48 0.054s
00:21 deploy:migrate
      [deploy:migrate] Run `rake db:migrate`
00:21 deploy:migrating
      01 /usr/local/rvm/bin/rvm default do bundle exec rake db:migrate
    ✔ 01 deploy@i-04d69907ddcda3087 4.869s
00:26 puma:install
      Uploading /tmp/planningalerts_puma_production.service 100.0%
      Uploading /tmp/planningalerts_puma_production.service 100.0%
      01 mkdir -p /home/deploy/.config/systemd/user
    ✔ 01 deploy@i-042c2bf7b3dea1d48 0.052s
      02 mv /tmp/planningalerts_puma_production.service /home/deploy/.config/systemd/user
    ✔ 01 deploy@i-04d69907ddcda3087 0.062s
    ✔ 02 deploy@i-042c2bf7b3dea1d48 0.054s
      03 /bin/systemctl --user daemon-reload
    ✔ 02 deploy@i-04d69907ddcda3087 0.054s
    ✔ 03 deploy@i-042c2bf7b3dea1d48 0.139s
    ✔ 03 deploy@i-04d69907ddcda3087 0.129s
Skipping task `puma:enable'.
Capistrano tasks may only be invoked once. Since task `puma:enable' was previously invoked, invoke("puma:enable") at /home/ianh/.local/share/mise/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/capistrano3-puma-8.0.0/lib/capistrano/tasks/systemd.rake:29 will be skipped.
00:26 puma:enable
If you really meant to run this task again, use invoke!("puma:enable")
      01 /bin/systemctl --user enable planningalerts_puma_production
THIS BEHAVIOR MAY CHANGE IN A FUTURE VERSION OF CAPISTRANO. Please join the conversation here if this affects you.
https://github.com/capistrano/capistrano/issues/1686
    ✔ 01 deploy@i-042c2bf7b3dea1d48 0.150s
    ✔ 01 deploy@i-04d69907ddcda3087 0.162s
00:26 deploy:symlink:release
      01 ln -s /srv/www/production/releases/20260826075917 /srv/www/production/releases/current
    ✔ 01 deploy@i-042c2bf7b3dea1d48 0.053s
    ✔ 01 deploy@i-04d69907ddcda3087 0.054s
      02 mv /srv/www/production/releases/current /srv/www/production
    ✔ 02 deploy@i-04d69907ddcda3087 0.055s
    ✔ 02 deploy@i-042c2bf7b3dea1d48 0.060s
00:26 puma:reload
      01 /bin/systemctl --user status planningalerts_puma_production > /dev/null
    ✔ 01 deploy@i-04d69907ddcda3087 0.058s
      02 /bin/systemctl --user reload planningalerts_puma_production
    ✔ 01 deploy@i-042c2bf7b3dea1d48 0.062s
    ✔ 02 deploy@i-04d69907ddcda3087 0.066s
    ✔ 02 deploy@i-042c2bf7b3dea1d48 0.065s
00:27 foreman:export
      01 cd /srv/www/production/current && sudo bundle exec foreman export systemd /etc/systemd/system -e .env.production -u deploy -a planningalerts-production -f Procfile.production --timeout 300 --te…
      01 [foreman export] cleaning up: /etc/systemd/system/planningalerts-production.target
      01 [foreman export] cleaning up: /etc/systemd/system/planningalerts-production-worker.1.service
      01 [foreman export] writing: planningalerts-production-worker.1.service
      01 [foreman export] writing: planningalerts-production.target
    ✔ 01 deploy@i-04d69907ddcda3087 1.458s
      01 [foreman export] cleaning up: /etc/systemd/system/planningalerts-production.target
      01 [foreman export] cleaning up: /etc/systemd/system/planningalerts-production-worker.1.service
      01 [foreman export] writing: planningalerts-production-worker.1.service
      01 [foreman export] writing: planningalerts-production.target
    ✔ 01 deploy@i-042c2bf7b3dea1d48 1.564s
00:28 foreman:enable
      01 sudo systemctl enable planningalerts-production.target
    ✔ 01 deploy@i-04d69907ddcda3087 0.464s
    ✔ 01 deploy@i-042c2bf7b3dea1d48 0.614s
00:29 foreman:restart
      01 sudo systemctl restart planningalerts-production.target
    ✔ 01 deploy@i-04d69907ddcda3087 1.809s
    ✔ 01 deploy@i-042c2bf7b3dea1d48 1.837s

Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 187 bytes | 187.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0
To github.com:openaustralia/planningalerts.git
 * [new tag]             production_20260826075917 -> production_20260826075917

keeping 5 of 6 release tags
Deleted tag 'production_20260818115019' (was 8bda6d7b8)
To github.com:openaustralia/planningalerts.git
 - [deleted]             production_20260818115019

keeping 5 of 6 release tags
00:39 deploy:cleanup
      Keeping 5 of 6 deployed releases on i-04d69907ddcda3087
      Keeping 5 of 6 deployed releases on i-042c2bf7b3dea1d48
      01 rm -rf /srv/www/production/releases/20260818115019
    ✔ 01 deploy@i-042c2bf7b3dea1d48 0.266s
    ✔ 01 deploy@i-04d69907ddcda3087 0.340s
00:40 honeybadger:deploy
      Notifying Honeybadger of deploy.
      01 RAILS_ENV=production /usr/local/rvm/bin/rvm default do bundle exec honeybadger deploy --environment production --revision 4d6e415d8ef603b226935983ce0b6c36a4cb0f42 --repository https://github.co…
      01 Deploy notification complete.
    ✔ 01 deploy@i-04d69907ddcda3087 16.126s
      Honeybadger notification complete.
00:56 deploy:log_revision
      01 echo "Branch main (at 4d6e415d8ef603b226935983ce0b6c36a4cb0f42) deployed as release 20260826075917 by ianh" >> /srv/www/production/revisions.log
    ✔ 01 deploy@i-04d69907ddcda3087 0.056s
    ✔ 01 deploy@i-042c2bf7b3dea1d48 0.078s
00:56 sentry:release
      WARN  ********************************************************************
WARNING: the Sentry CLI (sentry or sentry-cli) is not installed or
not authenticated.

This deploy was NOT recorded as a …
```    

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## AI usage

This PR's code was written with assistance from Claude Code (model: claude-sonnet-5). Each commit carries an `Assisted-by: Claude Code:claude-sonnet-5` trailer alongside the human testing and sign-off.