### PR TITLE
Add /whatismyip check that remote ip is correctly identified

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ If the Sentry CLI is missing or unauthenticated the deploy still succeeds — th
 
 ### whatismyip trust-boundary check
 
-`GET /whatismyip` reports the IP Rails sees for the request, to aid checking Cloudflare/ALB proxying with a one-line curl rather than a real sign-in or a log dig. It returns the IP, or the IP plus ` FAIL` if that IP falls within Cloudflare's own published ranges, a sign the trust boundary isn't rewriting it to the real visitor IP.
+`GET /whatismyip` reports the IP Rails sees for the request, to aid checking Cloudflare/ALB proxying with a one-line curl rather than a real sign-in or a log dig. It returns the IP, or the IP plus ` FAIL` if that IP falls within Cloudflare's own published ranges, a sign the trust boundary isn't rewriting it to the real visitor IP. If Cloudflare's published ranges can't be fetched or look implausibly short, it returns the IP plus ` UNABLE TO CHECK` rather than risk reporting a false pass.
 
 Off by default; turn it on for a server with the `provide_whatismyip` Flipper feature flag.
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,16 @@ Credentials are separate from that file and must never be committed. v3 reads yo
 
 If the Sentry CLI is missing or unauthenticated the deploy still succeeds — the hook prints a warning and skips recording the release, so set it up before your next production deploy.
 
+### whatismyip trust-boundary check
+
+`GET /whatismyip` reports the IP Rails sees for the request, to aid checking Cloudflare/ALB proxying with a one-line curl rather than a real sign-in or a log dig. It returns the IP, or the IP plus ` FAIL` if that IP falls within Cloudflare's own published ranges, a sign the trust boundary isn't rewriting it to the real visitor IP.
+
+Off by default; turn it on for a server with the `provide_whatismyip` Flipper feature flag.
+
+```sh
+curl https://www.planningalerts.org.au/whatismyip
+```
+
 ## Upgrading Ruby in production
 
 Upgrading Ruby in production is an unbelievably painful process right now. I'm sorry. Let's make it simpler

--- a/app/controllers/whatismyip_controller.rb
+++ b/app/controllers/whatismyip_controller.rb
@@ -13,7 +13,14 @@ class WhatismyipController < ApplicationController
   sig { void }
   def index
     ip = request.remote_ip
-    ip += " FAIL" if cloudflare_ip?(ip)
+    cloudflare_ranges = CloudflareIpRangesService.call
+    ip += if cloudflare_ranges.nil?
+            " UNABLE TO CHECK"
+          elsif cloudflare_ip?(ip, cloudflare_ranges)
+            " FAIL"
+          else
+            ""
+          end
     render plain: ip
   end
 
@@ -24,9 +31,9 @@ class WhatismyipController < ApplicationController
     head :not_found unless Flipper.enabled?(:provide_whatismyip)
   end
 
-  sig { params(ip: String).returns(T::Boolean) }
-  def cloudflare_ip?(ip)
-    CloudflareIpRangesService.call.any? { |range| range.include?(IPAddr.new(ip)) }
+  sig { params(ip: String, cloudflare_ranges: T::Array[IPAddr]).returns(T::Boolean) }
+  def cloudflare_ip?(ip, cloudflare_ranges)
+    cloudflare_ranges.any? { |range| range.include?(IPAddr.new(ip)) }
   rescue IPAddr::Error
     false
   end

--- a/app/controllers/whatismyip_controller.rb
+++ b/app/controllers/whatismyip_controller.rb
@@ -1,0 +1,33 @@
+# typed: strict
+# frozen_string_literal: true
+
+# Diagnostic for the Cloudflare/ALB trust boundary: reports the IP Rails sees for the
+# request, to aid checking Cloudflare proxying with a one-line curl rather than a real
+# sign-in or a log dig. Off by default behind the provide_whatismyip feature flag, since an
+# open endpoint would let anyone check whether a forged CF-Connecting-IP is being trusted.
+class WhatismyipController < ApplicationController
+  extend T::Sig
+
+  before_action :check_enabled
+
+  sig { void }
+  def index
+    ip = request.remote_ip
+    ip += " FAIL" if cloudflare_ip?(ip)
+    render plain: ip
+  end
+
+  private
+
+  sig { void }
+  def check_enabled
+    head :not_found unless Flipper.enabled?(:provide_whatismyip)
+  end
+
+  sig { params(ip: String).returns(T::Boolean) }
+  def cloudflare_ip?(ip)
+    CloudflareIpRangesService.call.any? { |range| range.include?(IPAddr.new(ip)) }
+  rescue IPAddr::Error
+    false
+  end
+end

