### PR TITLE
Verify postal webhooks against the published JWKS

### DIFF
--- a/app/controllers/postal_controller.rb
+++ b/app/controllers/postal_controller.rb
@@ -13,8 +13,9 @@ class PostalController < ApplicationController
   def event
     # Verify the signature against the raw body before trusting anything in it
     raw_post = request.raw_post
-    unless valid_signature?(raw_post)
-      head :forbidden
+    failure_status = signature_failure_status(raw_post)
+    if failure_status
+      head failure_status
       return
     end
 
@@ -88,22 +89,32 @@ class PostalController < ApplicationController
 
   private
 
-  # Postal signs each webhook request with the server's signing key. The
-  # X-Postal-Signature header contains a Base64 encoded RSA-SHA1 signature
-  # of the raw JSON request body and we hold the matching public key in the
-  # Rails credentials. See https://docs.postalserver.io/developer/webhooks
-  # The header name and digest are per the postal v3 docs and are kept in
-  # this one method so they're trivially adjustable during integration
-  # testing.
-  sig { params(raw_post: String).returns(T::Boolean) }
-  def valid_signature?(raw_post)
-    public_key_pem = T.cast(Rails.application.credentials.dig(:postal, :webhook_public_key), T.nilable(String))
-    return false if public_key_pem.nil?
+  # The X-Postal-Signature-256 header holds a Base64 encoded RSA-SHA256 signature of the raw
+  # JSON request body, made with postal's installation wide signing key. We check it against
+  # every signing key postal is currently publishing, so a rotation on the postal server needs
+  # no change here. Postal also sends X-Postal-Signature, an RSA-SHA1 signature of the same body
+  # that its own source marks as being for legacy use, and X-Postal-Signature-KID naming the
+  # key it used. We ignore both.
+  # See https://docs.postalserver.io/developer/webhooks
+  #
+  # Returns nil when the request is properly signed, otherwise the status to respond with. A
+  # signature that doesn't check out gets 403 and the event is gone for good. Not being able to
+  # reach the published keys is a different thing: we can't tell whether the request is genuine,
+  # so 503 asks postal to retry, which it does over about 36 minutes, rather than silently
+  # dropping a real delivery event.
+  sig { params(raw_post: String).returns(T.nilable(Symbol)) }
+  def signature_failure_status(raw_post)
+    signature = T.cast(request.headers["X-Postal-Signature-256"], T.nilable(String))
+    # Checked before the keys are fetched, so an unsigned request costs us no outbound request
+    return :forbidden if signature.nil?
 
-    signature = T.cast(request.headers["X-Postal-Signature"], T.nilable(String))
-    return false if signature.nil?
+    keys = PostalSigningKeysService.call
+    return :service_unavailable if keys.nil?
 
-    public_key = OpenSSL::PKey::RSA.new(public_key_pem)
-    public_key.verify(OpenSSL::Digest.new("SHA1"), Base64.decode64(signature), raw_post)
+    digest = OpenSSL::Digest.new("SHA256")
+    decoded_signature = Base64.decode64(signature)
+    return nil if keys.any? { |key| key.verify(digest, decoded_signature, raw_post) }
+
+    :forbidden
   end
 end

--- a/app/services/postal_signing_keys_service.rb
+++ b/app/services/postal_signing_keys_service.rb
@@ -23,6 +23,11 @@ class PostalSigningKeysService
   # webhook on an endpoint anyone can post to, and postal's later retries land after it expires.
   CACHE_TTL = T.let(15.minutes, ActiveSupport::Duration)
 
+  # When the cached copy expires, the first request bumps its expiry by this much and refreshes,
+  # while requests arriving during the refresh keep getting the stale copy instead of a fetch
+  # each. A refresh takes at most HTTP_TIMEOUT, so this only needs to cover that with slack.
+  RACE_CONDITION_TTL = T.let(5.seconds, ActiveSupport::Duration)
+
   sig { returns(T.nilable(T::Array[OpenSSL::PKey::RSA])) }
   def self.call
     new.call
@@ -37,7 +42,7 @@ class PostalSigningKeysService
 
   sig { returns(T.nilable(T::Array[String])) }
   def cached_pems
