### PR TITLE
Pin Sentry gems to version 6.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -258,9 +258,15 @@ end
 
 # Error tracking, tracing and profiling with Sentry. We're running this
 # alongside Honeybadger during the transition. See issue #2049
-gem "sentry-rails"
-gem "sentry-ruby"
-gem "sentry-sidekiq"
+#
+# Pinned to the 6.x line: 7.0.0 removed `enable_logs`, which
+# config/initializers/sentry.rb sets, and changed the PII and metrics
+# defaults. Deploys install from Gemfile.lock in deployment mode so they
+# can't drift, but without a constraint the next `bundle update` takes the
+# new major.
+gem "sentry-rails", "~> 6.7"
+gem "sentry-ruby", "~> 6.7"
+gem "sentry-sidekiq", "~> 6.7"
 # Profiler used by Sentry profiling (requires Ruby 3.2+)
 gem "vernier"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -906,9 +906,9 @@ DEPENDENCIES
   sanitize
   searchkick
   selenium-webdriver (>= 4.14.0)
-  sentry-rails
-  sentry-ruby
-  sentry-sidekiq
+  sentry-rails (~> 6.7)
+  sentry-ruby (~> 6.7)
+  sentry-sidekiq (~> 6.7)
   sidekiq (~> 7.0)
   sidekiq-cron
   simplecov


### PR DESCRIPTION
## What and why

Pin Sentry gems to version 6.x to prevent breaking changes in future updates. This change ensures compatibility with existing configurations and avoids issues that may arise from major version upgrades.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation

## How this was checked

- [x] Checked the affected area on my own or a staging system
- [x] Ran the automated tests
- [x] Ran `/code-review` (or equivalent): Not required - this is a simple gemfile lock
- [ ] GitHub Actions tests: likewise fixed so they pass or linked a follow-up issue / replied why not important directly on each comment (reviewer will mark resolved as part of review)
- [x] Documentation updated, or not needed