--- a/app/services/cloudflare_ip_ranges_service.rb
+++ b/app/services/cloudflare_ip_ranges_service.rb
@@ -17,23 +17,41 @@ class CloudflareIpRangesService
     T::Array[String]
   )
 
-  sig { returns(T::Array[IPAddr]) }
+  # Cloudflare currently publishes about 15 IPv4 and 7 IPv6 ranges. Treat anything short of
+  # this as a broken response (an error page, a truncated body) rather than a real shrinking
+  # of Cloudflare's network, so we don't cache and act on it for a day.
+  MIN_EXPECTED_ENTRIES_PER_RANGE = 4
+
+  # Returns nil if the ranges can't be reliably determined right now
+  sig { returns(T.nilable(T::Array[IPAddr])) }
   def self.call
     new.call
   end
 
-  sig { returns(T::Array[IPAddr]) }
+  sig { returns(T.nilable(T::Array[IPAddr])) }
   def call
-    cidrs.map { |cidr| IPAddr.new(cidr) }
+    cidrs&.map { |cidr| IPAddr.new(cidr) }
   end
 
   private
 
-  # Cached a day so this doesn't depend on cloudflare.com being reachable on every check
-  sig { returns(T::Array[String]) }
+  # Cached a day so this doesn't depend on cloudflare.com being reachable on every check.
+  # skip_nil so a failed fetch isn't cached, and gets retried on the next request instead.
+  sig { returns(T.nilable(T::Array[String])) }
   def cidrs
-    Rails.cache.fetch("cloudflare_ip_ranges_service/v1", expires_in: 1.day) do
-      RANGE_URLS.flat_map { |url| HTTParty.get(url).body.lines.map(&:strip).reject(&:empty?) }
+    Rails.cache.fetch("cloudflare_ip_ranges_service/v1", expires_in: 1.day, skip_nil: true) do
+      cidr_lists = RANGE_URLS.map { |url| fetch_cidr_list(url) }
+      cidr_lists.flatten unless cidr_lists.any?(&:nil?)
     end
+  end
+
+  # Returns nil if the response wasn't a usable CIDR list
+  sig { params(url: String).returns(T.nilable(T::Array[String])) }
+  def fetch_cidr_list(url)
+    response = HTTParty.get(url)
+    return nil unless response.code == 200
+
+    cidrs = response.body.lines.map(&:strip).reject(&:empty?)
+    cidrs if cidrs.size >= MIN_EXPECTED_ENTRIES_PER_RANGE
   end
 end

--- a/app/services/cloudflare_ip_ranges_service.rb
+++ b/app/services/cloudflare_ip_ranges_service.rb
@@ -1,0 +1,39 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "ipaddr"
+
+# Cloudflare's published edge IP ranges, used by WhatismyipController to check whether a
+# request's remote_ip has already been rewritten from a Cloudflare edge address to the real
+# visitor address.
+class CloudflareIpRangesService
+  extend T::Sig
+
+  RANGE_URLS = T.let(
+    [
+      "https://www.cloudflare.com/ips-v4",
+      "https://www.cloudflare.com/ips-v6"
+    ].freeze,
+    T::Array[String]
+  )
+
+  sig { returns(T::Array[IPAddr]) }
+  def self.call
+    new.call
+  end
+
+  sig { returns(T::Array[IPAddr]) }
+  def call
+    cidrs.map { |cidr| IPAddr.new(cidr) }
+  end
+
+  private
+
+  # Cached a day so this doesn't depend on cloudflare.com being reachable on every check
+  sig { returns(T::Array[String]) }
+  def cidrs
+    Rails.cache.fetch("cloudflare_ip_ranges_service/v1", expires_in: 1.day) do
+      RANGE_URLS.flat_map { |url| HTTParty.get(url).body.lines.map(&:strip).reject(&:empty?) }
+    end
+  end
+end