-    Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_TTL) { pems }
+    Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_TTL, race_condition_ttl: RACE_CONDITION_TTL) { pems }
   end
 
   # PEM strings rather than key objects, because these get cached and the production cache is

--- a/app/services/postal_signing_keys_service.rb
+++ b/app/services/postal_signing_keys_service.rb
@@ -1,0 +1,90 @@
+# typed: strict
+# frozen_string_literal: true
+
+# The public keys postal publishes for the key it signs webhooks with. Postal signs with one
+# installation wide key and publishes the matching public key as a JWK Set at a well known URL,
+# so we check signatures against whatever it publishes now rather than holding our own copy.
+# A key rotation on the postal server then needs no change here.
+# See https://docs.postalserver.io/developer/webhooks
+class PostalSigningKeysService
+  extend T::Sig
+
+  # Postal gives up on a webhook after 5 seconds, and this runs inline in that request, so a
+  # slower fetch than this is no use to us. HTTParty has no timeout at all by default.
+  HTTP_TIMEOUT = 2
+
+  # If we need to expire the cached copy for some reason then increment the version number below
+  CACHE_KEY = "postal_signing_keys_service/v1"
+
+  # Long enough that a burst of webhooks doesn't mean a fetch each, short enough that a signing
+  # key rotation on the postal server heals inside the retries postal gives up after (2, 3, 6,
+  # 10 and 15 minute backoffs, about 36 minutes in all). Deliberately no skip_nil: caching a
+  # failed fetch too is what stops an outage turning into one outbound request per inbound
+  # webhook on an endpoint anyone can post to, and postal's later retries land after it expires.
+  CACHE_TTL = T.let(15.minutes, ActiveSupport::Duration)
+
+  sig { returns(T.nilable(T::Array[OpenSSL::PKey::RSA])) }
+  def self.call
+    new.call
+  end
+
+  sig { returns(T.nilable(T::Array[OpenSSL::PKey::RSA])) }
+  def call
+    cached_pems&.map { |pem| OpenSSL::PKey::RSA.new(pem) }
+  end
+
+  private
+
+  sig { returns(T.nilable(T::Array[String])) }
+  def cached_pems
+    Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_TTL) { pems }
+  end
+
+  # PEM strings rather than key objects, because these get cached and the production cache is
+  # memcached, so whatever we store has to survive a round trip through Marshal.
+  #
+  # Returns nil if the keys can't be determined. Network level failures (timeouts, DNS, a dropped
+  # or reset connection) are rescued here alongside a malformed body, so postal's web interface
+  # being unreachable or broken degrades to "we can't check this signature" rather than an
+  # unhandled 500 out of the controller. OpenSSL::OpenSSLError covers both a failed TLS handshake
+  # and unusable key material. Programming errors are deliberately left unrescued.
+  sig { returns(T.nilable(T::Array[String])) }
+  def pems
+    response = HTTParty.get(jwks_url, timeout: HTTP_TIMEOUT)
+    return nil unless response.code == 200
+
+    parsed = JSON.parse(response.body)
+    return nil unless parsed.is_a?(Hash)
+
+    jwks = parsed["keys"]
+    return nil unless jwks.is_a?(Array)
+
+    jwks.filter_map { |jwk| signing_key_pem(jwk) }.presence
+  rescue Timeout::Error, SocketError, SystemCallError, EOFError, Net::ProtocolError, Net::HTTPBadResponse,
+         Net::HTTPHeaderSyntaxError, JSON::ParserError, JWT::DecodeError, OpenSSL::OpenSSLError
+    nil
+  end
+
+  # Postal publishes one RS256 signing key, but the format allows several and allows keys that
+  # aren't for signatures at all, so pick out only RSA keys marked for signature use. "use" is
+  # optional in RFC 7517, so a key without one is accepted, while an encryption key never is.
+  # The kty check is load bearing rather than cosmetic: JWT::JWK::HMAC::KTYS includes String,
+  # so an oct entry otherwise yields a JWK whose verify_key is a String.
+  sig { params(jwk: T.untyped).returns(T.nilable(String)) }
+  def signing_key_pem(jwk)
+    return nil unless jwk.is_a?(Hash)
+    return nil unless jwk["kty"] == "RSA"
+    return nil unless jwk["use"].nil? || jwk["use"] == "sig"
+    # A non-string modulus or exponent goes straight to Base64.urlsafe_decode64 inside the jwt
+    # gem and dies with a NoMethodError, which isn't one of its own rescuable errors
+    return nil unless jwk["n"].is_a?(String) && jwk["e"].is_a?(String)
+
+    # verify_key builds the key lazily, so force it here, inside the rescue above
+    T.cast(JWT::JWK.new(jwk).verify_key, OpenSSL::PKey::RSA).to_pem
+  end
+
+  sig { returns(String) }
+  def jwks_url
+    Rails.configuration.x.postal_jwks_url
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,6 +14,9 @@ Rails.application.configure do
   config.x.flipper_redis_url = "redis://redis:6379/2"
   config.x.split_redis_url = "redis://redis:6379/3"
 
+  # Where postal publishes the public key it signs delivery webhooks with
+  config.x.postal_jwks_url = "https://postal.oaf.org.au/.well-known/jwks.json"
+
   ## User settings (END)
 
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -14,6 +14,9 @@ Rails.application.configure do
   config.x.flipper_redis_url = Rails.application.credentials[:flipper_redis_url]
   config.x.split_redis_url = Rails.application.credentials[:split_redis_url]
 
+  # Where postal publishes the public key it signs delivery webhooks with
+  config.x.postal_jwks_url = "https://postal.oaf.org.au/.well-known/jwks.json"
+
   ## User settings (END)
 
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -18,6 +18,10 @@ Rails.application.configure do
   # TODO: #2167 Fix this
   config.x.sidekiq_redis_url = "redis://localhost:6379/0"
 
+  # A reserved domain (RFC 2606), so a spec that forgets to stub the fetch can't reach the
+  # real postal server
+  config.x.postal_jwks_url = "https://postal.example.com/.well-known/jwks.json"
+
   ## User settings (END)
 
   # Settings specified here will take precedence over those in config/application.rb.

--- a/spec/controllers/postal_controller_spec.rb
+++ b/spec/controllers/postal_controller_spec.rb
@@ -13,16 +13,16 @@ describe PostalController do
   let(:message_url) { "https://postal.oaf.org.au/org/oaf/servers/planningalerts-comments/messages/#{message_id}" }
 
   before do
-    allow(Rails.application.credentials).to receive(:dig).with(:postal, :webhook_public_key).and_return(private_key.public_key.to_pem)
+    stub_jwks(body: jwks_json(private_key.public_key))
     allow(NotifySlackCommentDeliveryService).to receive(:call)
   end
 
   def sign(body)
-    Base64.strict_encode64(private_key.sign(OpenSSL::Digest.new("SHA1"), body))
+    Base64.strict_encode64(private_key.sign(OpenSSL::Digest.new("SHA256"), body))
   end
 
   def post_event(body, signature: sign(body))
-    request.headers["X-Postal-Signature"] = signature unless signature.nil?
+    request.headers["X-Postal-Signature-256"] = signature unless signature.nil?
     post :event, body:, format: :json
   end
 
@@ -88,9 +88,20 @@ describe PostalController do
     }.to_json
   end
 
+  it "accepts a webhook signed by the key postal publishes" do
+    create(:alert, id: alert_id)
+    post_event(status_event_body(event: "MessageSent", tag: alert_tag))
+    expect(response).to have_http_status(:ok)
+  end
+
   it "rejects a request with no signature" do
     post_event(status_event_body(event: "MessageSent", tag: alert_tag), signature: nil)
     expect(response).to have_http_status(:forbidden)
+  end
+
+  it "doesn't go looking for the signing keys when there's no signature" do
+    post_event(status_event_body(event: "MessageSent", tag: alert_tag), signature: nil)
+    expect(HTTParty).not_to have_received(:get)
   end
 
   it "rejects a request with an invalid signature" do
@@ -98,9 +109,24 @@ describe PostalController do
     expect(response).to have_http_status(:forbidden)
   end
 