--- a/app/services/cloudflare_ip_ranges_service.rb
+++ b/app/services/cloudflare_ip_ranges_service.rb
@@ -45,7 +45,10 @@ class CloudflareIpRangesService
     end
   end
 
-  # Returns nil if the response wasn't a usable CIDR list
+  # Returns nil if the response wasn't a usable CIDR list. Network-level failures (timeouts, DNS,
+  # a dropped or reset connection, a bad TLS handshake) are rescued here too, alongside the
+  # non-200/too-short checks above, so a Cloudflare outage degrades to "can't check" rather than
+  # an unhandled 500 out of the controller. Programming errors are deliberately left unrescued.
   sig { params(url: String).returns(T.nilable(T::Array[String])) }
   def fetch_cidr_list(url)
     response = HTTParty.get(url)
@@ -53,5 +56,8 @@ class CloudflareIpRangesService
 
     cidrs = response.body.lines.map(&:strip).reject(&:empty?)
     cidrs if cidrs.size >= MIN_EXPECTED_ENTRIES_PER_RANGE
+  rescue Timeout::Error, SocketError, SystemCallError, OpenSSL::SSL::SSLError, EOFError, Net::ProtocolError,
+         Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError
+    nil
   end
 end

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -16,7 +16,8 @@ Flipper::UI.configure do |config|
       "maintenance_mode" => "Put a banner across the site and give helpful message to the user if trying to write to the database",
       "full_text_search" => "Allow searching for all applications containing the word 'tree', for example",
       "view_application_versions" => "Can view the update history of an application",
-      "request_api_keys" => "Allow a new experimental flow for requesting API keys"
+      "request_api_keys" => "Allow a new experimental flow for requesting API keys",
+      "provide_whatismyip" => "Serve /whatismyip, a trust-boundary check for Cloudflare/ALB proxying"
     }
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -238,4 +238,7 @@ Rails.application.routes.draw do
   get "/500", to: "documentation#error_500"
 
   post "/cuttlefish/event", to: "cuttlefish#event"
+
+  # See app/controllers/whatismyip_controller.rb. 404s unless the provide_whatismyip feature flag is on.
+  get "/whatismyip", to: "whatismyip#index"
 end

--- a/sorbet/rbi/dsl/generated_path_helpers_module.rbi
+++ b/sorbet/rbi/dsl/generated_path_helpers_module.rbi
@@ -446,4 +446,7 @@ module GeneratedPathHelpersModule
 
   sig { params(args: T.untyped).returns(String) }
   def users_activation_path(*args); end
+
+  sig { params(args: T.untyped).returns(String) }
+  def whatismyip_path(*args); end
 end

--- a/sorbet/rbi/dsl/generated_url_helpers_module.rbi
+++ b/sorbet/rbi/dsl/generated_url_helpers_module.rbi
@@ -446,4 +446,7 @@ module GeneratedUrlHelpersModule
 
   sig { params(args: T.untyped).returns(String) }
   def users_activation_url(*args); end
+
+  sig { params(args: T.untyped).returns(String) }
+  def whatismyip_url(*args); end
 end

--- a/spec/controllers/whatismyip_controller_spec.rb
+++ b/spec/controllers/whatismyip_controller_spec.rb
@@ -32,6 +32,18 @@ describe WhatismyipController do
         get :index
         expect(response.body).to eq "173.245.48.1 FAIL"
       end
+
+      context "when Cloudflare's ranges can't be determined right now" do
+        before do
+          allow(CloudflareIpRangesService).to receive(:call).and_return(nil)
+        end
+
+        it "appends UNABLE TO CHECK rather than risk reporting a false pass" do
+          request.remote_addr = "173.245.48.1"
+          get :index
+          expect(response.body).to eq "173.245.48.1 UNABLE TO CHECK"
+        end
+      end
     end
   end
 end