-  it "rejects a request when no public key is configured" do
-    allow(Rails.application.credentials).to receive(:dig).with(:postal, :webhook_public_key).and_return(nil)
+  it "accepts a webhook signed by any of the keys postal publishes" do
+    create(:alert, id: alert_id)
+    stub_jwks(body: jwks_json(OpenSSL::PKey::RSA.new(2048).public_key, private_key.public_key))
     post_event(status_event_body(event: "MessageSent", tag: alert_tag))
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "asks postal to retry when the signing keys can't be fetched" do
+    allow(HTTParty).to receive(:get).and_raise(Net::OpenTimeout)
+    post_event(status_event_body(event: "MessageSent", tag: alert_tag))
+    expect(response).to have_http_status(:service_unavailable)
+  end
+
+  it "rejects a body signed by a key postal isn't publishing" do
+    impostor_key = OpenSSL::PKey::RSA.new(2048)
+    body = status_event_body(event: "MessageSent", tag: alert_tag)
+    signature = Base64.strict_encode64(impostor_key.sign(OpenSSL::Digest.new("SHA256"), body))
+    post_event(body, signature:)
     expect(response).to have_http_status(:forbidden)
   end
 

--- a/spec/services/postal_signing_keys_service_spec.rb
+++ b/spec/services/postal_signing_keys_service_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe PostalSigningKeysService do
+  let(:signing_key) { OpenSSL::PKey::RSA.new(2048) }
+
+  def pems
+    described_class.call&.map(&:to_pem)
+  end
+
+  it "returns the key postal publishes" do
+    stub_jwks(body: jwks_json(signing_key.public_key))
+    expect(pems).to eq [signing_key.public_key.to_pem]
+  end
+
+  it "ignores a key that isn't for signatures" do
+    stub_jwks(body: { "keys" => [jwk(signing_key.public_key, use: "enc")] }.to_json)
+    expect(pems).to be_nil
+  end
+
+  it "accepts a key with no use, which the format allows" do
+    stub_jwks(body: { "keys" => [jwk(signing_key.public_key, use: nil)] }.to_json)
+    expect(pems).to eq [signing_key.public_key.to_pem]
+  end
+
+  it "ignores a key that isn't RSA" do
+    stub_jwks(body: { "keys" => [{ "kty" => "oct", "k" => "c2VjcmV0", "use" => "sig" }] }.to_json)
+    expect(pems).to be_nil
+  end
+
+  it "returns nil on a non-200" do
+    stub_jwks(body: jwks_json(signing_key.public_key), code: 502)
+    expect(pems).to be_nil
+  end
+
+  it "returns nil when the body isn't json" do
+    stub_jwks(body: "<html>Bad gateway</html>")
+    expect(pems).to be_nil
+  end
+
+  it "returns nil when the body isn't an object" do
+    stub_jwks(body: "[1, 2]")
+    expect(pems).to be_nil
+  end
+
+  it "returns nil when there's no keys member" do
+    stub_jwks(body: { "foo" => "bar" }.to_json)
+    expect(pems).to be_nil
+  end
+
+  it "returns nil when the keys member isn't a list" do
+    stub_jwks(body: { "keys" => "nope" }.to_json)
+    expect(pems).to be_nil
+  end
+
+  it "returns nil when a key's modulus is malformed" do
+    stub_jwks(body: { "keys" => [jwk(signing_key.public_key).merge("n" => "!!!!")] }.to_json)
+    expect(pems).to be_nil
+  end
+
+  it "returns nil when a key's modulus isn't a string" do
+    stub_jwks(body: { "keys" => [jwk(signing_key.public_key).merge("n" => 123)] }.to_json)
+    expect(pems).to be_nil
+  end
+
+  [Net::OpenTimeout.new, SocketError.new, Errno::ECONNRESET.new, OpenSSL::SSL::SSLError.new,
+   EOFError.new, Net::HTTPBadResponse.new].each do |error|
+    it "returns nil rather than let a #{error.class} escape" do
+      allow(HTTParty).to receive(:get).and_raise(error)
+      expect(pems).to be_nil
+    end
+  end
+
+  # Bounding these fetches is the whole point: /postal/event is unauthenticated, so without a
+  # cached copy anyone could turn each request they send into an outbound request of ours.
+  # config.cache_store is :null_store in test, so these examples need a real one.
+  describe "caching" do
+    around do |example|
+      original = Rails.cache
+      Rails.cache = ActiveSupport::Cache::MemoryStore.new
+      example.run
+      Rails.cache = original
+    end
+
+    it "fetches the published keys once however many times it's asked" do
+      stub_jwks(body: jwks_json(signing_key.public_key))
+      2.times { described_class.call }
+      expect(HTTParty).to have_received(:get).once
+    end
+
+    it "doesn't retry a failed fetch on the very next request" do
+      allow(HTTParty).to receive(:get).and_raise(Net::OpenTimeout)
+      2.times { described_class.call }
+      expect(HTTParty).to have_received(:get).once
+    end
+
+    it "fetches again once the cached copy has expired" do
+      stub_jwks(body: jwks_json(signing_key.public_key))
+      described_class.call
+      Timecop.travel(16.minutes.from_now) { described_class.call }
+      expect(HTTParty).to have_received(:get).twice
+    end
+  end
+end

--- a/spec/services/postal_signing_keys_service_spec.rb
+++ b/spec/services/postal_signing_keys_service_spec.rb
@@ -101,5 +101,22 @@ describe PostalSigningKeysService do
       Timecop.travel(16.minutes.from_now) { described_class.call }
       expect(HTTParty).to have_received(:get).twice
     end
+
+    it "serves the stale copy to a request arriving while a refresh is in flight" do
+      stub_jwks(body: jwks_json(signing_key.public_key))
+      described_class.call
+      Timecop.travel(15.minutes.from_now + 1.second) do
+        # Re-stub the fetch so that mid-refresh, like a concurrent request would, we ask again
+        pems_during_refresh = :unset
+        allow(HTTParty).to receive(:get) do
+          pems_during_refresh = pems
+          instance_double(HTTParty::Response, code: 200, body: jwks_json(signing_key.public_key))
+        end
+        described_class.call
+        expect(pems_during_refresh).to eq [signing_key.public_key.to_pem]
+      end
+      # Once to warm the cache and once for the refresh; the mid-refresh request fetched nothing
+      expect(HTTParty).to have_received(:get).twice
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,6 +93,7 @@ RSpec.configure do |config|
   config.include SessionHelpers, type: :feature
   config.include MockLocationHelpers
   config.include AutocompleteHelpers
+  config.include PostalJwksHelpers
 
   # Disable searchkick during testing so that we don't need to run
   # elasticsearch locally which is a pain

--- a/spec/support/postal_jwks_helpers.rb
+++ b/spec/support/postal_jwks_helpers.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Builds the JWK Set that Postal publishes at /.well-known/jwks.json and stubs the fetch of it.
+# The modulus and exponent are base64url encoded here the way Postal encodes them (RFC 7518
+# section 6.3.1) rather than round tripped through the jwt gem, so that specs exercise our own
+# parsing rather than the gem agreeing with itself.
+module PostalJwksHelpers
+  def jwks_json(*keys)
+    { "keys" => keys.map { |key| jwk(key) } }.to_json
+  end
+
+  # Pass use: nil for a key with no "use" member at all, which RFC 7517 allows
+  def jwk(key, use: "sig", kid: "postal")
+    {
+      "kty" => "RSA",
+      "n" => Base64.urlsafe_encode64(key.n.to_s(2), padding: false),
+      "e" => Base64.urlsafe_encode64(key.e.to_s(2), padding: false),
+      "kid" => kid,
+      "use" => use,
+      "alg" => "RS256"
+    }.compact
+  end
+
+  def stub_jwks(body:, code: 200)
+    allow(HTTParty).to receive(:get)
+      .with(Rails.configuration.x.postal_jwks_url, timeout: 2)
+      .and_return(instance_double(HTTParty::Response, code:, body:))
+  end
+end


### PR DESCRIPTION
## What and why