--- a/spec/controllers/whatismyip_controller_spec.rb
+++ b/spec/controllers/whatismyip_controller_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe WhatismyipController do
+  before do
+    allow(CloudflareIpRangesService).to receive(:call).and_return([IPAddr.new("173.245.48.0/20")])
+  end
+
+  describe "GET #index" do
+    context "when the provide_whatismyip feature flag is off" do
+      before { get :index }
+
+      it "is not found" do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when the provide_whatismyip feature flag is on" do
+      before do
+        Flipper.enable(:provide_whatismyip)
+      end
+
+      it "returns the remote IP alone when it is outside Cloudflare's ranges" do
+        request.remote_addr = "1.2.3.4"
+        get :index
+        expect(response.body).to eq "1.2.3.4"
+      end
+
+      it "appends FAIL when the remote IP is inside Cloudflare's ranges" do
+        request.remote_addr = "173.245.48.1"
+        get :index
+        expect(response.body).to eq "173.245.48.1 FAIL"
+      end
+    end
+  end
+end

--- a/spec/services/cloudflare_ip_ranges_service_spec.rb
+++ b/spec/services/cloudflare_ip_ranges_service_spec.rb
@@ -3,6 +3,11 @@
 require "spec_helper"
 
 describe CloudflareIpRangesService do
+  # Real Cloudflare-published ranges, so the pass/fail examples in whatismyip_controller_spec
+  # mean something. Four each, since that's the service's minimum-plausible-list size.
+  let(:ipv4_ranges) { "173.245.48.0/20\n103.21.244.0/22\n103.22.200.0/22\n103.31.4.0/22\n" }
+  let(:ipv6_ranges) { "2400:cb00::/32\n2606:4700::/32\n2803:f800::/32\n2405:b500::/32\n" }
+
   describe ".call" do
     context "when the ranges are already cached" do
       before do
@@ -16,18 +21,53 @@ describe CloudflareIpRangesService do
 
     context "when the ranges are not yet cached" do
       # config.cache_store is :null_store in test, so Rails.cache.fetch always runs its
-      # block, which is what we want to exercise here
+      # block, which is what we want to exercise below
       before do
         allow(HTTParty).to receive(:get)
           .with("https://www.cloudflare.com/ips-v4")
-          .and_return(instance_double(HTTParty::Response, body: "173.245.48.0/20\n"))
+          .and_return(instance_double(HTTParty::Response, code: 200, body: ipv4_ranges))
         allow(HTTParty).to receive(:get)
           .with("https://www.cloudflare.com/ips-v6")
-          .and_return(instance_double(HTTParty::Response, body: "2400:cb00::/32\n"))
+          .and_return(instance_double(HTTParty::Response, code: 200, body: ipv6_ranges))
       end
 
       it "fetches and parses Cloudflare's published IPv4 and IPv6 ranges" do
-        expect(described_class.call).to eq [IPAddr.new("173.245.48.0/20"), IPAddr.new("2400:cb00::/32")]
+        expect(described_class.call).to eq(
+          (ipv4_ranges.lines + ipv6_ranges.lines).map { |cidr| IPAddr.new(cidr.strip) }
+        )
+      end
+
+      it "caches the combined ranges without hitting cloudflare.com on every check" do
+        allow(Rails.cache).to receive(:fetch).and_call_original
+
+        described_class.call
+
+        expect(Rails.cache).to have_received(:fetch)
+          .with("cloudflare_ip_ranges_service/v1", expires_in: 1.day, skip_nil: true)
+      end
+
+      context "when one range comes back with a non-200 status" do
+        before do
+          allow(HTTParty).to receive(:get)
+            .with("https://www.cloudflare.com/ips-v4")
+            .and_return(instance_double(HTTParty::Response, code: 502, body: "Bad Gateway"))
+        end
+
+        it "returns nil rather than treat the error page as a range list" do
+          expect(described_class.call).to be_nil
+        end
+      end
+
+      context "when one range comes back implausibly short" do
+        before do
+          allow(HTTParty).to receive(:get)
+            .with("https://www.cloudflare.com/ips-v4")
+            .and_return(instance_double(HTTParty::Response, code: 200, body: "173.245.48.0/20\n"))
+        end
+
+        it "returns nil rather than trust a truncated list" do
+          expect(described_class.call).to be_nil
+        end
       end
     end
   end

--- a/spec/services/cloudflare_ip_ranges_service_spec.rb
+++ b/spec/services/cloudflare_ip_ranges_service_spec.rb
@@ -69,6 +69,23 @@ describe CloudflareIpRangesService do
           expect(described_class.call).to be_nil
         end
       end
+
+      context "when fetching a range fails at the network level" do
+        [
+          Net::OpenTimeout.new,
+          SocketError.new,
+          Errno::ECONNRESET.new,
+          OpenSSL::SSL::SSLError.new,
+          EOFError.new,
+          Net::HTTPBadResponse.new
+        ].each do |error|
+          it "returns nil rather than let a #{error.class} escape" do
+            allow(HTTParty).to receive(:get).with("https://www.cloudflare.com/ips-v4").and_raise(error)
+
+            expect(described_class.call).to be_nil
+          end
+        end
+      end
     end
   end
 end

--- a/spec/services/cloudflare_ip_ranges_service_spec.rb
+++ b/spec/services/cloudflare_ip_ranges_service_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe CloudflareIpRangesService do
+  describe ".call" do
+    context "when the ranges are already cached" do
+      before do
+        allow(Rails.cache).to receive(:fetch).and_return(["173.245.48.0/20", "2400:cb00::/32"])
+      end
+
+      it "returns the cached ranges as IPAddr instances" do
+        expect(described_class.call).to eq [IPAddr.new("173.245.48.0/20"), IPAddr.new("2400:cb00::/32")]
+      end
+    end
+
+    context "when the ranges are not yet cached" do
+      # config.cache_store is :null_store in test, so Rails.cache.fetch always runs its
+      # block, which is what we want to exercise here
+      before do
+        allow(HTTParty).to receive(:get)
+          .with("https://www.cloudflare.com/ips-v4")
+          .and_return(instance_double(HTTParty::Response, body: "173.245.48.0/20\n"))
+        allow(HTTParty).to receive(:get)
+          .with("https://www.cloudflare.com/ips-v6")
+          .and_return(instance_double(HTTParty::Response, body: "2400:cb00::/32\n"))
+      end
+
+      it "fetches and parses Cloudflare's published IPv4 and IPv6 ranges" do
+        expect(described_class.call).to eq [IPAddr.new("173.245.48.0/20"), IPAddr.new("2400:cb00::/32")]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Adds a `/whatismyip` diagnostic endpoint that reports the IP Rails sees for the request as plain text, appending ` FAIL` if that IP falls within Cloudflare's own published ranges. Off by default, behind the new `provide_whatismyip` Flipper feature flag, since an open endpoint would let anyone check whether a forged `CF-Connecting-IP` is being trusted.

Adapted from the equivalent endpoint in the righttoknow repo (commit 5f27e65), rewritten to fit this repo's normal Rails conventions rather than the Alaveteli-theme pattern used there: a regular `ApplicationController` subclass and route rather than a `to_prepare` block in a theme lib file, `Flipper.enabled?(:provide_whatismyip)` rather than a bespoke `PROVIDE_WHATISMYIP` config var (since this app already uses Flipper for feature flags), and `HTTParty` rather than `Net::HTTP` (the gem already used for outbound HTTP here).

## Motivation and Context

PlanningAlerts has an open proposal to move web traffic behind Cloudflare, similar to a change already made on righttoknow. When that lands, this gives a one-line curl check for whether the Cloudflare/ALB trust boundary is correctly rewriting `remote_ip` to the real visitor IP, instead of digging through app logs or sign-in records.

## How Has This Been Tested?

- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

New specs cover the controller (flag on/off, in/out of Cloudflare's ranges) and the caching service (cached and not-yet-cached paths). Full suite: 709 examples, 0 failures, 6 pending (pre-existing). RuboCop, Sorbet (`bin/rake ci:type`) and Brakeman (`bin/rake ci:lint`) all pass.

## Types of Changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---

Assisted-by: Claude Code:claude-sonnet-5