`/postal/event` has been deployed since 31 August but has never processed a single event: it verifies against a public key PEM in credentials at `postal.webhook_public_key`, and that credential was never set, so the endpoint 403s everything. Postal has no UI or API that hands you that key, which is what made it awkward to populate in the first place. It does publish the public half of its installation-wide signing key, unauthenticated, at `https://postal.oaf.org.au/.well-known/jwks.json`, so this verifies against that instead and the credential goes away entirely.

Two things the diff can't show. The signature moves from `X-Postal-Signature` (RSA-SHA1) to `X-Postal-Signature-256`, because upstream's `lib/postal/signer.rb` marks the SHA1 one "for legacy use" and sends both on every request; I checked the tag we actually run (3.3.7, pinned in the infrastructure repo) rather than `main`. And the 15 minute cache TTL is doing real work rather than tuning: it caches a failed fetch as well as a good one, which is what stops a Postal outage turning into one outbound request of ours per inbound POST on an endpoint anyone can post to, and it is short enough that a signing key rotation heals inside the roughly 36 minutes of retries Postal gives a non-2xx.

Part of #2199. The SMTP cutover is the follow-up and will close it. Because the key is per installation rather than per mail server, one published key verifies both the `planningalerts` and `planningalerts-comments` webhooks.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

## How this was checked

Built test-first, one behaviour at a time, at two seams: `POST /postal/event` and `PostalSigningKeysService.call`. Only `HTTParty` is stubbed, so the controller examples run the real key fetch and parse rather than a stub of our own service. 38 examples across the two, and three of the red steps paid for themselves: an `oct` entry in the key set really does yield a JWK whose `verify_key` is a `String` (hence the `kty` filter), a non-string modulus dies with a `NoMethodError` from inside the jwt gem rather than a rescuable JWT error (hence the guard), and RuboCop caught `OpenSSL::SSL::SSLError` shadowing the `OpenSSL::OpenSSLError` I had added to the same rescue.

- [ ] Checked the affected area on my own or a staging system
- [x] Ran the automated tests
- [ ] Ran `/code-review` (or equivalent): fixed any concerns (and rechecked), linked follow-up issues below, or noted why they are not important below
- [ ] GitHub Actions tests: likewise fixed so they pass or linked a follow-up issue / replied why not important directly on each comment (reviewer will mark resolved as part of review)
- [x] Documentation updated, or not needed

Full suite 768 examples 0 failures (6 pending are pre-existing placeholders in `alert_policy_spec.rb`), `bin/rake ci:type` clean with RBIs up to date, RuboCop clean on tracked files, `bin/erblint --lint-all` clean, Brakeman `-q -w2` 0 warnings, and no VCR cassette drift. Note that `bin/rake ci:lint` fails on my machine on an untracked scratch file under `tmp/`, which aborts the task before its erb_lint and Brakeman steps, so those two were run directly.

Not checked on a real system yet, and it can't be until this is deployed: proving it end to end means firing a webhook from Postal at the deployed endpoint and seeing a 200 in its delivery log plus `last_delivered_at` moving, once on each of the two mail servers. That is the gate for taking this out of draft alongside the Actions run, not something staging can answer.

No documentation change here. The reasoning that a future reader would want is in the comment on `signature_failure_status`; if we want the decision recorded, the proportionate home is the consequences list on the infrastructure repo's ADR 0002, which already owns the Postal migration, rather than starting an ADR tree in this repo.

Worth knowing for later, deliberately not in this PR: once Postal gives up after about 36 minutes, a sustained JWKS failure is silent, and bounce processing and auto-unsubscribing just stop. A Honeybadger uptime check on the JWKS URL is the cheapest cover, given Sentry and Honeybadger are still side by side under #2049.

Assisted-by: Claude Code:claude-opus-5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Postal webhooks now use published RSA-SHA256 signing keys for signature verification.
  * Invalid or missing signatures are rejected, while temporary signing-key outages return a retryable service-unavailable response.
  * Signing keys are securely retrieved and cached for improved reliability.

* **Tests**
  * Added coverage for key retrieval, caching, failures, multiple keys, and unpublished signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->